### PR TITLE
Improve code quality and normalize Dart sources

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,33 +1,16 @@
 name: Build iOS (NeoStation)
 
-# Standalone workflow for the iOS port, kept separate from
-# build-and-deploy.yml so it can't break the existing release pipeline while
-# this platform is still experimental.
+# Dedicated iOS build workflow. It remains separate from the main release
+# pipeline while the iOS port is maintained independently.
 #
-# WHAT THIS DOES
-#   1. Scaffolds the ios/ Xcode project via `flutter create` (it isn't
-#      committed to the repo yet — this generates it fresh on the runner
-#      every time, which avoids hand-writing a project.pbxproj).
-#   2. Patches Info.plist with the entries NeoStation needs (landscape,
-#      Files/document access, local networking for NeoSync discovery, etc).
-#   3. Runs `pod install` and `flutter build ios`.
-#   4a. If Apple signing secrets are configured (see below), exports a
-#       properly signed, installable .ipa.
-#   4b. Otherwise, builds with --no-codesign and zips the raw .app so you
-#       still get an artifact to inspect / sign yourself later in Xcode.
+# Signed builds require:
+#   IOS_CERTIFICATE_BASE64
+#   IOS_CERTIFICATE_PASSWORD
+#   IOS_PROVISIONING_PROFILE_BASE64
+#   IOS_TEAM_ID
 #
-# REQUIRED SECRETS FOR A SIGNED, INSTALLABLE IPA
-#   IOS_CERTIFICATE_BASE64       - your .p12 signing certificate, base64-encoded
-#   IOS_CERTIFICATE_PASSWORD     - password for that .p12
-#   IOS_PROVISIONING_PROFILE_BASE64 - your .mobileprovision file, base64-encoded
-#   IOS_TEAM_ID                  - your Apple Developer Team ID
-# Without these, the workflow still runs and gives you an unsigned .app you
-# can open/sign manually in Xcode, or sideload via AltStore/Sideloadly which
-# do their own signing.
-#
-# To encode a file for a secret:
-#   base64 -i Certificates.p12 | pbcopy      (macOS)
-#   base64 -w 0 Certificates.p12             (Linux)
+# Without signing secrets, the workflow produces an unsigned IPA that can be
+# signed by the installer before sideloading.
 
 on:
   workflow_dispatch:
@@ -83,7 +66,8 @@ jobs:
       - name: Patch Info.plist
         run: |
           PLIST=ios/Runner/Info.plist
-          # Landscape-only, matching the Windows/Linux/macOS/Android UI.
+
+          # NeoStation uses a landscape-only interface on iOS and iPadOS.
           /usr/libexec/PlistBuddy -c "Delete :UISupportedInterfaceOrientations" "$PLIST" 2>/dev/null || true
           /usr/libexec/PlistBuddy -c "Add :UISupportedInterfaceOrientations array" "$PLIST"
           /usr/libexec/PlistBuddy -c "Add :UISupportedInterfaceOrientations:0 string UIInterfaceOrientationLandscapeLeft" "$PLIST"
@@ -93,19 +77,11 @@ jobs:
           /usr/libexec/PlistBuddy -c "Add :UISupportedInterfaceOrientations~ipad:0 string UIInterfaceOrientationLandscapeLeft" "$PLIST"
           /usr/libexec/PlistBuddy -c "Add :UISupportedInterfaceOrientations~ipad:1 string UIInterfaceOrientationLandscapeRight" "$PLIST"
 
-          # Lets the app show up as a destination in the Files app / document
-          # picker so ROM folders can eventually be selected there (phase 2).
+          # Expose the app's Documents directory through iOS document APIs.
           /usr/libexec/PlistBuddy -c "Add :UIFileSharingEnabled bool true" "$PLIST" 2>/dev/null || true
           /usr/libexec/PlistBuddy -c "Add :LSSupportsOpeningDocumentsInPlace bool true" "$PLIST" 2>/dev/null || true
 
-          # Registers neostation:// as a URL scheme this app can be opened
-          # with — RetroArch's library-export protocol calls back via
-          # neostation://retroarch?games=<base64url>, handled natively via
-          # external_folder_access's application(_:open:options:) rather
-          # than the app_links package. Confirmed via isolation testing
-          # that these two plist additions were not what caused the
-          # "requires a selected Development Team" build failure seen
-          # earlier — that was unrelated (see IOS_PORT.md).
+          # Register NeoStation's callback URL scheme for emulator integrations.
           /usr/libexec/PlistBuddy -c "Delete :CFBundleURLTypes" "$PLIST" 2>/dev/null || true
           /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes array" "$PLIST"
           /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0 dict" "$PLIST"
@@ -113,11 +89,7 @@ jobs:
           /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes array" "$PLIST"
           /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string neostation" "$PLIST"
 
-          # External-emulator URL schemes used by NeoStation must be in
-          # LSApplicationQueriesSchemes for canOpenURL/launchUrl checks to
-          # succeed. RetroArch provides library export + direct launching;
-          # ARMSX2 provides its iOS library export + direct PS2 launch;
-          # MeloNX provides Switch library export + direct game launch.
+          # Allow availability checks and launches for supported iOS integrations.
           /usr/libexec/PlistBuddy -c "Delete :LSApplicationQueriesSchemes" "$PLIST" 2>/dev/null || true
           /usr/libexec/PlistBuddy -c "Add :LSApplicationQueriesSchemes array" "$PLIST"
           /usr/libexec/PlistBuddy -c "Add :LSApplicationQueriesSchemes:0 string retroarch" "$PLIST"
@@ -132,20 +104,15 @@ jobs:
 
       - name: Patch device_info_plus for older Xcode SDK compatibility
         run: |
-          # device_info_plus's iOS source unconditionally calls
-          # NSProcessInfo.isiOSAppOnVision, an API that requires the iOS 26.1
-          # SDK (Xcode 26+). We're intentionally pinned to an older macOS
-          # runner (see the runs-on note above) where that selector doesn't
-          # exist in the SDK headers at all, so this fails to compile
-          # regardless of which device_info_plus version pub resolves to
-          # (confirmed on both 12.4.0 and 13.2.0). We don't use this
-          # property from Dart, so removing the line entirely is safe.
+          # Some runner SDKs do not expose NSProcessInfo.isiOSAppOnVision.
+          # NeoStation does not consume that value, so remove the unsupported
+          # assignment when it is present in the resolved plugin source.
           DEVICE_INFO_FILE=$(find "$HOME/.pub-cache" -path "*device_info_plus*/FPPDeviceInfoPlusPlugin.m" 2>/dev/null | head -1)
           if [ -n "$DEVICE_INFO_FILE" ]; then
             echo "Patching $DEVICE_INFO_FILE"
             sed -i '' '/isiOSAppOnVision/d' "$DEVICE_INFO_FILE"
           else
-            echo "device_info_plus source not found at the expected path — skipping patch (nothing to do, or plugin structure changed upstream)."
+            echo "device_info_plus source not found at the expected path — skipping patch."
           fi
 
       - name: Generate app icons
@@ -215,11 +182,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Flutter can emit a misleading "selected Development Team" error
-          # after an otherwise useful --no-codesign device build. Configure the
-          # generated iOS project with Flutter, then let xcodebuild compile the
-          # unsigned Runner directly. This also preserves the real Xcode error
-          # output in the Actions log if compilation genuinely fails.
+          # Configure Flutter first, then build Runner directly without signing
+          # so the workflow retains useful Xcode diagnostics on failure.
           flutter build ios \
             --release \
             --no-codesign \

--- a/lib/data/datasources/sqlite_migrations.dart
+++ b/lib/data/datasources/sqlite_migrations.dart
@@ -5334,7 +5334,9 @@ class SqliteMigrations {
   /// not pay for an unnecessary library rescan. Future media additions are
   /// handled generically by ScraperRepository.saveEnabledMediaTypes().
   static Future<void> _migrateToVersion112(Database db) async {
-    _log.i('Migration v112: Repairing ScreenScraper completion state for manuals');
+    _log.i(
+      'Migration v112: Repairing ScreenScraper completion state for manuals',
+    );
     try {
       final tables = db.select(
         "SELECT name FROM sqlite_master WHERE type = 'table' "
@@ -5350,7 +5352,9 @@ class SqliteMigrations {
           .map((row) => row['name'].toString())
           .toSet();
       if (!configColumns.contains('scrape_media_types')) {
-        _log.i('Migration v112: scrape_media_types column missing, nothing to do');
+        _log.i(
+          'Migration v112: scrape_media_types column missing, nothing to do',
+        );
         return;
       }
 
@@ -5361,7 +5365,9 @@ class SqliteMigrations {
 
       final selected = configRows.first['scrape_media_types']?.toString() ?? '';
       if (!selected.contains('"manuel"')) {
-        _log.i('Migration v112: manuals are disabled; completion state unchanged');
+        _log.i(
+          'Migration v112: manuals are disabled; completion state unchanged',
+        );
         return;
       }
 
@@ -5379,5 +5385,4 @@ class SqliteMigrations {
       rethrow;
     }
   }
-
 }

--- a/lib/l10n/app_locale.dart
+++ b/lib/l10n/app_locale.dart
@@ -707,7 +707,8 @@ mixin AppLocale {
   static const String systemType = 'system_type';
   static const String supportedFormats = 'supported_formats';
   static const String systemInfoSummary = 'system_info_summary';
-  static const String systemInfoSummaryNoManufacturer = 'system_info_summary_no_manufacturer';
+  static const String systemInfoSummaryNoManufacturer =
+      'system_info_summary_no_manufacturer';
   static const String systemTypeConsole = 'system_type_console';
   static const String systemTypeHandheld = 'system_type_handheld';
   static const String systemTypeComputer = 'system_type_computer';
@@ -721,20 +722,33 @@ mixin AppLocale {
   static const String systemTechnicalDetails = 'system_technical_details';
   static const String systemGamesDetected = 'system_games_detected';
   static const String systemInfoDetailedIntro = 'system_info_detailed_intro';
-  static const String systemInfoDetailedIntroNoManufacturer = 'system_info_detailed_intro_no_manufacturer';
-  static const String systemInfoArchitectureSentence = 'system_info_architecture_sentence';
-  static const String systemInfoGenerationSentence = 'system_info_generation_sentence';
-  static const String systemInfoProcessorSentence = 'system_info_processor_sentence';
+  static const String systemInfoDetailedIntroNoManufacturer =
+      'system_info_detailed_intro_no_manufacturer';
+  static const String systemInfoArchitectureSentence =
+      'system_info_architecture_sentence';
+  static const String systemInfoGenerationSentence =
+      'system_info_generation_sentence';
+  static const String systemInfoProcessorSentence =
+      'system_info_processor_sentence';
   static const String systemInfoMediaSentence = 'system_info_media_sentence';
-  static const String systemInfoCollectionRomHacks = 'system_info_collection_rom_hacks';
-  static const String systemInfoCollectionAllSystems = 'system_info_collection_all_systems';
-  static const String systemInfoCollectionFavorites = 'system_info_collection_favorites';
-  static const String systemInfoCollectionDigitalStore = 'system_info_collection_digital_store';
-  static const String systemInfoCollectionEmulationPlatform = 'system_info_collection_emulation_platform';
-  static const String systemInfoCollectionFantasyConsole = 'system_info_collection_fantasy_console';
-  static const String systemInfoCollectionMediaCollection = 'system_info_collection_media_collection';
-  static const String systemInfoCollectionGameEngine = 'system_info_collection_game_engine';
-  static const String systemInfoCollectionSoftwarePlatform = 'system_info_collection_software_platform';
+  static const String systemInfoCollectionRomHacks =
+      'system_info_collection_rom_hacks';
+  static const String systemInfoCollectionAllSystems =
+      'system_info_collection_all_systems';
+  static const String systemInfoCollectionFavorites =
+      'system_info_collection_favorites';
+  static const String systemInfoCollectionDigitalStore =
+      'system_info_collection_digital_store';
+  static const String systemInfoCollectionEmulationPlatform =
+      'system_info_collection_emulation_platform';
+  static const String systemInfoCollectionFantasyConsole =
+      'system_info_collection_fantasy_console';
+  static const String systemInfoCollectionMediaCollection =
+      'system_info_collection_media_collection';
+  static const String systemInfoCollectionGameEngine =
+      'system_info_collection_game_engine';
+  static const String systemInfoCollectionSoftwarePlatform =
+      'system_info_collection_software_platform';
   static const String mediaCartridge = 'media_cartridge';
   static const String mediaCdRom = 'media_cd_rom';
   static const String mediaDvd = 'media_dvd';
@@ -1011,14 +1025,17 @@ mixin AppLocale {
   static const String iosEmuLinkFolder = 'ios_emu_link_folder';
   static const String iosEmuChangeFolder = 'ios_emu_change_folder';
   static const String iosEmuLinkingFailed = 'ios_emu_linking_failed';
-  static const String iosRetroarchSyncRequested = 'ios_retroarch_sync_requested';
+  static const String iosRetroarchSyncRequested =
+      'ios_retroarch_sync_requested';
   static const String iosRetroarchUnavailable = 'ios_retroarch_unavailable';
   static const String iosArmsx2SyncRequested = 'ios_armsx2_sync_requested';
   static const String iosArmsx2Unavailable = 'ios_armsx2_unavailable';
   static const String iosMelonxSyncRequested = 'ios_melonx_sync_requested';
   static const String iosMelonxUnavailable = 'ios_melonx_unavailable';
-  static const String iosRetroarchStatusNeedsLink = 'ios_retroarch_status_needs_link';
-  static const String iosRetroarchStatusNeedsSync = 'ios_retroarch_status_needs_sync';
+  static const String iosRetroarchStatusNeedsLink =
+      'ios_retroarch_status_needs_link';
+  static const String iosRetroarchStatusNeedsSync =
+      'ios_retroarch_status_needs_sync';
   static const String iosRetroarchStatusSynced = 'ios_retroarch_status_synced';
   static const String iosRetroarchLinkSuccess = 'ios_retroarch_link_success';
   static const String iosArmsx2StatusNeedsLink = 'ios_armsx2_status_needs_link';

--- a/lib/l10n/app_locale_de.dart
+++ b/lib/l10n/app_locale_de.dart
@@ -184,7 +184,8 @@ const Map<String, dynamic> appLocaleDe = {
 
   AppLocale.configureDirectories: 'Verzeichnisse konfigurieren',
   AppLocale.configureLaunch: 'Start konfigurieren',
-  AppLocale.shortcutSetupOpenError: 'Die Startkonfiguration konnte nicht geöffnet werden.',
+  AppLocale.shortcutSetupOpenError:
+      'Die Startkonfiguration konnte nicht geöffnet werden.',
   AppLocale.configureRomsFolder: 'ROM-Ordner konfigurieren',
   AppLocale.cannotAccessFolder: 'Zugriff auf den Ordner nicht möglich',
   AppLocale.backgroundImage: 'Hintergrundbild',
@@ -561,22 +562,30 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.gameInfo: 'Spiel-Info',
   AppLocale.manage: 'Verwalten',
   AppLocale.manual: 'Handbuch',
-  AppLocale.scrapeManualDesc: 'PDF-Spielhandbücher herunterladen, wenn verfügbar.',
+  AppLocale.scrapeManualDesc:
+      'PDF-Spielhandbücher herunterladen, wenn verfügbar.',
   AppLocale.manualReady: 'Handbuch heruntergeladen',
   AppLocale.manualNotDownloaded: 'Kein Handbuch heruntergeladen',
-  AppLocale.manualDownloadHint: 'Lade das Spielhandbuch von ScreenScraper herunter, wenn es verfügbar ist.',
+  AppLocale.manualDownloadHint:
+      'Lade das Spielhandbuch von ScreenScraper herunter, wenn es verfügbar ist.',
   AppLocale.downloadManual: 'Handbuch herunterladen',
-  AppLocale.downloadManualDesc: 'Lade das beste verfügbare PDF für deine Sprache und Region herunter.',
+  AppLocale.downloadManualDesc:
+      'Lade das beste verfügbare PDF für deine Sprache und Region herunter.',
   AppLocale.readManual: 'Handbuch lesen',
-  AppLocale.readManualDesc: 'Öffne das gespeicherte PDF im integrierten NeoStation-Reader.',
+  AppLocale.readManualDesc:
+      'Öffne das gespeicherte PDF im integrierten NeoStation-Reader.',
   AppLocale.redownloadManual: 'Handbuch erneut laden',
-  AppLocale.redownloadManualDesc: 'Ersetze die lokale Kopie durch die beste verfügbare Version.',
+  AppLocale.redownloadManualDesc:
+      'Ersetze die lokale Kopie durch die beste verfügbare Version.',
   AppLocale.deleteManual: 'Handbuch löschen',
   AppLocale.deleteManualDesc: 'Entferne das gespeicherte PDF von diesem Gerät.',
-  AppLocale.deleteManualConfirmation: 'Das heruntergeladene Handbuch für dieses Spiel löschen?',
+  AppLocale.deleteManualConfirmation:
+      'Das heruntergeladene Handbuch für dieses Spiel löschen?',
   AppLocale.manualDownloaded: 'Handbuch heruntergeladen',
-  AppLocale.manualDownloadFailed: 'Handbuch konnte nicht heruntergeladen werden',
-  AppLocale.manualNotAvailable: 'Für dieses Spiel ist auf ScreenScraper kein Handbuch verfügbar.',
+  AppLocale.manualDownloadFailed:
+      'Handbuch konnte nicht heruntergeladen werden',
+  AppLocale.manualNotAvailable:
+      'Für dieses Spiel ist auf ScreenScraper kein Handbuch verfügbar.',
   AppLocale.manualDeleted: 'Handbuch gelöscht',
   AppLocale.downloadingManual: 'Handbuch wird heruntergeladen...',
   AppLocale.pinchToZoom: 'Zum Zoomen aufziehen',
@@ -744,8 +753,10 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.systemInfo: 'Systeminfo',
   AppLocale.systemType: 'Typ',
   AppLocale.supportedFormats: 'Unterstützte Formate',
-  AppLocale.systemInfoSummary: '{name} ist ein {type} von {manufacturer}, das im Jahr {year} veröffentlicht wurde. NeoStation erkennt derzeit {count} Spiele für dieses System.',
-  AppLocale.systemInfoSummaryNoManufacturer: '{name} ist ein {type}, das im Jahr {year} eingeführt wurde. NeoStation erkennt derzeit {count} Spiele für dieses System.',
+  AppLocale.systemInfoSummary:
+      '{name} ist ein {type} von {manufacturer}, das im Jahr {year} veröffentlicht wurde. NeoStation erkennt derzeit {count} Spiele für dieses System.',
+  AppLocale.systemInfoSummaryNoManufacturer:
+      '{name} ist ein {type}, das im Jahr {year} eingeführt wurde. NeoStation erkennt derzeit {count} Spiele für dieses System.',
   AppLocale.systemTypeConsole: 'Heimkonsolensystem',
   AppLocale.systemTypeHandheld: 'Handheld-System',
   AppLocale.systemTypeComputer: 'Computersystem',
@@ -1054,22 +1065,38 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.iosEmuLinkFolder: "Ordner verknüpfen",
   AppLocale.iosEmuChangeFolder: "Ordner ändern",
   AppLocale.iosEmuLinkingFailed: "Verknüpfung fehlgeschlagen: {error}",
-  AppLocale.iosRetroarchSyncRequested: "Die Synchronisierung der RetroArch-Bibliothek wurde angefordert. Sie läuft im Hintergrund; bitte einige Sekunden warten.",
-  AppLocale.iosRetroarchUnavailable: "RetroArch konnte nicht erreicht werden. Ist es installiert?",
-  AppLocale.iosArmsx2SyncRequested: "Die Synchronisierung der ARMSX2-Bibliothek wurde angefordert. ARMSX2 kehrt automatisch zu NeoStation zurück, sobald der Export bereit ist.",
-  AppLocale.iosArmsx2Unavailable: "ARMSX2 konnte nicht erreicht werden. Ist es installiert?",
-  AppLocale.iosMelonxSyncRequested: "Die Synchronisierung der MeloNX-Nintendo-Switch-Bibliothek wurde angefordert. MeloNX kehrt automatisch zu NeoStation zurück, sobald der Export bereit ist.",
-  AppLocale.iosMelonxUnavailable: "MeloNX konnte nicht erreicht werden. Ist es installiert?",
-  AppLocale.iosRetroarchStatusNeedsLink: "Verknüpfe den RetroArch-Ordner, damit NeoStation direkt auf deine Spiele zugreifen kann — ohne Kopieren.",
-  AppLocale.iosRetroarchStatusNeedsSync: "Ordner verknüpft. Synchronisiere die Bibliothek, damit Spiele mit einem Tippen direkt in RetroArch starten.",
-  AppLocale.iosRetroarchStatusSynced: "Ordner verknüpft und Bibliothek synchronisiert — Spiele starten direkt in RetroArch.",
-  AppLocale.iosRetroarchLinkSuccess: "Ordner verknüpft. NeoStation scannt ihn direkt, ohne Kopie. Gefundene Spiele starten direkt in RetroArch.",
-  AppLocale.iosArmsx2StatusNeedsLink: "ARMSX2 verwendet denselben ROM-Ordner wie RetroArch. Verknüpfe den gemeinsamen ROM-Ordner und synchronisiere anschließend die ARMSX2-Bibliothek.",
-  AppLocale.iosArmsx2StatusNeedsSync: "Gemeinsamer ROM-Ordner verknüpft. Synchronisiere ARMSX2, um die PS2-Bibliothek in NeoStation zu importieren.",
-  AppLocale.iosArmsx2StatusSynced: "Gemeinsamer Ordner und ARMSX2-Bibliothek synchronisiert — PS2-Spiele starten direkt in ARMSX2.",
-  AppLocale.iosArmsx2LinkSuccess: "Gemeinsamer ROM-Ordner verknüpft. RetroArch und ARMSX2 verwenden jetzt dieselbe NeoStation-ROM-Quelle.",
-  AppLocale.iosMelonxStatusSynced: "MeloNX-Bibliothek synchronisiert — Nintendo-Switch-Spiele starten direkt in MeloNX.",
-  AppLocale.iosMelonxStatusNeedsSync: "Synchronisiere MeloNX, um die Nintendo-Switch-Bibliothek direkt in NeoStation zu importieren. Ein Scan des ROM-Ordners ist nicht erforderlich.",
+  AppLocale.iosRetroarchSyncRequested:
+      "Die Synchronisierung der RetroArch-Bibliothek wurde angefordert. Sie läuft im Hintergrund; bitte einige Sekunden warten.",
+  AppLocale.iosRetroarchUnavailable:
+      "RetroArch konnte nicht erreicht werden. Ist es installiert?",
+  AppLocale.iosArmsx2SyncRequested:
+      "Die Synchronisierung der ARMSX2-Bibliothek wurde angefordert. ARMSX2 kehrt automatisch zu NeoStation zurück, sobald der Export bereit ist.",
+  AppLocale.iosArmsx2Unavailable:
+      "ARMSX2 konnte nicht erreicht werden. Ist es installiert?",
+  AppLocale.iosMelonxSyncRequested:
+      "Die Synchronisierung der MeloNX-Nintendo-Switch-Bibliothek wurde angefordert. MeloNX kehrt automatisch zu NeoStation zurück, sobald der Export bereit ist.",
+  AppLocale.iosMelonxUnavailable:
+      "MeloNX konnte nicht erreicht werden. Ist es installiert?",
+  AppLocale.iosRetroarchStatusNeedsLink:
+      "Verknüpfe den RetroArch-Ordner, damit NeoStation direkt auf deine Spiele zugreifen kann — ohne Kopieren.",
+  AppLocale.iosRetroarchStatusNeedsSync:
+      "Ordner verknüpft. Synchronisiere die Bibliothek, damit Spiele mit einem Tippen direkt in RetroArch starten.",
+  AppLocale.iosRetroarchStatusSynced:
+      "Ordner verknüpft und Bibliothek synchronisiert — Spiele starten direkt in RetroArch.",
+  AppLocale.iosRetroarchLinkSuccess:
+      "Ordner verknüpft. NeoStation scannt ihn direkt, ohne Kopie. Gefundene Spiele starten direkt in RetroArch.",
+  AppLocale.iosArmsx2StatusNeedsLink:
+      "ARMSX2 verwendet denselben ROM-Ordner wie RetroArch. Verknüpfe den gemeinsamen ROM-Ordner und synchronisiere anschließend die ARMSX2-Bibliothek.",
+  AppLocale.iosArmsx2StatusNeedsSync:
+      "Gemeinsamer ROM-Ordner verknüpft. Synchronisiere ARMSX2, um die PS2-Bibliothek in NeoStation zu importieren.",
+  AppLocale.iosArmsx2StatusSynced:
+      "Gemeinsamer Ordner und ARMSX2-Bibliothek synchronisiert — PS2-Spiele starten direkt in ARMSX2.",
+  AppLocale.iosArmsx2LinkSuccess:
+      "Gemeinsamer ROM-Ordner verknüpft. RetroArch und ARMSX2 verwenden jetzt dieselbe NeoStation-ROM-Quelle.",
+  AppLocale.iosMelonxStatusSynced:
+      "MeloNX-Bibliothek synchronisiert — Nintendo-Switch-Spiele starten direkt in MeloNX.",
+  AppLocale.iosMelonxStatusNeedsSync:
+      "Synchronisiere MeloNX, um die Nintendo-Switch-Bibliothek direkt in NeoStation zu importieren. Ein Scan des ROM-Ordners ist nicht erforderlich.",
 
   // Rich System Info
   AppLocale.systemArchitecture: 'Architektur',
@@ -1079,21 +1106,35 @@ const Map<String, dynamic> appLocaleDe = {
   AppLocale.systemNotableGames: 'Bekannte Spiele',
   AppLocale.systemTechnicalDetails: 'Technische Details',
   AppLocale.systemGamesDetected: 'Erkannte Spiele',
-  AppLocale.systemInfoDetailedIntro: '{name} ist ein System vom Typ {type}, das {manufacturer} {year} veröffentlichte.',
-  AppLocale.systemInfoDetailedIntroNoManufacturer: '{name} ist ein System vom Typ {type}, das {year} erschien.',
-  AppLocale.systemInfoArchitectureSentence: 'Die Hardwarearchitektur ist {architecture}.',
-  AppLocale.systemInfoGenerationSentence: 'Es gehört zur Generation {generation}.',
+  AppLocale.systemInfoDetailedIntro:
+      '{name} ist ein System vom Typ {type}, das {manufacturer} {year} veröffentlichte.',
+  AppLocale.systemInfoDetailedIntroNoManufacturer:
+      '{name} ist ein System vom Typ {type}, das {year} erschien.',
+  AppLocale.systemInfoArchitectureSentence:
+      'Die Hardwarearchitektur ist {architecture}.',
+  AppLocale.systemInfoGenerationSentence:
+      'Es gehört zur Generation {generation}.',
   AppLocale.systemInfoProcessorSentence: 'Der Hauptprozessor ist {cpu}.',
-  AppLocale.systemInfoMediaSentence: 'Spiele und Software wurden hauptsächlich auf {media} veröffentlicht.',
-  AppLocale.systemInfoCollectionRomHacks: 'Dieser Eintrag bündelt ROM-Hacks und Community-Varianten des ursprünglichen Systems.',
-  AppLocale.systemInfoCollectionAllSystems: 'Diese virtuelle Sammlung vereint Spiele aller erkannten Systeme.',
-  AppLocale.systemInfoCollectionFavorites: 'Diese virtuelle Sammlung enthält die vom Benutzer als Favoriten markierten Spiele.',
-  AppLocale.systemInfoCollectionDigitalStore: 'Dieser Eintrag steht für einen digitalen PC-Spiele-Shop; Katalog und Hardwareanforderungen unterscheiden sich je nach Titel.',
-  AppLocale.systemInfoCollectionEmulationPlatform: 'Dieser Eintrag steht für eine Emulations- oder Kompatibilitätsplattform für mehrere ursprüngliche Hardwarefamilien.',
-  AppLocale.systemInfoCollectionFantasyConsole: 'Dies ist eine Fantasy-Konsole mit bewusst begrenzter virtueller Hardware für kleine Spiele und Demos.',
-  AppLocale.systemInfoCollectionMediaCollection: 'Dies ist eine Mediensammlung und keine feste Gaming-Hardwareplattform.',
-  AppLocale.systemInfoCollectionGameEngine: 'Dieser Eintrag steht für eine Engine oder Laufzeitumgebung, deren Spiele verschiedene Hardwaregenerationen abdecken können.',
-  AppLocale.systemInfoCollectionSoftwarePlatform: 'Diese Softwareplattform umfasst unterschiedliche Hardwarekonfigurationen; die Architektur variiert daher je nach Gerät oder Epoche.',
+  AppLocale.systemInfoMediaSentence:
+      'Spiele und Software wurden hauptsächlich auf {media} veröffentlicht.',
+  AppLocale.systemInfoCollectionRomHacks:
+      'Dieser Eintrag bündelt ROM-Hacks und Community-Varianten des ursprünglichen Systems.',
+  AppLocale.systemInfoCollectionAllSystems:
+      'Diese virtuelle Sammlung vereint Spiele aller erkannten Systeme.',
+  AppLocale.systemInfoCollectionFavorites:
+      'Diese virtuelle Sammlung enthält die vom Benutzer als Favoriten markierten Spiele.',
+  AppLocale.systemInfoCollectionDigitalStore:
+      'Dieser Eintrag steht für einen digitalen PC-Spiele-Shop; Katalog und Hardwareanforderungen unterscheiden sich je nach Titel.',
+  AppLocale.systemInfoCollectionEmulationPlatform:
+      'Dieser Eintrag steht für eine Emulations- oder Kompatibilitätsplattform für mehrere ursprüngliche Hardwarefamilien.',
+  AppLocale.systemInfoCollectionFantasyConsole:
+      'Dies ist eine Fantasy-Konsole mit bewusst begrenzter virtueller Hardware für kleine Spiele und Demos.',
+  AppLocale.systemInfoCollectionMediaCollection:
+      'Dies ist eine Mediensammlung und keine feste Gaming-Hardwareplattform.',
+  AppLocale.systemInfoCollectionGameEngine:
+      'Dieser Eintrag steht für eine Engine oder Laufzeitumgebung, deren Spiele verschiedene Hardwaregenerationen abdecken können.',
+  AppLocale.systemInfoCollectionSoftwarePlatform:
+      'Diese Softwareplattform umfasst unterschiedliche Hardwarekonfigurationen; die Architektur variiert daher je nach Gerät oder Epoche.',
   AppLocale.mediaCartridge: 'Modul',
   AppLocale.mediaCdRom: 'CD-ROM',
   AppLocale.mediaDvd: 'DVD',

--- a/lib/l10n/app_locale_en.dart
+++ b/lib/l10n/app_locale_en.dart
@@ -544,19 +544,25 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.scrapeManualDesc: 'Download PDF game manuals when available.',
   AppLocale.manualReady: 'Manual downloaded',
   AppLocale.manualNotDownloaded: 'No manual downloaded',
-  AppLocale.manualDownloadHint: 'Download the game manual from ScreenScraper when available.',
+  AppLocale.manualDownloadHint:
+      'Download the game manual from ScreenScraper when available.',
   AppLocale.downloadManual: 'Download manual',
-  AppLocale.downloadManualDesc: 'Download the best available PDF for your language and region.',
+  AppLocale.downloadManualDesc:
+      'Download the best available PDF for your language and region.',
   AppLocale.readManual: 'Read manual',
-  AppLocale.readManualDesc: 'Open the cached PDF in NeoStation\'s built-in reader.',
+  AppLocale.readManualDesc:
+      'Open the cached PDF in NeoStation\'s built-in reader.',
   AppLocale.redownloadManual: 'Re-download manual',
-  AppLocale.redownloadManualDesc: 'Replace the local copy with the best available version.',
+  AppLocale.redownloadManualDesc:
+      'Replace the local copy with the best available version.',
   AppLocale.deleteManual: 'Delete manual',
   AppLocale.deleteManualDesc: 'Remove the cached PDF from this device.',
-  AppLocale.deleteManualConfirmation: 'Delete the downloaded manual for this game?',
+  AppLocale.deleteManualConfirmation:
+      'Delete the downloaded manual for this game?',
   AppLocale.manualDownloaded: 'Manual downloaded',
   AppLocale.manualDownloadFailed: 'Manual download failed',
-  AppLocale.manualNotAvailable: 'No manual is available for this game on ScreenScraper.',
+  AppLocale.manualNotAvailable:
+      'No manual is available for this game on ScreenScraper.',
   AppLocale.manualDeleted: 'Manual deleted',
   AppLocale.downloadingManual: 'Downloading manual...',
   AppLocale.pinchToZoom: 'Pinch to zoom',
@@ -723,8 +729,10 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.systemInfo: 'System Info',
   AppLocale.systemType: 'Type',
   AppLocale.supportedFormats: 'Supported formats',
-  AppLocale.systemInfoSummary: '{name} is a {type} released by {manufacturer} in {year}. NeoStation currently detects {count} games for this system.',
-  AppLocale.systemInfoSummaryNoManufacturer: '{name} is a {type} introduced in {year}. NeoStation currently detects {count} games for this system.',
+  AppLocale.systemInfoSummary:
+      '{name} is a {type} released by {manufacturer} in {year}. NeoStation currently detects {count} games for this system.',
+  AppLocale.systemInfoSummaryNoManufacturer:
+      '{name} is a {type} introduced in {year}. NeoStation currently detects {count} games for this system.',
   AppLocale.systemTypeConsole: 'home console',
   AppLocale.systemTypeHandheld: 'handheld system',
   AppLocale.systemTypeComputer: 'computer',
@@ -1019,22 +1027,36 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.iosEmuLinkFolder: "Link folder",
   AppLocale.iosEmuChangeFolder: "Change folder",
   AppLocale.iosEmuLinkingFailed: "Linking failed: {error}",
-  AppLocale.iosRetroarchSyncRequested: "RetroArch library sync requested. This runs in the background; wait a few seconds.",
-  AppLocale.iosRetroarchUnavailable: "Could not reach RetroArch. Is it installed?",
-  AppLocale.iosArmsx2SyncRequested: "ARMSX2 library sync requested. ARMSX2 will return to NeoStation automatically when the export is ready.",
+  AppLocale.iosRetroarchSyncRequested:
+      "RetroArch library sync requested. This runs in the background; wait a few seconds.",
+  AppLocale.iosRetroarchUnavailable:
+      "Could not reach RetroArch. Is it installed?",
+  AppLocale.iosArmsx2SyncRequested:
+      "ARMSX2 library sync requested. ARMSX2 will return to NeoStation automatically when the export is ready.",
   AppLocale.iosArmsx2Unavailable: "Could not reach ARMSX2. Is it installed?",
-  AppLocale.iosMelonxSyncRequested: "MeloNX Nintendo Switch library sync requested. MeloNX will return to NeoStation automatically when the export is ready.",
+  AppLocale.iosMelonxSyncRequested:
+      "MeloNX Nintendo Switch library sync requested. MeloNX will return to NeoStation automatically when the export is ready.",
   AppLocale.iosMelonxUnavailable: "Could not reach MeloNX. Is it installed?",
-  AppLocale.iosRetroarchStatusNeedsLink: "Link RetroArch's folder so NeoStation can access your games in place — no copying.",
-  AppLocale.iosRetroarchStatusNeedsSync: "Folder linked. Sync the library so games launch directly in RetroArch with one tap.",
-  AppLocale.iosRetroarchStatusSynced: "Folder linked and library synced — games launch directly in RetroArch.",
-  AppLocale.iosRetroarchLinkSuccess: "Folder linked. NeoStation will scan it in place — no copy needed. Games found here will launch directly in RetroArch.",
-  AppLocale.iosArmsx2StatusNeedsLink: "ARMSX2 uses the same ROM folder as RetroArch. Link the shared ROM folder, then sync the ARMSX2 library.",
-  AppLocale.iosArmsx2StatusNeedsSync: "Shared ROM folder linked. Sync ARMSX2 to import the PS2 library into NeoStation.",
-  AppLocale.iosArmsx2StatusSynced: "Shared folder and ARMSX2 library synced — PS2 games launch directly in ARMSX2.",
-  AppLocale.iosArmsx2LinkSuccess: "Shared ROM folder linked. RetroArch and ARMSX2 now use the same NeoStation ROM source.",
-  AppLocale.iosMelonxStatusSynced: "MeloNX library synced — Nintendo Switch games launch directly in MeloNX.",
-  AppLocale.iosMelonxStatusNeedsSync: "Sync MeloNX to import its Nintendo Switch library directly into NeoStation. No ROM-folder scan is required.",
+  AppLocale.iosRetroarchStatusNeedsLink:
+      "Link RetroArch's folder so NeoStation can access your games in place — no copying.",
+  AppLocale.iosRetroarchStatusNeedsSync:
+      "Folder linked. Sync the library so games launch directly in RetroArch with one tap.",
+  AppLocale.iosRetroarchStatusSynced:
+      "Folder linked and library synced — games launch directly in RetroArch.",
+  AppLocale.iosRetroarchLinkSuccess:
+      "Folder linked. NeoStation will scan it in place — no copy needed. Games found here will launch directly in RetroArch.",
+  AppLocale.iosArmsx2StatusNeedsLink:
+      "ARMSX2 uses the same ROM folder as RetroArch. Link the shared ROM folder, then sync the ARMSX2 library.",
+  AppLocale.iosArmsx2StatusNeedsSync:
+      "Shared ROM folder linked. Sync ARMSX2 to import the PS2 library into NeoStation.",
+  AppLocale.iosArmsx2StatusSynced:
+      "Shared folder and ARMSX2 library synced — PS2 games launch directly in ARMSX2.",
+  AppLocale.iosArmsx2LinkSuccess:
+      "Shared ROM folder linked. RetroArch and ARMSX2 now use the same NeoStation ROM source.",
+  AppLocale.iosMelonxStatusSynced:
+      "MeloNX library synced — Nintendo Switch games launch directly in MeloNX.",
+  AppLocale.iosMelonxStatusNeedsSync:
+      "Sync MeloNX to import its Nintendo Switch library directly into NeoStation. No ROM-folder scan is required.",
 
   // Rich System Info
   AppLocale.systemArchitecture: 'Architecture',
@@ -1044,21 +1066,35 @@ const Map<String, dynamic> appLocaleEn = {
   AppLocale.systemNotableGames: 'Notable games',
   AppLocale.systemTechnicalDetails: 'Technical details',
   AppLocale.systemGamesDetected: 'Games detected',
-  AppLocale.systemInfoDetailedIntro: '{name} is a {type} released by {manufacturer} in {year}.',
-  AppLocale.systemInfoDetailedIntroNoManufacturer: '{name} is a {type} introduced in {year}.',
-  AppLocale.systemInfoArchitectureSentence: 'Its hardware architecture is {architecture}.',
-  AppLocale.systemInfoGenerationSentence: 'It belongs to generation {generation}.',
+  AppLocale.systemInfoDetailedIntro:
+      '{name} is a {type} released by {manufacturer} in {year}.',
+  AppLocale.systemInfoDetailedIntroNoManufacturer:
+      '{name} is a {type} introduced in {year}.',
+  AppLocale.systemInfoArchitectureSentence:
+      'Its hardware architecture is {architecture}.',
+  AppLocale.systemInfoGenerationSentence:
+      'It belongs to generation {generation}.',
   AppLocale.systemInfoProcessorSentence: 'Its main processor is {cpu}.',
-  AppLocale.systemInfoMediaSentence: 'Games and software were mainly distributed on {media}.',
-  AppLocale.systemInfoCollectionRomHacks: 'This entry groups ROM hacks and fan-made variants for the original system.',
-  AppLocale.systemInfoCollectionAllSystems: 'This virtual collection combines games from all detected systems.',
-  AppLocale.systemInfoCollectionFavorites: 'This virtual collection contains the games marked as favorites by the user.',
-  AppLocale.systemInfoCollectionDigitalStore: 'This entry represents a digital PC game storefront; its catalog and hardware requirements vary by title.',
-  AppLocale.systemInfoCollectionEmulationPlatform: 'This entry represents an emulation or compatibility platform covering multiple original hardware families.',
-  AppLocale.systemInfoCollectionFantasyConsole: 'This is a fantasy-console platform with deliberately constrained virtual hardware for small games and demos.',
-  AppLocale.systemInfoCollectionMediaCollection: 'This is a media collection rather than a fixed gaming hardware platform.',
-  AppLocale.systemInfoCollectionGameEngine: 'This entry represents a game engine/runtime whose titles can target different hardware generations.',
-  AppLocale.systemInfoCollectionSoftwarePlatform: 'This software platform spans multiple hardware configurations, so architecture can vary between devices or eras.',
+  AppLocale.systemInfoMediaSentence:
+      'Games and software were mainly distributed on {media}.',
+  AppLocale.systemInfoCollectionRomHacks:
+      'This entry groups ROM hacks and fan-made variants for the original system.',
+  AppLocale.systemInfoCollectionAllSystems:
+      'This virtual collection combines games from all detected systems.',
+  AppLocale.systemInfoCollectionFavorites:
+      'This virtual collection contains the games marked as favorites by the user.',
+  AppLocale.systemInfoCollectionDigitalStore:
+      'This entry represents a digital PC game storefront; its catalog and hardware requirements vary by title.',
+  AppLocale.systemInfoCollectionEmulationPlatform:
+      'This entry represents an emulation or compatibility platform covering multiple original hardware families.',
+  AppLocale.systemInfoCollectionFantasyConsole:
+      'This is a fantasy-console platform with deliberately constrained virtual hardware for small games and demos.',
+  AppLocale.systemInfoCollectionMediaCollection:
+      'This is a media collection rather than a fixed gaming hardware platform.',
+  AppLocale.systemInfoCollectionGameEngine:
+      'This entry represents a game engine/runtime whose titles can target different hardware generations.',
+  AppLocale.systemInfoCollectionSoftwarePlatform:
+      'This software platform spans multiple hardware configurations, so architecture can vary between devices or eras.',
   AppLocale.mediaCartridge: 'Cartridge',
   AppLocale.mediaCdRom: 'CD-ROM',
   AppLocale.mediaDvd: 'DVD',

--- a/lib/l10n/app_locale_es.dart
+++ b/lib/l10n/app_locale_es.dart
@@ -186,7 +186,8 @@ const Map<String, dynamic> appLocaleEs = {
 
   AppLocale.configureDirectories: 'Directorios',
   AppLocale.configureLaunch: 'Configurar lanzamiento',
-  AppLocale.shortcutSetupOpenError: 'No se pudo abrir la configuración de lanzamiento.',
+  AppLocale.shortcutSetupOpenError:
+      'No se pudo abrir la configuración de lanzamiento.',
   AppLocale.configureRomsFolder: 'Configurar carpeta de ROMs',
   AppLocale.cannotAccessFolder: 'No se puede acceder a la carpeta',
   AppLocale.backgroundImage: 'Imagen de Fondo',
@@ -558,22 +559,29 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.gameInfo: 'Info del Juego',
   AppLocale.manage: 'Administrar',
   AppLocale.manual: 'Manual',
-  AppLocale.scrapeManualDesc: 'Descargar manuales de juegos en PDF cuando estén disponibles.',
+  AppLocale.scrapeManualDesc:
+      'Descargar manuales de juegos en PDF cuando estén disponibles.',
   AppLocale.manualReady: 'Manual descargado',
   AppLocale.manualNotDownloaded: 'Ningún manual descargado',
-  AppLocale.manualDownloadHint: 'Descarga el manual del juego desde ScreenScraper cuando esté disponible.',
+  AppLocale.manualDownloadHint:
+      'Descarga el manual del juego desde ScreenScraper cuando esté disponible.',
   AppLocale.downloadManual: 'Descargar manual',
-  AppLocale.downloadManualDesc: 'Descarga el mejor PDF disponible para tu idioma y región.',
+  AppLocale.downloadManualDesc:
+      'Descarga el mejor PDF disponible para tu idioma y región.',
   AppLocale.readManual: 'Leer manual',
-  AppLocale.readManualDesc: 'Abre el PDF guardado en el lector integrado de NeoStation.',
+  AppLocale.readManualDesc:
+      'Abre el PDF guardado en el lector integrado de NeoStation.',
   AppLocale.redownloadManual: 'Volver a descargar',
-  AppLocale.redownloadManualDesc: 'Reemplaza la copia local por la mejor versión disponible.',
+  AppLocale.redownloadManualDesc:
+      'Reemplaza la copia local por la mejor versión disponible.',
   AppLocale.deleteManual: 'Eliminar manual',
   AppLocale.deleteManualDesc: 'Elimina el PDF guardado de este dispositivo.',
-  AppLocale.deleteManualConfirmation: '¿Eliminar el manual descargado de este juego?',
+  AppLocale.deleteManualConfirmation:
+      '¿Eliminar el manual descargado de este juego?',
   AppLocale.manualDownloaded: 'Manual descargado',
   AppLocale.manualDownloadFailed: 'Error al descargar el manual',
-  AppLocale.manualNotAvailable: 'No hay ningún manual disponible para este juego en ScreenScraper.',
+  AppLocale.manualNotAvailable:
+      'No hay ningún manual disponible para este juego en ScreenScraper.',
   AppLocale.manualDeleted: 'Manual eliminado',
   AppLocale.downloadingManual: 'Descargando manual...',
   AppLocale.pinchToZoom: 'Pellizca para ampliar',
@@ -744,8 +752,10 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.systemInfo: 'Info del Sistema',
   AppLocale.systemType: 'Tipo',
   AppLocale.supportedFormats: 'Formatos compatibles',
-  AppLocale.systemInfoSummary: '{name} es un sistema de tipo {type}, lanzado por {manufacturer} en {year}. NeoStation detecta actualmente {count} juegos para este sistema.',
-  AppLocale.systemInfoSummaryNoManufacturer: '{name} es un sistema de tipo {type}, aparecido en {year}. NeoStation detecta actualmente {count} juegos para este sistema.',
+  AppLocale.systemInfoSummary:
+      '{name} es un sistema de tipo {type}, lanzado por {manufacturer} en {year}. NeoStation detecta actualmente {count} juegos para este sistema.',
+  AppLocale.systemInfoSummaryNoManufacturer:
+      '{name} es un sistema de tipo {type}, aparecido en {year}. NeoStation detecta actualmente {count} juegos para este sistema.',
   AppLocale.systemTypeConsole: 'consola doméstica',
   AppLocale.systemTypeHandheld: 'consola portátil',
   AppLocale.systemTypeComputer: 'ordenador',
@@ -1050,22 +1060,38 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.iosEmuLinkFolder: "Vincular carpeta",
   AppLocale.iosEmuChangeFolder: "Cambiar carpeta",
   AppLocale.iosEmuLinkingFailed: "Error al vincular: {error}",
-  AppLocale.iosRetroarchSyncRequested: "Se solicitó la sincronización de la biblioteca de RetroArch. Se realiza en segundo plano; espera unos segundos.",
-  AppLocale.iosRetroarchUnavailable: "No se pudo acceder a RetroArch. ¿Está instalado?",
-  AppLocale.iosArmsx2SyncRequested: "Se solicitó la sincronización de la biblioteca de ARMSX2. ARMSX2 volverá automáticamente a NeoStation cuando la exportación esté lista.",
-  AppLocale.iosArmsx2Unavailable: "No se pudo acceder a ARMSX2. ¿Está instalado?",
-  AppLocale.iosMelonxSyncRequested: "Se solicitó la sincronización de la biblioteca de Nintendo Switch de MeloNX. MeloNX volverá automáticamente a NeoStation cuando la exportación esté lista.",
-  AppLocale.iosMelonxUnavailable: "No se pudo acceder a MeloNX. ¿Está instalado?",
-  AppLocale.iosRetroarchStatusNeedsLink: "Vincula la carpeta de RetroArch para que NeoStation acceda a tus juegos directamente, sin copiarlos.",
-  AppLocale.iosRetroarchStatusNeedsSync: "Carpeta vinculada. Sincroniza la biblioteca para iniciar los juegos directamente en RetroArch con un toque.",
-  AppLocale.iosRetroarchStatusSynced: "Carpeta vinculada y biblioteca sincronizada: los juegos se inician directamente en RetroArch.",
-  AppLocale.iosRetroarchLinkSuccess: "Carpeta vinculada. NeoStation la analizará directamente, sin copiarla. Los juegos encontrados aquí se iniciarán directamente en RetroArch.",
-  AppLocale.iosArmsx2StatusNeedsLink: "ARMSX2 usa la misma carpeta de ROMs que RetroArch. Vincula la carpeta compartida y después sincroniza la biblioteca de ARMSX2.",
-  AppLocale.iosArmsx2StatusNeedsSync: "Carpeta de ROMs compartida vinculada. Sincroniza ARMSX2 para importar la biblioteca de PS2 en NeoStation.",
-  AppLocale.iosArmsx2StatusSynced: "Carpeta compartida y biblioteca de ARMSX2 sincronizadas: los juegos de PS2 se inician directamente en ARMSX2.",
-  AppLocale.iosArmsx2LinkSuccess: "Carpeta de ROMs compartida vinculada. RetroArch y ARMSX2 ahora usan la misma fuente de ROMs de NeoStation.",
-  AppLocale.iosMelonxStatusSynced: "Biblioteca de MeloNX sincronizada: los juegos de Nintendo Switch se inician directamente en MeloNX.",
-  AppLocale.iosMelonxStatusNeedsSync: "Sincroniza MeloNX para importar directamente su biblioteca de Nintendo Switch en NeoStation. No es necesario analizar una carpeta de ROMs.",
+  AppLocale.iosRetroarchSyncRequested:
+      "Se solicitó la sincronización de la biblioteca de RetroArch. Se realiza en segundo plano; espera unos segundos.",
+  AppLocale.iosRetroarchUnavailable:
+      "No se pudo acceder a RetroArch. ¿Está instalado?",
+  AppLocale.iosArmsx2SyncRequested:
+      "Se solicitó la sincronización de la biblioteca de ARMSX2. ARMSX2 volverá automáticamente a NeoStation cuando la exportación esté lista.",
+  AppLocale.iosArmsx2Unavailable:
+      "No se pudo acceder a ARMSX2. ¿Está instalado?",
+  AppLocale.iosMelonxSyncRequested:
+      "Se solicitó la sincronización de la biblioteca de Nintendo Switch de MeloNX. MeloNX volverá automáticamente a NeoStation cuando la exportación esté lista.",
+  AppLocale.iosMelonxUnavailable:
+      "No se pudo acceder a MeloNX. ¿Está instalado?",
+  AppLocale.iosRetroarchStatusNeedsLink:
+      "Vincula la carpeta de RetroArch para que NeoStation acceda a tus juegos directamente, sin copiarlos.",
+  AppLocale.iosRetroarchStatusNeedsSync:
+      "Carpeta vinculada. Sincroniza la biblioteca para iniciar los juegos directamente en RetroArch con un toque.",
+  AppLocale.iosRetroarchStatusSynced:
+      "Carpeta vinculada y biblioteca sincronizada: los juegos se inician directamente en RetroArch.",
+  AppLocale.iosRetroarchLinkSuccess:
+      "Carpeta vinculada. NeoStation la analizará directamente, sin copiarla. Los juegos encontrados aquí se iniciarán directamente en RetroArch.",
+  AppLocale.iosArmsx2StatusNeedsLink:
+      "ARMSX2 usa la misma carpeta de ROMs que RetroArch. Vincula la carpeta compartida y después sincroniza la biblioteca de ARMSX2.",
+  AppLocale.iosArmsx2StatusNeedsSync:
+      "Carpeta de ROMs compartida vinculada. Sincroniza ARMSX2 para importar la biblioteca de PS2 en NeoStation.",
+  AppLocale.iosArmsx2StatusSynced:
+      "Carpeta compartida y biblioteca de ARMSX2 sincronizadas: los juegos de PS2 se inician directamente en ARMSX2.",
+  AppLocale.iosArmsx2LinkSuccess:
+      "Carpeta de ROMs compartida vinculada. RetroArch y ARMSX2 ahora usan la misma fuente de ROMs de NeoStation.",
+  AppLocale.iosMelonxStatusSynced:
+      "Biblioteca de MeloNX sincronizada: los juegos de Nintendo Switch se inician directamente en MeloNX.",
+  AppLocale.iosMelonxStatusNeedsSync:
+      "Sincroniza MeloNX para importar directamente su biblioteca de Nintendo Switch en NeoStation. No es necesario analizar una carpeta de ROMs.",
 
   // Rich System Info
   AppLocale.systemArchitecture: 'Arquitectura',
@@ -1075,21 +1101,35 @@ const Map<String, dynamic> appLocaleEs = {
   AppLocale.systemNotableGames: 'Juegos emblemáticos',
   AppLocale.systemTechnicalDetails: 'Detalles técnicos',
   AppLocale.systemGamesDetected: 'Juegos detectados',
-  AppLocale.systemInfoDetailedIntro: '{name} es un sistema de tipo {type} lanzado por {manufacturer} en {year}.',
-  AppLocale.systemInfoDetailedIntroNoManufacturer: '{name} es un sistema de tipo {type} presentado en {year}.',
-  AppLocale.systemInfoArchitectureSentence: 'Su arquitectura de hardware es {architecture}.',
-  AppLocale.systemInfoGenerationSentence: 'Pertenece a la generación {generation}.',
+  AppLocale.systemInfoDetailedIntro:
+      '{name} es un sistema de tipo {type} lanzado por {manufacturer} en {year}.',
+  AppLocale.systemInfoDetailedIntroNoManufacturer:
+      '{name} es un sistema de tipo {type} presentado en {year}.',
+  AppLocale.systemInfoArchitectureSentence:
+      'Su arquitectura de hardware es {architecture}.',
+  AppLocale.systemInfoGenerationSentence:
+      'Pertenece a la generación {generation}.',
   AppLocale.systemInfoProcessorSentence: 'Su procesador principal es {cpu}.',
-  AppLocale.systemInfoMediaSentence: 'Los juegos y programas se distribuían principalmente en {media}.',
-  AppLocale.systemInfoCollectionRomHacks: 'Esta entrada agrupa ROM hacks y variantes creadas por la comunidad para el sistema original.',
-  AppLocale.systemInfoCollectionAllSystems: 'Esta colección virtual reúne juegos de todos los sistemas detectados.',
-  AppLocale.systemInfoCollectionFavorites: 'Esta colección virtual contiene los juegos marcados como favoritos por el usuario.',
-  AppLocale.systemInfoCollectionDigitalStore: 'Esta entrada representa una tienda digital de juegos para PC; el catálogo y los requisitos de hardware varían según el título.',
-  AppLocale.systemInfoCollectionEmulationPlatform: 'Esta entrada representa una plataforma de emulación o compatibilidad que abarca varias familias de hardware original.',
-  AppLocale.systemInfoCollectionFantasyConsole: 'Es una consola de fantasía con hardware virtual deliberadamente limitado para juegos y demos pequeños.',
-  AppLocale.systemInfoCollectionMediaCollection: 'Es una colección multimedia y no una plataforma de hardware de juego fija.',
-  AppLocale.systemInfoCollectionGameEngine: 'Esta entrada representa un motor o entorno de ejecución cuyos juegos pueden abarcar distintas generaciones de hardware.',
-  AppLocale.systemInfoCollectionSoftwarePlatform: 'Esta plataforma de software abarca múltiples configuraciones de hardware, por lo que la arquitectura varía según el dispositivo o la época.',
+  AppLocale.systemInfoMediaSentence:
+      'Los juegos y programas se distribuían principalmente en {media}.',
+  AppLocale.systemInfoCollectionRomHacks:
+      'Esta entrada agrupa ROM hacks y variantes creadas por la comunidad para el sistema original.',
+  AppLocale.systemInfoCollectionAllSystems:
+      'Esta colección virtual reúne juegos de todos los sistemas detectados.',
+  AppLocale.systemInfoCollectionFavorites:
+      'Esta colección virtual contiene los juegos marcados como favoritos por el usuario.',
+  AppLocale.systemInfoCollectionDigitalStore:
+      'Esta entrada representa una tienda digital de juegos para PC; el catálogo y los requisitos de hardware varían según el título.',
+  AppLocale.systemInfoCollectionEmulationPlatform:
+      'Esta entrada representa una plataforma de emulación o compatibilidad que abarca varias familias de hardware original.',
+  AppLocale.systemInfoCollectionFantasyConsole:
+      'Es una consola de fantasía con hardware virtual deliberadamente limitado para juegos y demos pequeños.',
+  AppLocale.systemInfoCollectionMediaCollection:
+      'Es una colección multimedia y no una plataforma de hardware de juego fija.',
+  AppLocale.systemInfoCollectionGameEngine:
+      'Esta entrada representa un motor o entorno de ejecución cuyos juegos pueden abarcar distintas generaciones de hardware.',
+  AppLocale.systemInfoCollectionSoftwarePlatform:
+      'Esta plataforma de software abarca múltiples configuraciones de hardware, por lo que la arquitectura varía según el dispositivo o la época.',
   AppLocale.mediaCartridge: 'Cartucho',
   AppLocale.mediaCdRom: 'CD-ROM',
   AppLocale.mediaDvd: 'DVD',

--- a/lib/l10n/app_locale_fr.dart
+++ b/lib/l10n/app_locale_fr.dart
@@ -189,7 +189,8 @@ const Map<String, dynamic> appLocaleFr = {
 
   AppLocale.configureDirectories: 'Configurer les Répertoires',
   AppLocale.configureLaunch: 'Configurer le lancement',
-  AppLocale.shortcutSetupOpenError: 'Impossible d’ouvrir la configuration du lancement.',
+  AppLocale.shortcutSetupOpenError:
+      'Impossible d’ouvrir la configuration du lancement.',
   AppLocale.configureRomsFolder: 'Configurer le Dossier des ROMs',
   AppLocale.cannotAccessFolder: 'Impossible d’accéder au dossier',
   AppLocale.backgroundImage: 'Image de Fond',
@@ -568,22 +569,29 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.gameInfo: 'Info du Jeu',
   AppLocale.manage: 'Gérer',
   AppLocale.manual: 'Notice',
-  AppLocale.scrapeManualDesc: 'Télécharger les notices de jeu en PDF lorsqu’elles sont disponibles.',
+  AppLocale.scrapeManualDesc:
+      'Télécharger les notices de jeu en PDF lorsqu’elles sont disponibles.',
   AppLocale.manualReady: 'Notice téléchargée',
   AppLocale.manualNotDownloaded: 'Aucune notice téléchargée',
-  AppLocale.manualDownloadHint: 'Téléchargez la notice du jeu depuis ScreenScraper lorsqu’elle est disponible.',
+  AppLocale.manualDownloadHint:
+      'Téléchargez la notice du jeu depuis ScreenScraper lorsqu’elle est disponible.',
   AppLocale.downloadManual: 'Télécharger la notice',
-  AppLocale.downloadManualDesc: 'Télécharger le meilleur PDF disponible pour votre langue et votre région.',
+  AppLocale.downloadManualDesc:
+      'Télécharger le meilleur PDF disponible pour votre langue et votre région.',
   AppLocale.readManual: 'Lire la notice',
-  AppLocale.readManualDesc: 'Ouvrir le PDF enregistré dans le lecteur intégré de NeoStation.',
+  AppLocale.readManualDesc:
+      'Ouvrir le PDF enregistré dans le lecteur intégré de NeoStation.',
   AppLocale.redownloadManual: 'Retélécharger la notice',
-  AppLocale.redownloadManualDesc: 'Remplacer la copie locale par la meilleure version disponible.',
+  AppLocale.redownloadManualDesc:
+      'Remplacer la copie locale par la meilleure version disponible.',
   AppLocale.deleteManual: 'Supprimer la notice',
   AppLocale.deleteManualDesc: 'Supprimer le PDF enregistré de cet appareil.',
-  AppLocale.deleteManualConfirmation: 'Supprimer la notice téléchargée pour ce jeu ?',
+  AppLocale.deleteManualConfirmation:
+      'Supprimer la notice téléchargée pour ce jeu ?',
   AppLocale.manualDownloaded: 'Notice téléchargée',
   AppLocale.manualDownloadFailed: 'Échec du téléchargement de la notice',
-  AppLocale.manualNotAvailable: 'Aucune notice n’est disponible pour ce jeu sur ScreenScraper.',
+  AppLocale.manualNotAvailable:
+      'Aucune notice n’est disponible pour ce jeu sur ScreenScraper.',
   AppLocale.manualDeleted: 'Notice supprimée',
   AppLocale.downloadingManual: 'Téléchargement de la notice...',
   AppLocale.pinchToZoom: 'Pincez pour zoomer',
@@ -752,8 +760,10 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.systemInfo: 'Infos Système',
   AppLocale.systemType: 'Type',
   AppLocale.supportedFormats: 'Formats pris en charge',
-  AppLocale.systemInfoSummary: '{name} est un système de type {type}, commercialisé par {manufacturer} en {year}. NeoStation détecte actuellement {count} jeux pour ce système.',
-  AppLocale.systemInfoSummaryNoManufacturer: '{name} est un système de type {type}, apparu en {year}. NeoStation détecte actuellement {count} jeux pour ce système.',
+  AppLocale.systemInfoSummary:
+      '{name} est un système de type {type}, commercialisé par {manufacturer} en {year}. NeoStation détecte actuellement {count} jeux pour ce système.',
+  AppLocale.systemInfoSummaryNoManufacturer:
+      '{name} est un système de type {type}, apparu en {year}. NeoStation détecte actuellement {count} jeux pour ce système.',
   AppLocale.systemTypeConsole: 'console de salon',
   AppLocale.systemTypeHandheld: 'console portable',
   AppLocale.systemTypeComputer: 'ordinateur',
@@ -1058,22 +1068,38 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.iosEmuLinkFolder: "Lier le dossier",
   AppLocale.iosEmuChangeFolder: "Changer de dossier",
   AppLocale.iosEmuLinkingFailed: "Échec de la liaison : {error}",
-  AppLocale.iosRetroarchSyncRequested: "Synchronisation de la bibliothèque RetroArch demandée. Elle s’effectue en arrière-plan ; patientez quelques secondes.",
-  AppLocale.iosRetroarchUnavailable: "Impossible de joindre RetroArch. Est-il installé ?",
-  AppLocale.iosArmsx2SyncRequested: "Synchronisation de la bibliothèque ARMSX2 demandée. ARMSX2 reviendra automatiquement dans NeoStation lorsque l’export sera prêt.",
-  AppLocale.iosArmsx2Unavailable: "Impossible de joindre ARMSX2. Est-il installé ?",
-  AppLocale.iosMelonxSyncRequested: "Synchronisation de la bibliothèque Nintendo Switch de MeloNX demandée. MeloNX reviendra automatiquement dans NeoStation lorsque l’export sera prêt.",
-  AppLocale.iosMelonxUnavailable: "Impossible de joindre MeloNX. Est-il installé ?",
-  AppLocale.iosRetroarchStatusNeedsLink: "Liez le dossier de RetroArch afin que NeoStation accède directement à vos jeux, sans copie.",
-  AppLocale.iosRetroarchStatusNeedsSync: "Dossier lié. Synchronisez la bibliothèque pour lancer les jeux directement dans RetroArch en un appui.",
-  AppLocale.iosRetroarchStatusSynced: "Dossier lié et bibliothèque synchronisée — les jeux se lancent directement dans RetroArch.",
-  AppLocale.iosRetroarchLinkSuccess: "Dossier lié. NeoStation l’analysera directement, sans copie. Les jeux trouvés ici seront lancés directement dans RetroArch.",
-  AppLocale.iosArmsx2StatusNeedsLink: "ARMSX2 utilise le même dossier de ROMs que RetroArch. Liez le dossier partagé, puis synchronisez la bibliothèque ARMSX2.",
-  AppLocale.iosArmsx2StatusNeedsSync: "Dossier de ROMs partagé lié. Synchronisez ARMSX2 pour importer la bibliothèque PS2 dans NeoStation.",
-  AppLocale.iosArmsx2StatusSynced: "Dossier partagé et bibliothèque ARMSX2 synchronisés — les jeux PS2 se lancent directement dans ARMSX2.",
-  AppLocale.iosArmsx2LinkSuccess: "Dossier de ROMs partagé lié. RetroArch et ARMSX2 utilisent désormais la même source de ROMs NeoStation.",
-  AppLocale.iosMelonxStatusSynced: "Bibliothèque MeloNX synchronisée — les jeux Nintendo Switch se lancent directement dans MeloNX.",
-  AppLocale.iosMelonxStatusNeedsSync: "Synchronisez MeloNX pour importer directement sa bibliothèque Nintendo Switch dans NeoStation. Aucune analyse de dossier de ROMs n’est nécessaire.",
+  AppLocale.iosRetroarchSyncRequested:
+      "Synchronisation de la bibliothèque RetroArch demandée. Elle s’effectue en arrière-plan ; patientez quelques secondes.",
+  AppLocale.iosRetroarchUnavailable:
+      "Impossible de joindre RetroArch. Est-il installé ?",
+  AppLocale.iosArmsx2SyncRequested:
+      "Synchronisation de la bibliothèque ARMSX2 demandée. ARMSX2 reviendra automatiquement dans NeoStation lorsque l’export sera prêt.",
+  AppLocale.iosArmsx2Unavailable:
+      "Impossible de joindre ARMSX2. Est-il installé ?",
+  AppLocale.iosMelonxSyncRequested:
+      "Synchronisation de la bibliothèque Nintendo Switch de MeloNX demandée. MeloNX reviendra automatiquement dans NeoStation lorsque l’export sera prêt.",
+  AppLocale.iosMelonxUnavailable:
+      "Impossible de joindre MeloNX. Est-il installé ?",
+  AppLocale.iosRetroarchStatusNeedsLink:
+      "Liez le dossier de RetroArch afin que NeoStation accède directement à vos jeux, sans copie.",
+  AppLocale.iosRetroarchStatusNeedsSync:
+      "Dossier lié. Synchronisez la bibliothèque pour lancer les jeux directement dans RetroArch en un appui.",
+  AppLocale.iosRetroarchStatusSynced:
+      "Dossier lié et bibliothèque synchronisée — les jeux se lancent directement dans RetroArch.",
+  AppLocale.iosRetroarchLinkSuccess:
+      "Dossier lié. NeoStation l’analysera directement, sans copie. Les jeux trouvés ici seront lancés directement dans RetroArch.",
+  AppLocale.iosArmsx2StatusNeedsLink:
+      "ARMSX2 utilise le même dossier de ROMs que RetroArch. Liez le dossier partagé, puis synchronisez la bibliothèque ARMSX2.",
+  AppLocale.iosArmsx2StatusNeedsSync:
+      "Dossier de ROMs partagé lié. Synchronisez ARMSX2 pour importer la bibliothèque PS2 dans NeoStation.",
+  AppLocale.iosArmsx2StatusSynced:
+      "Dossier partagé et bibliothèque ARMSX2 synchronisés — les jeux PS2 se lancent directement dans ARMSX2.",
+  AppLocale.iosArmsx2LinkSuccess:
+      "Dossier de ROMs partagé lié. RetroArch et ARMSX2 utilisent désormais la même source de ROMs NeoStation.",
+  AppLocale.iosMelonxStatusSynced:
+      "Bibliothèque MeloNX synchronisée — les jeux Nintendo Switch se lancent directement dans MeloNX.",
+  AppLocale.iosMelonxStatusNeedsSync:
+      "Synchronisez MeloNX pour importer directement sa bibliothèque Nintendo Switch dans NeoStation. Aucune analyse de dossier de ROMs n’est nécessaire.",
 
   // Rich System Info
   AppLocale.systemArchitecture: 'Architecture',
@@ -1083,21 +1109,35 @@ const Map<String, dynamic> appLocaleFr = {
   AppLocale.systemNotableGames: 'Jeux emblématiques',
   AppLocale.systemTechnicalDetails: 'Détails techniques',
   AppLocale.systemGamesDetected: 'Jeux détectés',
-  AppLocale.systemInfoDetailedIntro: '{name} est un système de type {type}, commercialisé par {manufacturer} en {year}.',
-  AppLocale.systemInfoDetailedIntroNoManufacturer: '{name} est un système de type {type}, apparu en {year}.',
-  AppLocale.systemInfoArchitectureSentence: 'Son architecture matérielle est de type {architecture}.',
-  AppLocale.systemInfoGenerationSentence: 'Il appartient à la génération {generation}.',
+  AppLocale.systemInfoDetailedIntro:
+      '{name} est un système de type {type}, commercialisé par {manufacturer} en {year}.',
+  AppLocale.systemInfoDetailedIntroNoManufacturer:
+      '{name} est un système de type {type}, apparu en {year}.',
+  AppLocale.systemInfoArchitectureSentence:
+      'Son architecture matérielle est de type {architecture}.',
+  AppLocale.systemInfoGenerationSentence:
+      'Il appartient à la génération {generation}.',
   AppLocale.systemInfoProcessorSentence: 'Son processeur principal est {cpu}.',
-  AppLocale.systemInfoMediaSentence: 'Les jeux et logiciels étaient principalement distribués sur {media}.',
-  AppLocale.systemInfoCollectionRomHacks: 'Cette entrée regroupe les ROM hacks et variantes créées par la communauté pour le système d’origine.',
-  AppLocale.systemInfoCollectionAllSystems: 'Cette collection virtuelle réunit les jeux de tous les systèmes détectés.',
-  AppLocale.systemInfoCollectionFavorites: 'Cette collection virtuelle contient les jeux marqués comme favoris par l’utilisateur.',
-  AppLocale.systemInfoCollectionDigitalStore: 'Cette entrée représente une boutique numérique de jeux PC ; son catalogue et les exigences matérielles varient selon les titres.',
-  AppLocale.systemInfoCollectionEmulationPlatform: 'Cette entrée représente une plateforme d’émulation ou de compatibilité couvrant plusieurs familles de matériels d’origine.',
-  AppLocale.systemInfoCollectionFantasyConsole: 'Il s’agit d’une console virtuelle à contraintes volontaires, conçue pour de petits jeux et démos rétro.',
-  AppLocale.systemInfoCollectionMediaCollection: 'Il s’agit d’une collection multimédia et non d’une plateforme matérielle de jeu fixe.',
-  AppLocale.systemInfoCollectionGameEngine: 'Cette entrée représente un moteur ou environnement d’exécution dont les jeux peuvent viser différentes générations de matériel.',
-  AppLocale.systemInfoCollectionSoftwarePlatform: 'Cette plateforme logicielle couvre plusieurs configurations matérielles ; son architecture varie donc selon les appareils ou les époques.',
+  AppLocale.systemInfoMediaSentence:
+      'Les jeux et logiciels étaient principalement distribués sur {media}.',
+  AppLocale.systemInfoCollectionRomHacks:
+      'Cette entrée regroupe les ROM hacks et variantes créées par la communauté pour le système d’origine.',
+  AppLocale.systemInfoCollectionAllSystems:
+      'Cette collection virtuelle réunit les jeux de tous les systèmes détectés.',
+  AppLocale.systemInfoCollectionFavorites:
+      'Cette collection virtuelle contient les jeux marqués comme favoris par l’utilisateur.',
+  AppLocale.systemInfoCollectionDigitalStore:
+      'Cette entrée représente une boutique numérique de jeux PC ; son catalogue et les exigences matérielles varient selon les titres.',
+  AppLocale.systemInfoCollectionEmulationPlatform:
+      'Cette entrée représente une plateforme d’émulation ou de compatibilité couvrant plusieurs familles de matériels d’origine.',
+  AppLocale.systemInfoCollectionFantasyConsole:
+      'Il s’agit d’une console virtuelle à contraintes volontaires, conçue pour de petits jeux et démos rétro.',
+  AppLocale.systemInfoCollectionMediaCollection:
+      'Il s’agit d’une collection multimédia et non d’une plateforme matérielle de jeu fixe.',
+  AppLocale.systemInfoCollectionGameEngine:
+      'Cette entrée représente un moteur ou environnement d’exécution dont les jeux peuvent viser différentes générations de matériel.',
+  AppLocale.systemInfoCollectionSoftwarePlatform:
+      'Cette plateforme logicielle couvre plusieurs configurations matérielles ; son architecture varie donc selon les appareils ou les époques.',
   AppLocale.mediaCartridge: 'Cartouche',
   AppLocale.mediaCdRom: 'CD-ROM',
   AppLocale.mediaDvd: 'DVD',

--- a/lib/l10n/app_locale_id.dart
+++ b/lib/l10n/app_locale_id.dart
@@ -180,7 +180,8 @@ const Map<String, dynamic> appLocaleId = {
 
   AppLocale.configureDirectories: 'Konfigurasi Direktori',
   AppLocale.configureLaunch: 'Konfigurasikan peluncuran',
-  AppLocale.shortcutSetupOpenError: 'Tidak dapat membuka konfigurasi peluncuran.',
+  AppLocale.shortcutSetupOpenError:
+      'Tidak dapat membuka konfigurasi peluncuran.',
   AppLocale.configureRomsFolder: 'Konfigurasi Folder ROM',
   AppLocale.cannotAccessFolder: 'Tidak dapat mengakses folder',
   AppLocale.backgroundImage: 'Gambar Latar Belakang',
@@ -547,19 +548,24 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.scrapeManualDesc: 'Unduh manual game PDF jika tersedia.',
   AppLocale.manualReady: 'Manual telah diunduh',
   AppLocale.manualNotDownloaded: 'Belum ada manual yang diunduh',
-  AppLocale.manualDownloadHint: 'Unduh manual game dari ScreenScraper jika tersedia.',
+  AppLocale.manualDownloadHint:
+      'Unduh manual game dari ScreenScraper jika tersedia.',
   AppLocale.downloadManual: 'Unduh manual',
-  AppLocale.downloadManualDesc: 'Unduh PDF terbaik yang tersedia untuk bahasa dan wilayah Anda.',
+  AppLocale.downloadManualDesc:
+      'Unduh PDF terbaik yang tersedia untuk bahasa dan wilayah Anda.',
   AppLocale.readManual: 'Baca manual',
   AppLocale.readManualDesc: 'Buka PDF tersimpan di pembaca bawaan NeoStation.',
   AppLocale.redownloadManual: 'Unduh ulang manual',
-  AppLocale.redownloadManualDesc: 'Ganti salinan lokal dengan versi terbaik yang tersedia.',
+  AppLocale.redownloadManualDesc:
+      'Ganti salinan lokal dengan versi terbaik yang tersedia.',
   AppLocale.deleteManual: 'Hapus manual',
   AppLocale.deleteManualDesc: 'Hapus PDF tersimpan dari perangkat ini.',
-  AppLocale.deleteManualConfirmation: 'Hapus manual yang telah diunduh untuk game ini?',
+  AppLocale.deleteManualConfirmation:
+      'Hapus manual yang telah diunduh untuk game ini?',
   AppLocale.manualDownloaded: 'Manual telah diunduh',
   AppLocale.manualDownloadFailed: 'Gagal mengunduh manual',
-  AppLocale.manualNotAvailable: 'Tidak ada manual untuk game ini di ScreenScraper.',
+  AppLocale.manualNotAvailable:
+      'Tidak ada manual untuk game ini di ScreenScraper.',
   AppLocale.manualDeleted: 'Manual dihapus',
   AppLocale.downloadingManual: 'Mengunduh manual...',
   AppLocale.pinchToZoom: 'Cubit untuk memperbesar',
@@ -726,8 +732,10 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.systemInfo: 'Info Sistem',
   AppLocale.systemType: 'Tipe',
   AppLocale.supportedFormats: 'Format yang didukung',
-  AppLocale.systemInfoSummary: '{name} adalah {type} yang dirilis oleh {manufacturer} pada {year}. NeoStation saat ini mendeteksi {count} game untuk sistem ini.',
-  AppLocale.systemInfoSummaryNoManufacturer: '{name} adalah {type} yang diperkenalkan pada {year}. NeoStation saat ini mendeteksi {count} game untuk sistem ini.',
+  AppLocale.systemInfoSummary:
+      '{name} adalah {type} yang dirilis oleh {manufacturer} pada {year}. NeoStation saat ini mendeteksi {count} game untuk sistem ini.',
+  AppLocale.systemInfoSummaryNoManufacturer:
+      '{name} adalah {type} yang diperkenalkan pada {year}. NeoStation saat ini mendeteksi {count} game untuk sistem ini.',
   AppLocale.systemTypeConsole: 'konsol rumahan',
   AppLocale.systemTypeHandheld: 'sistem genggam',
   AppLocale.systemTypeComputer: 'komputer',
@@ -1025,22 +1033,38 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.iosEmuLinkFolder: "Tautkan folder",
   AppLocale.iosEmuChangeFolder: "Ubah folder",
   AppLocale.iosEmuLinkingFailed: "Gagal menautkan: {error}",
-  AppLocale.iosRetroarchSyncRequested: "Sinkronisasi pustaka RetroArch diminta. Proses berjalan di latar belakang; tunggu beberapa detik.",
-  AppLocale.iosRetroarchUnavailable: "Tidak dapat mengakses RetroArch. Apakah sudah terpasang?",
-  AppLocale.iosArmsx2SyncRequested: "Sinkronisasi pustaka ARMSX2 diminta. ARMSX2 akan kembali ke NeoStation secara otomatis saat ekspor siap.",
-  AppLocale.iosArmsx2Unavailable: "Tidak dapat mengakses ARMSX2. Apakah sudah terpasang?",
-  AppLocale.iosMelonxSyncRequested: "Sinkronisasi pustaka Nintendo Switch MeloNX diminta. MeloNX akan kembali ke NeoStation secara otomatis saat ekspor siap.",
-  AppLocale.iosMelonxUnavailable: "Tidak dapat mengakses MeloNX. Apakah sudah terpasang?",
-  AppLocale.iosRetroarchStatusNeedsLink: "Tautkan folder RetroArch agar NeoStation dapat mengakses game langsung tanpa menyalinnya.",
-  AppLocale.iosRetroarchStatusNeedsSync: "Folder sudah ditautkan. Sinkronkan pustaka agar game dapat dibuka langsung di RetroArch dengan satu ketukan.",
-  AppLocale.iosRetroarchStatusSynced: "Folder dan pustaka sudah tersinkron — game dibuka langsung di RetroArch.",
-  AppLocale.iosRetroarchLinkSuccess: "Folder sudah ditautkan. NeoStation akan memindainya langsung tanpa menyalin. Game yang ditemukan di sini akan dibuka langsung di RetroArch.",
-  AppLocale.iosArmsx2StatusNeedsLink: "ARMSX2 menggunakan folder ROM yang sama dengan RetroArch. Tautkan folder ROM bersama, lalu sinkronkan pustaka ARMSX2.",
-  AppLocale.iosArmsx2StatusNeedsSync: "Folder ROM bersama sudah ditautkan. Sinkronkan ARMSX2 untuk mengimpor pustaka PS2 ke NeoStation.",
-  AppLocale.iosArmsx2StatusSynced: "Folder bersama dan pustaka ARMSX2 sudah tersinkron — game PS2 dibuka langsung di ARMSX2.",
-  AppLocale.iosArmsx2LinkSuccess: "Folder ROM bersama sudah ditautkan. RetroArch dan ARMSX2 kini menggunakan sumber ROM NeoStation yang sama.",
-  AppLocale.iosMelonxStatusSynced: "Pustaka MeloNX sudah tersinkron — game Nintendo Switch dibuka langsung di MeloNX.",
-  AppLocale.iosMelonxStatusNeedsSync: "Sinkronkan MeloNX untuk mengimpor pustaka Nintendo Switch langsung ke NeoStation. Pemindaian folder ROM tidak diperlukan.",
+  AppLocale.iosRetroarchSyncRequested:
+      "Sinkronisasi pustaka RetroArch diminta. Proses berjalan di latar belakang; tunggu beberapa detik.",
+  AppLocale.iosRetroarchUnavailable:
+      "Tidak dapat mengakses RetroArch. Apakah sudah terpasang?",
+  AppLocale.iosArmsx2SyncRequested:
+      "Sinkronisasi pustaka ARMSX2 diminta. ARMSX2 akan kembali ke NeoStation secara otomatis saat ekspor siap.",
+  AppLocale.iosArmsx2Unavailable:
+      "Tidak dapat mengakses ARMSX2. Apakah sudah terpasang?",
+  AppLocale.iosMelonxSyncRequested:
+      "Sinkronisasi pustaka Nintendo Switch MeloNX diminta. MeloNX akan kembali ke NeoStation secara otomatis saat ekspor siap.",
+  AppLocale.iosMelonxUnavailable:
+      "Tidak dapat mengakses MeloNX. Apakah sudah terpasang?",
+  AppLocale.iosRetroarchStatusNeedsLink:
+      "Tautkan folder RetroArch agar NeoStation dapat mengakses game langsung tanpa menyalinnya.",
+  AppLocale.iosRetroarchStatusNeedsSync:
+      "Folder sudah ditautkan. Sinkronkan pustaka agar game dapat dibuka langsung di RetroArch dengan satu ketukan.",
+  AppLocale.iosRetroarchStatusSynced:
+      "Folder dan pustaka sudah tersinkron — game dibuka langsung di RetroArch.",
+  AppLocale.iosRetroarchLinkSuccess:
+      "Folder sudah ditautkan. NeoStation akan memindainya langsung tanpa menyalin. Game yang ditemukan di sini akan dibuka langsung di RetroArch.",
+  AppLocale.iosArmsx2StatusNeedsLink:
+      "ARMSX2 menggunakan folder ROM yang sama dengan RetroArch. Tautkan folder ROM bersama, lalu sinkronkan pustaka ARMSX2.",
+  AppLocale.iosArmsx2StatusNeedsSync:
+      "Folder ROM bersama sudah ditautkan. Sinkronkan ARMSX2 untuk mengimpor pustaka PS2 ke NeoStation.",
+  AppLocale.iosArmsx2StatusSynced:
+      "Folder bersama dan pustaka ARMSX2 sudah tersinkron — game PS2 dibuka langsung di ARMSX2.",
+  AppLocale.iosArmsx2LinkSuccess:
+      "Folder ROM bersama sudah ditautkan. RetroArch dan ARMSX2 kini menggunakan sumber ROM NeoStation yang sama.",
+  AppLocale.iosMelonxStatusSynced:
+      "Pustaka MeloNX sudah tersinkron — game Nintendo Switch dibuka langsung di MeloNX.",
+  AppLocale.iosMelonxStatusNeedsSync:
+      "Sinkronkan MeloNX untuk mengimpor pustaka Nintendo Switch langsung ke NeoStation. Pemindaian folder ROM tidak diperlukan.",
 
   // Rich System Info
   AppLocale.systemArchitecture: 'Arsitektur',
@@ -1050,21 +1074,35 @@ const Map<String, dynamic> appLocaleId = {
   AppLocale.systemNotableGames: 'Game ikonik',
   AppLocale.systemTechnicalDetails: 'Detail teknis',
   AppLocale.systemGamesDetected: 'Game terdeteksi',
-  AppLocale.systemInfoDetailedIntro: '{name} adalah sistem jenis {type} yang dirilis oleh {manufacturer} pada {year}.',
-  AppLocale.systemInfoDetailedIntroNoManufacturer: '{name} adalah sistem jenis {type} yang diperkenalkan pada {year}.',
-  AppLocale.systemInfoArchitectureSentence: 'Arsitektur perangkat kerasnya adalah {architecture}.',
-  AppLocale.systemInfoGenerationSentence: 'Sistem ini termasuk generasi {generation}.',
+  AppLocale.systemInfoDetailedIntro:
+      '{name} adalah sistem jenis {type} yang dirilis oleh {manufacturer} pada {year}.',
+  AppLocale.systemInfoDetailedIntroNoManufacturer:
+      '{name} adalah sistem jenis {type} yang diperkenalkan pada {year}.',
+  AppLocale.systemInfoArchitectureSentence:
+      'Arsitektur perangkat kerasnya adalah {architecture}.',
+  AppLocale.systemInfoGenerationSentence:
+      'Sistem ini termasuk generasi {generation}.',
   AppLocale.systemInfoProcessorSentence: 'Prosesor utamanya adalah {cpu}.',
-  AppLocale.systemInfoMediaSentence: 'Game dan perangkat lunak terutama didistribusikan melalui {media}.',
-  AppLocale.systemInfoCollectionRomHacks: 'Entri ini mengelompokkan ROM hack dan varian buatan komunitas untuk sistem asli.',
-  AppLocale.systemInfoCollectionAllSystems: 'Koleksi virtual ini menggabungkan game dari semua sistem yang terdeteksi.',
-  AppLocale.systemInfoCollectionFavorites: 'Koleksi virtual ini berisi game yang ditandai sebagai favorit oleh pengguna.',
-  AppLocale.systemInfoCollectionDigitalStore: 'Entri ini mewakili toko game PC digital; katalog dan kebutuhan perangkat keras berbeda untuk setiap judul.',
-  AppLocale.systemInfoCollectionEmulationPlatform: 'Entri ini mewakili platform emulasi atau kompatibilitas yang mencakup beberapa keluarga perangkat keras asli.',
-  AppLocale.systemInfoCollectionFantasyConsole: 'Ini adalah fantasy console dengan perangkat keras virtual yang sengaja dibatasi untuk game dan demo kecil.',
-  AppLocale.systemInfoCollectionMediaCollection: 'Ini adalah koleksi media, bukan platform perangkat keras game tetap.',
-  AppLocale.systemInfoCollectionGameEngine: 'Entri ini mewakili engine atau runtime game yang judulnya dapat mencakup beberapa generasi perangkat keras.',
-  AppLocale.systemInfoCollectionSoftwarePlatform: 'Platform perangkat lunak ini mencakup banyak konfigurasi perangkat keras, sehingga arsitektur berbeda menurut perangkat atau era.',
+  AppLocale.systemInfoMediaSentence:
+      'Game dan perangkat lunak terutama didistribusikan melalui {media}.',
+  AppLocale.systemInfoCollectionRomHacks:
+      'Entri ini mengelompokkan ROM hack dan varian buatan komunitas untuk sistem asli.',
+  AppLocale.systemInfoCollectionAllSystems:
+      'Koleksi virtual ini menggabungkan game dari semua sistem yang terdeteksi.',
+  AppLocale.systemInfoCollectionFavorites:
+      'Koleksi virtual ini berisi game yang ditandai sebagai favorit oleh pengguna.',
+  AppLocale.systemInfoCollectionDigitalStore:
+      'Entri ini mewakili toko game PC digital; katalog dan kebutuhan perangkat keras berbeda untuk setiap judul.',
+  AppLocale.systemInfoCollectionEmulationPlatform:
+      'Entri ini mewakili platform emulasi atau kompatibilitas yang mencakup beberapa keluarga perangkat keras asli.',
+  AppLocale.systemInfoCollectionFantasyConsole:
+      'Ini adalah fantasy console dengan perangkat keras virtual yang sengaja dibatasi untuk game dan demo kecil.',
+  AppLocale.systemInfoCollectionMediaCollection:
+      'Ini adalah koleksi media, bukan platform perangkat keras game tetap.',
+  AppLocale.systemInfoCollectionGameEngine:
+      'Entri ini mewakili engine atau runtime game yang judulnya dapat mencakup beberapa generasi perangkat keras.',
+  AppLocale.systemInfoCollectionSoftwarePlatform:
+      'Platform perangkat lunak ini mencakup banyak konfigurasi perangkat keras, sehingga arsitektur berbeda menurut perangkat atau era.',
   AppLocale.mediaCartridge: 'Kartrid',
   AppLocale.mediaCdRom: 'CD-ROM',
   AppLocale.mediaDvd: 'DVD',

--- a/lib/l10n/app_locale_it.dart
+++ b/lib/l10n/app_locale_it.dart
@@ -183,7 +183,8 @@ const Map<String, dynamic> appLocaleIt = {
 
   AppLocale.configureDirectories: 'Configura Directory',
   AppLocale.configureLaunch: 'Configura avvio',
-  AppLocale.shortcutSetupOpenError: 'Impossibile aprire la configurazione di avvio.',
+  AppLocale.shortcutSetupOpenError:
+      'Impossibile aprire la configurazione di avvio.',
   AppLocale.configureRomsFolder: 'Configura Cartella ROM',
   AppLocale.cannotAccessFolder: 'Impossibile accedere alla cartella',
   AppLocale.backgroundImage: 'Immagine di Sfondo',
@@ -556,22 +557,29 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.gameInfo: 'Info Gioco',
   AppLocale.manage: 'Gestisci',
   AppLocale.manual: 'Manuale',
-  AppLocale.scrapeManualDesc: 'Scarica i manuali dei giochi in PDF quando disponibili.',
+  AppLocale.scrapeManualDesc:
+      'Scarica i manuali dei giochi in PDF quando disponibili.',
   AppLocale.manualReady: 'Manuale scaricato',
   AppLocale.manualNotDownloaded: 'Nessun manuale scaricato',
-  AppLocale.manualDownloadHint: 'Scarica il manuale del gioco da ScreenScraper quando disponibile.',
+  AppLocale.manualDownloadHint:
+      'Scarica il manuale del gioco da ScreenScraper quando disponibile.',
   AppLocale.downloadManual: 'Scarica manuale',
-  AppLocale.downloadManualDesc: 'Scarica il miglior PDF disponibile per lingua e regione.',
+  AppLocale.downloadManualDesc:
+      'Scarica il miglior PDF disponibile per lingua e regione.',
   AppLocale.readManual: 'Leggi manuale',
-  AppLocale.readManualDesc: 'Apri il PDF salvato nel lettore integrato di NeoStation.',
+  AppLocale.readManualDesc:
+      'Apri il PDF salvato nel lettore integrato di NeoStation.',
   AppLocale.redownloadManual: 'Riscarica manuale',
-  AppLocale.redownloadManualDesc: 'Sostituisci la copia locale con la migliore versione disponibile.',
+  AppLocale.redownloadManualDesc:
+      'Sostituisci la copia locale con la migliore versione disponibile.',
   AppLocale.deleteManual: 'Elimina manuale',
   AppLocale.deleteManualDesc: 'Rimuovi il PDF salvato da questo dispositivo.',
-  AppLocale.deleteManualConfirmation: 'Eliminare il manuale scaricato per questo gioco?',
+  AppLocale.deleteManualConfirmation:
+      'Eliminare il manuale scaricato per questo gioco?',
   AppLocale.manualDownloaded: 'Manuale scaricato',
   AppLocale.manualDownloadFailed: 'Download del manuale non riuscito',
-  AppLocale.manualNotAvailable: 'Nessun manuale disponibile per questo gioco su ScreenScraper.',
+  AppLocale.manualNotAvailable:
+      'Nessun manuale disponibile per questo gioco su ScreenScraper.',
   AppLocale.manualDeleted: 'Manuale eliminato',
   AppLocale.downloadingManual: 'Download del manuale...',
   AppLocale.pinchToZoom: 'Pizzica per zoomare',
@@ -741,8 +749,10 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.systemInfo: 'Info Sistema',
   AppLocale.systemType: 'Tipo',
   AppLocale.supportedFormats: 'Formati supportati',
-  AppLocale.systemInfoSummary: '{name} è un sistema di tipo {type}, pubblicato da {manufacturer} nel {year}. NeoStation rileva attualmente {count} giochi per questo sistema.',
-  AppLocale.systemInfoSummaryNoManufacturer: '{name} è un sistema di tipo {type}, introdotto nel {year}. NeoStation rileva attualmente {count} giochi per questo sistema.',
+  AppLocale.systemInfoSummary:
+      '{name} è un sistema di tipo {type}, pubblicato da {manufacturer} nel {year}. NeoStation rileva attualmente {count} giochi per questo sistema.',
+  AppLocale.systemInfoSummaryNoManufacturer:
+      '{name} è un sistema di tipo {type}, introdotto nel {year}. NeoStation rileva attualmente {count} giochi per questo sistema.',
   AppLocale.systemTypeConsole: 'console domestica',
   AppLocale.systemTypeHandheld: 'console portatile',
   AppLocale.systemTypeComputer: 'computer',
@@ -1046,22 +1056,38 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.iosEmuLinkFolder: "Collega cartella",
   AppLocale.iosEmuChangeFolder: "Cambia cartella",
   AppLocale.iosEmuLinkingFailed: "Collegamento non riuscito: {error}",
-  AppLocale.iosRetroarchSyncRequested: "Sincronizzazione della libreria RetroArch richiesta. Avviene in background; attendi qualche secondo.",
-  AppLocale.iosRetroarchUnavailable: "Impossibile raggiungere RetroArch. È installato?",
-  AppLocale.iosArmsx2SyncRequested: "Sincronizzazione della libreria ARMSX2 richiesta. ARMSX2 tornerà automaticamente a NeoStation quando l’esportazione sarà pronta.",
-  AppLocale.iosArmsx2Unavailable: "Impossibile raggiungere ARMSX2. È installato?",
-  AppLocale.iosMelonxSyncRequested: "Sincronizzazione della libreria Nintendo Switch di MeloNX richiesta. MeloNX tornerà automaticamente a NeoStation quando l’esportazione sarà pronta.",
-  AppLocale.iosMelonxUnavailable: "Impossibile raggiungere MeloNX. È installato?",
-  AppLocale.iosRetroarchStatusNeedsLink: "Collega la cartella di RetroArch affinché NeoStation acceda ai giochi direttamente, senza copiarli.",
-  AppLocale.iosRetroarchStatusNeedsSync: "Cartella collegata. Sincronizza la libreria per avviare i giochi direttamente in RetroArch con un tocco.",
-  AppLocale.iosRetroarchStatusSynced: "Cartella collegata e libreria sincronizzata — i giochi si avviano direttamente in RetroArch.",
-  AppLocale.iosRetroarchLinkSuccess: "Cartella collegata. NeoStation la analizzerà direttamente, senza copiarla. I giochi trovati qui si avvieranno direttamente in RetroArch.",
-  AppLocale.iosArmsx2StatusNeedsLink: "ARMSX2 usa la stessa cartella ROM di RetroArch. Collega la cartella ROM condivisa, quindi sincronizza la libreria ARMSX2.",
-  AppLocale.iosArmsx2StatusNeedsSync: "Cartella ROM condivisa collegata. Sincronizza ARMSX2 per importare la libreria PS2 in NeoStation.",
-  AppLocale.iosArmsx2StatusSynced: "Cartella condivisa e libreria ARMSX2 sincronizzate — i giochi PS2 si avviano direttamente in ARMSX2.",
-  AppLocale.iosArmsx2LinkSuccess: "Cartella ROM condivisa collegata. RetroArch e ARMSX2 ora usano la stessa sorgente ROM di NeoStation.",
-  AppLocale.iosMelonxStatusSynced: "Libreria MeloNX sincronizzata — i giochi Nintendo Switch si avviano direttamente in MeloNX.",
-  AppLocale.iosMelonxStatusNeedsSync: "Sincronizza MeloNX per importare direttamente la sua libreria Nintendo Switch in NeoStation. Non è necessaria la scansione di una cartella ROM.",
+  AppLocale.iosRetroarchSyncRequested:
+      "Sincronizzazione della libreria RetroArch richiesta. Avviene in background; attendi qualche secondo.",
+  AppLocale.iosRetroarchUnavailable:
+      "Impossibile raggiungere RetroArch. È installato?",
+  AppLocale.iosArmsx2SyncRequested:
+      "Sincronizzazione della libreria ARMSX2 richiesta. ARMSX2 tornerà automaticamente a NeoStation quando l’esportazione sarà pronta.",
+  AppLocale.iosArmsx2Unavailable:
+      "Impossibile raggiungere ARMSX2. È installato?",
+  AppLocale.iosMelonxSyncRequested:
+      "Sincronizzazione della libreria Nintendo Switch di MeloNX richiesta. MeloNX tornerà automaticamente a NeoStation quando l’esportazione sarà pronta.",
+  AppLocale.iosMelonxUnavailable:
+      "Impossibile raggiungere MeloNX. È installato?",
+  AppLocale.iosRetroarchStatusNeedsLink:
+      "Collega la cartella di RetroArch affinché NeoStation acceda ai giochi direttamente, senza copiarli.",
+  AppLocale.iosRetroarchStatusNeedsSync:
+      "Cartella collegata. Sincronizza la libreria per avviare i giochi direttamente in RetroArch con un tocco.",
+  AppLocale.iosRetroarchStatusSynced:
+      "Cartella collegata e libreria sincronizzata — i giochi si avviano direttamente in RetroArch.",
+  AppLocale.iosRetroarchLinkSuccess:
+      "Cartella collegata. NeoStation la analizzerà direttamente, senza copiarla. I giochi trovati qui si avvieranno direttamente in RetroArch.",
+  AppLocale.iosArmsx2StatusNeedsLink:
+      "ARMSX2 usa la stessa cartella ROM di RetroArch. Collega la cartella ROM condivisa, quindi sincronizza la libreria ARMSX2.",
+  AppLocale.iosArmsx2StatusNeedsSync:
+      "Cartella ROM condivisa collegata. Sincronizza ARMSX2 per importare la libreria PS2 in NeoStation.",
+  AppLocale.iosArmsx2StatusSynced:
+      "Cartella condivisa e libreria ARMSX2 sincronizzate — i giochi PS2 si avviano direttamente in ARMSX2.",
+  AppLocale.iosArmsx2LinkSuccess:
+      "Cartella ROM condivisa collegata. RetroArch e ARMSX2 ora usano la stessa sorgente ROM di NeoStation.",
+  AppLocale.iosMelonxStatusSynced:
+      "Libreria MeloNX sincronizzata — i giochi Nintendo Switch si avviano direttamente in MeloNX.",
+  AppLocale.iosMelonxStatusNeedsSync:
+      "Sincronizza MeloNX per importare direttamente la sua libreria Nintendo Switch in NeoStation. Non è necessaria la scansione di una cartella ROM.",
 
   // Rich System Info
   AppLocale.systemArchitecture: 'Architettura',
@@ -1071,21 +1097,35 @@ const Map<String, dynamic> appLocaleIt = {
   AppLocale.systemNotableGames: 'Giochi iconici',
   AppLocale.systemTechnicalDetails: 'Dettagli tecnici',
   AppLocale.systemGamesDetected: 'Giochi rilevati',
-  AppLocale.systemInfoDetailedIntro: '{name} è un sistema di tipo {type}, pubblicato da {manufacturer} nel {year}.',
-  AppLocale.systemInfoDetailedIntroNoManufacturer: '{name} è un sistema di tipo {type}, introdotto nel {year}.',
-  AppLocale.systemInfoArchitectureSentence: 'La sua architettura hardware è {architecture}.',
-  AppLocale.systemInfoGenerationSentence: 'Appartiene alla generazione {generation}.',
+  AppLocale.systemInfoDetailedIntro:
+      '{name} è un sistema di tipo {type}, pubblicato da {manufacturer} nel {year}.',
+  AppLocale.systemInfoDetailedIntroNoManufacturer:
+      '{name} è un sistema di tipo {type}, introdotto nel {year}.',
+  AppLocale.systemInfoArchitectureSentence:
+      'La sua architettura hardware è {architecture}.',
+  AppLocale.systemInfoGenerationSentence:
+      'Appartiene alla generazione {generation}.',
   AppLocale.systemInfoProcessorSentence: 'Il processore principale è {cpu}.',
-  AppLocale.systemInfoMediaSentence: 'Giochi e software erano distribuiti principalmente su {media}.',
-  AppLocale.systemInfoCollectionRomHacks: 'Questa voce raggruppa ROM hack e varianti create dalla community per il sistema originale.',
-  AppLocale.systemInfoCollectionAllSystems: 'Questa raccolta virtuale riunisce i giochi di tutti i sistemi rilevati.',
-  AppLocale.systemInfoCollectionFavorites: 'Questa raccolta virtuale contiene i giochi contrassegnati come preferiti dall’utente.',
-  AppLocale.systemInfoCollectionDigitalStore: 'Questa voce rappresenta uno store digitale di giochi PC; catalogo e requisiti hardware variano in base al titolo.',
-  AppLocale.systemInfoCollectionEmulationPlatform: 'Questa voce rappresenta una piattaforma di emulazione o compatibilità che copre diverse famiglie di hardware originale.',
-  AppLocale.systemInfoCollectionFantasyConsole: 'È una fantasy console con hardware virtuale volutamente limitato per piccoli giochi e demo.',
-  AppLocale.systemInfoCollectionMediaCollection: 'È una raccolta multimediale, non una piattaforma hardware di gioco fissa.',
-  AppLocale.systemInfoCollectionGameEngine: 'Questa voce rappresenta un motore o runtime i cui giochi possono coprire diverse generazioni hardware.',
-  AppLocale.systemInfoCollectionSoftwarePlatform: 'Questa piattaforma software copre più configurazioni hardware, quindi l’architettura varia a seconda del dispositivo o dell’epoca.',
+  AppLocale.systemInfoMediaSentence:
+      'Giochi e software erano distribuiti principalmente su {media}.',
+  AppLocale.systemInfoCollectionRomHacks:
+      'Questa voce raggruppa ROM hack e varianti create dalla community per il sistema originale.',
+  AppLocale.systemInfoCollectionAllSystems:
+      'Questa raccolta virtuale riunisce i giochi di tutti i sistemi rilevati.',
+  AppLocale.systemInfoCollectionFavorites:
+      'Questa raccolta virtuale contiene i giochi contrassegnati come preferiti dall’utente.',
+  AppLocale.systemInfoCollectionDigitalStore:
+      'Questa voce rappresenta uno store digitale di giochi PC; catalogo e requisiti hardware variano in base al titolo.',
+  AppLocale.systemInfoCollectionEmulationPlatform:
+      'Questa voce rappresenta una piattaforma di emulazione o compatibilità che copre diverse famiglie di hardware originale.',
+  AppLocale.systemInfoCollectionFantasyConsole:
+      'È una fantasy console con hardware virtuale volutamente limitato per piccoli giochi e demo.',
+  AppLocale.systemInfoCollectionMediaCollection:
+      'È una raccolta multimediale, non una piattaforma hardware di gioco fissa.',
+  AppLocale.systemInfoCollectionGameEngine:
+      'Questa voce rappresenta un motore o runtime i cui giochi possono coprire diverse generazioni hardware.',
+  AppLocale.systemInfoCollectionSoftwarePlatform:
+      'Questa piattaforma software copre più configurazioni hardware, quindi l’architettura varia a seconda del dispositivo o dell’epoca.',
   AppLocale.mediaCartridge: 'Cartuccia',
   AppLocale.mediaCdRom: 'CD-ROM',
   AppLocale.mediaDvd: 'DVD',

--- a/lib/l10n/app_locale_ja.dart
+++ b/lib/l10n/app_locale_ja.dart
@@ -659,8 +659,10 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.systemInfo: 'システム情報',
   AppLocale.systemType: '種類',
   AppLocale.supportedFormats: '対応フォーマット',
-  AppLocale.systemInfoSummary: '{name} は {manufacturer} が {year} 年に発売した{type}です。NeoStation では現在、このシステムのゲームを {count} 本検出しています。',
-  AppLocale.systemInfoSummaryNoManufacturer: '{name} は {year} 年に登場した{type}です。NeoStation では現在、このシステムのゲームを {count} 本検出しています。',
+  AppLocale.systemInfoSummary:
+      '{name} は {manufacturer} が {year} 年に発売した{type}です。NeoStation では現在、このシステムのゲームを {count} 本検出しています。',
+  AppLocale.systemInfoSummaryNoManufacturer:
+      '{name} は {year} 年に登場した{type}です。NeoStation では現在、このシステムのゲームを {count} 本検出しています。',
   AppLocale.systemTypeConsole: '家庭用ゲーム機',
   AppLocale.systemTypeHandheld: '携帯ゲーム機',
   AppLocale.systemTypeComputer: 'コンピューター',
@@ -936,22 +938,35 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.iosEmuLinkFolder: "フォルダをリンク",
   AppLocale.iosEmuChangeFolder: "フォルダを変更",
   AppLocale.iosEmuLinkingFailed: "リンクに失敗しました: {error}",
-  AppLocale.iosRetroarchSyncRequested: "RetroArch ライブラリの同期を要求しました。バックグラウンドで実行されるため、数秒お待ちください。",
+  AppLocale.iosRetroarchSyncRequested:
+      "RetroArch ライブラリの同期を要求しました。バックグラウンドで実行されるため、数秒お待ちください。",
   AppLocale.iosRetroarchUnavailable: "RetroArch に接続できませんでした。インストールされていますか？",
-  AppLocale.iosArmsx2SyncRequested: "ARMSX2 ライブラリの同期を要求しました。エクスポートの準備が完了すると、ARMSX2 は自動的に NeoStation に戻ります。",
+  AppLocale.iosArmsx2SyncRequested:
+      "ARMSX2 ライブラリの同期を要求しました。エクスポートの準備が完了すると、ARMSX2 は自動的に NeoStation に戻ります。",
   AppLocale.iosArmsx2Unavailable: "ARMSX2 に接続できませんでした。インストールされていますか？",
-  AppLocale.iosMelonxSyncRequested: "MeloNX の Nintendo Switch ライブラリの同期を要求しました。エクスポートの準備が完了すると、MeloNX は自動的に NeoStation に戻ります。",
+  AppLocale.iosMelonxSyncRequested:
+      "MeloNX の Nintendo Switch ライブラリの同期を要求しました。エクスポートの準備が完了すると、MeloNX は自動的に NeoStation に戻ります。",
   AppLocale.iosMelonxUnavailable: "MeloNX に接続できませんでした。インストールされていますか？",
-  AppLocale.iosRetroarchStatusNeedsLink: "RetroArch のフォルダをリンクすると、コピーせずに NeoStation からゲームへ直接アクセスできます。",
-  AppLocale.iosRetroarchStatusNeedsSync: "フォルダをリンクしました。ライブラリを同期すると、ワンタップで RetroArch から直接ゲームを起動できます。",
-  AppLocale.iosRetroarchStatusSynced: "フォルダとライブラリを同期済み — ゲームは RetroArch で直接起動します。",
-  AppLocale.iosRetroarchLinkSuccess: "フォルダをリンクしました。NeoStation はコピーせず、その場所を直接スキャンします。ここで見つかったゲームは RetroArch で直接起動します。",
-  AppLocale.iosArmsx2StatusNeedsLink: "ARMSX2 は RetroArch と同じ ROM フォルダを使用します。共有 ROM フォルダをリンクしてから、ARMSX2 ライブラリを同期してください。",
-  AppLocale.iosArmsx2StatusNeedsSync: "共有 ROM フォルダをリンクしました。ARMSX2 を同期して PS2 ライブラリを NeoStation にインポートしてください。",
-  AppLocale.iosArmsx2StatusSynced: "共有フォルダと ARMSX2 ライブラリを同期済み — PS2 ゲームは ARMSX2 で直接起動します。",
-  AppLocale.iosArmsx2LinkSuccess: "共有 ROM フォルダをリンクしました。RetroArch と ARMSX2 は同じ NeoStation ROM ソースを使用します。",
-  AppLocale.iosMelonxStatusSynced: "MeloNX ライブラリを同期済み — Nintendo Switch ゲームは MeloNX で直接起動します。",
-  AppLocale.iosMelonxStatusNeedsSync: "MeloNX を同期して Nintendo Switch ライブラリを NeoStation に直接インポートします。ROM フォルダのスキャンは不要です。",
+  AppLocale.iosRetroarchStatusNeedsLink:
+      "RetroArch のフォルダをリンクすると、コピーせずに NeoStation からゲームへ直接アクセスできます。",
+  AppLocale.iosRetroarchStatusNeedsSync:
+      "フォルダをリンクしました。ライブラリを同期すると、ワンタップで RetroArch から直接ゲームを起動できます。",
+  AppLocale.iosRetroarchStatusSynced:
+      "フォルダとライブラリを同期済み — ゲームは RetroArch で直接起動します。",
+  AppLocale.iosRetroarchLinkSuccess:
+      "フォルダをリンクしました。NeoStation はコピーせず、その場所を直接スキャンします。ここで見つかったゲームは RetroArch で直接起動します。",
+  AppLocale.iosArmsx2StatusNeedsLink:
+      "ARMSX2 は RetroArch と同じ ROM フォルダを使用します。共有 ROM フォルダをリンクしてから、ARMSX2 ライブラリを同期してください。",
+  AppLocale.iosArmsx2StatusNeedsSync:
+      "共有 ROM フォルダをリンクしました。ARMSX2 を同期して PS2 ライブラリを NeoStation にインポートしてください。",
+  AppLocale.iosArmsx2StatusSynced:
+      "共有フォルダと ARMSX2 ライブラリを同期済み — PS2 ゲームは ARMSX2 で直接起動します。",
+  AppLocale.iosArmsx2LinkSuccess:
+      "共有 ROM フォルダをリンクしました。RetroArch と ARMSX2 は同じ NeoStation ROM ソースを使用します。",
+  AppLocale.iosMelonxStatusSynced:
+      "MeloNX ライブラリを同期済み — Nintendo Switch ゲームは MeloNX で直接起動します。",
+  AppLocale.iosMelonxStatusNeedsSync:
+      "MeloNX を同期して Nintendo Switch ライブラリを NeoStation に直接インポートします。ROM フォルダのスキャンは不要です。",
 
   // Rich System Info
   AppLocale.systemArchitecture: 'アーキテクチャ',
@@ -961,21 +976,32 @@ const Map<String, dynamic> appLocaleJa = {
   AppLocale.systemNotableGames: '代表的なゲーム',
   AppLocale.systemTechnicalDetails: '技術情報',
   AppLocale.systemGamesDetected: '検出されたゲーム',
-  AppLocale.systemInfoDetailedIntro: '{name} は {manufacturer} が {year} 年に発売した{type}です。',
-  AppLocale.systemInfoDetailedIntroNoManufacturer: '{name} は {year} 年に登場した{type}です。',
+  AppLocale.systemInfoDetailedIntro:
+      '{name} は {manufacturer} が {year} 年に発売した{type}です。',
+  AppLocale.systemInfoDetailedIntroNoManufacturer:
+      '{name} は {year} 年に登場した{type}です。',
   AppLocale.systemInfoArchitectureSentence: 'ハードウェアアーキテクチャは {architecture} です。',
   AppLocale.systemInfoGenerationSentence: '第 {generation} 世代に属します。',
   AppLocale.systemInfoProcessorSentence: '主なプロセッサは {cpu} です。',
   AppLocale.systemInfoMediaSentence: 'ゲームやソフトウェアは主に {media} で提供されました。',
-  AppLocale.systemInfoCollectionRomHacks: 'この項目は元のシステム向けのROMハックやコミュニティ製バリエーションをまとめたものです。',
-  AppLocale.systemInfoCollectionAllSystems: 'この仮想コレクションには、検出されたすべてのシステムのゲームがまとめられます。',
-  AppLocale.systemInfoCollectionFavorites: 'この仮想コレクションには、ユーザーがお気に入りに設定したゲームが含まれます。',
-  AppLocale.systemInfoCollectionDigitalStore: 'この項目はPC向けデジタルゲームストアを表し、カタログや必要ハードウェアはタイトルごとに異なります。',
-  AppLocale.systemInfoCollectionEmulationPlatform: 'この項目は複数の元ハードウェア系統を扱うエミュレーション／互換プラットフォームを表します。',
-  AppLocale.systemInfoCollectionFantasyConsole: '小規模なゲームやデモ向けに、意図的に制約された仮想ハードウェアを持つファンタジーコンソールです。',
-  AppLocale.systemInfoCollectionMediaCollection: '固定のゲームハードウェアではなく、メディアコレクションです。',
-  AppLocale.systemInfoCollectionGameEngine: 'この項目はゲームエンジン／ランタイムを表し、作品は複数のハードウェア世代にまたがる場合があります。',
-  AppLocale.systemInfoCollectionSoftwarePlatform: 'このソフトウェアプラットフォームは複数のハードウェア構成で動作するため、アーキテクチャは端末や時代によって異なります。',
+  AppLocale.systemInfoCollectionRomHacks:
+      'この項目は元のシステム向けのROMハックやコミュニティ製バリエーションをまとめたものです。',
+  AppLocale.systemInfoCollectionAllSystems:
+      'この仮想コレクションには、検出されたすべてのシステムのゲームがまとめられます。',
+  AppLocale.systemInfoCollectionFavorites:
+      'この仮想コレクションには、ユーザーがお気に入りに設定したゲームが含まれます。',
+  AppLocale.systemInfoCollectionDigitalStore:
+      'この項目はPC向けデジタルゲームストアを表し、カタログや必要ハードウェアはタイトルごとに異なります。',
+  AppLocale.systemInfoCollectionEmulationPlatform:
+      'この項目は複数の元ハードウェア系統を扱うエミュレーション／互換プラットフォームを表します。',
+  AppLocale.systemInfoCollectionFantasyConsole:
+      '小規模なゲームやデモ向けに、意図的に制約された仮想ハードウェアを持つファンタジーコンソールです。',
+  AppLocale.systemInfoCollectionMediaCollection:
+      '固定のゲームハードウェアではなく、メディアコレクションです。',
+  AppLocale.systemInfoCollectionGameEngine:
+      'この項目はゲームエンジン／ランタイムを表し、作品は複数のハードウェア世代にまたがる場合があります。',
+  AppLocale.systemInfoCollectionSoftwarePlatform:
+      'このソフトウェアプラットフォームは複数のハードウェア構成で動作するため、アーキテクチャは端末や時代によって異なります。',
   AppLocale.mediaCartridge: 'カートリッジ',
   AppLocale.mediaCdRom: 'CD-ROM',
   AppLocale.mediaDvd: 'DVD',

--- a/lib/l10n/app_locale_ko.dart
+++ b/lib/l10n/app_locale_ko.dart
@@ -666,8 +666,10 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.systemInfo: '시스템 정보',
   AppLocale.systemType: '유형',
   AppLocale.supportedFormats: '지원 형식',
-  AppLocale.systemInfoSummary: '{name}은(는) {manufacturer}에서 {year}년에 출시한 {type}입니다. NeoStation은 현재 이 시스템에서 {count}개의 게임을 감지합니다.',
-  AppLocale.systemInfoSummaryNoManufacturer: '{name}은(는) {year}년에 등장한 {type}입니다. NeoStation은 현재 이 시스템에서 {count}개의 게임을 감지합니다.',
+  AppLocale.systemInfoSummary:
+      '{name}은(는) {manufacturer}에서 {year}년에 출시한 {type}입니다. NeoStation은 현재 이 시스템에서 {count}개의 게임을 감지합니다.',
+  AppLocale.systemInfoSummaryNoManufacturer:
+      '{name}은(는) {year}년에 등장한 {type}입니다. NeoStation은 현재 이 시스템에서 {count}개의 게임을 감지합니다.',
   AppLocale.systemTypeConsole: '가정용 콘솔',
   AppLocale.systemTypeHandheld: '휴대용 게임기',
   AppLocale.systemTypeComputer: '컴퓨터',
@@ -943,22 +945,35 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.iosEmuLinkFolder: "폴더 연결",
   AppLocale.iosEmuChangeFolder: "폴더 변경",
   AppLocale.iosEmuLinkingFailed: "연결 실패: {error}",
-  AppLocale.iosRetroarchSyncRequested: "RetroArch 라이브러리 동기화를 요청했습니다. 백그라운드에서 진행되므로 몇 초 기다려 주세요.",
+  AppLocale.iosRetroarchSyncRequested:
+      "RetroArch 라이브러리 동기화를 요청했습니다. 백그라운드에서 진행되므로 몇 초 기다려 주세요.",
   AppLocale.iosRetroarchUnavailable: "RetroArch에 연결할 수 없습니다. 설치되어 있나요?",
-  AppLocale.iosArmsx2SyncRequested: "ARMSX2 라이브러리 동기화를 요청했습니다. 내보내기가 준비되면 ARMSX2가 자동으로 NeoStation으로 돌아옵니다.",
+  AppLocale.iosArmsx2SyncRequested:
+      "ARMSX2 라이브러리 동기화를 요청했습니다. 내보내기가 준비되면 ARMSX2가 자동으로 NeoStation으로 돌아옵니다.",
   AppLocale.iosArmsx2Unavailable: "ARMSX2에 연결할 수 없습니다. 설치되어 있나요?",
-  AppLocale.iosMelonxSyncRequested: "MeloNX Nintendo Switch 라이브러리 동기화를 요청했습니다. 내보내기가 준비되면 MeloNX가 자동으로 NeoStation으로 돌아옵니다.",
+  AppLocale.iosMelonxSyncRequested:
+      "MeloNX Nintendo Switch 라이브러리 동기화를 요청했습니다. 내보내기가 준비되면 MeloNX가 자동으로 NeoStation으로 돌아옵니다.",
   AppLocale.iosMelonxUnavailable: "MeloNX에 연결할 수 없습니다. 설치되어 있나요?",
-  AppLocale.iosRetroarchStatusNeedsLink: "RetroArch 폴더를 연결하면 복사 없이 NeoStation에서 게임에 직접 접근할 수 있습니다.",
-  AppLocale.iosRetroarchStatusNeedsSync: "폴더가 연결되었습니다. 라이브러리를 동기화하면 한 번의 탭으로 RetroArch에서 게임을 바로 실행할 수 있습니다.",
-  AppLocale.iosRetroarchStatusSynced: "폴더와 라이브러리가 동기화되었습니다 — 게임이 RetroArch에서 바로 실행됩니다.",
-  AppLocale.iosRetroarchLinkSuccess: "폴더가 연결되었습니다. NeoStation이 복사 없이 해당 위치를 직접 스캔합니다. 여기서 찾은 게임은 RetroArch에서 바로 실행됩니다.",
-  AppLocale.iosArmsx2StatusNeedsLink: "ARMSX2는 RetroArch와 같은 ROM 폴더를 사용합니다. 공유 ROM 폴더를 연결한 뒤 ARMSX2 라이브러리를 동기화하세요.",
-  AppLocale.iosArmsx2StatusNeedsSync: "공유 ROM 폴더가 연결되었습니다. ARMSX2를 동기화하여 PS2 라이브러리를 NeoStation으로 가져오세요.",
-  AppLocale.iosArmsx2StatusSynced: "공유 폴더와 ARMSX2 라이브러리가 동기화되었습니다 — PS2 게임이 ARMSX2에서 바로 실행됩니다.",
-  AppLocale.iosArmsx2LinkSuccess: "공유 ROM 폴더가 연결되었습니다. RetroArch와 ARMSX2가 이제 동일한 NeoStation ROM 소스를 사용합니다.",
-  AppLocale.iosMelonxStatusSynced: "MeloNX 라이브러리가 동기화되었습니다 — Nintendo Switch 게임이 MeloNX에서 바로 실행됩니다.",
-  AppLocale.iosMelonxStatusNeedsSync: "MeloNX를 동기화하여 Nintendo Switch 라이브러리를 NeoStation으로 직접 가져옵니다. ROM 폴더 스캔은 필요하지 않습니다.",
+  AppLocale.iosRetroarchStatusNeedsLink:
+      "RetroArch 폴더를 연결하면 복사 없이 NeoStation에서 게임에 직접 접근할 수 있습니다.",
+  AppLocale.iosRetroarchStatusNeedsSync:
+      "폴더가 연결되었습니다. 라이브러리를 동기화하면 한 번의 탭으로 RetroArch에서 게임을 바로 실행할 수 있습니다.",
+  AppLocale.iosRetroarchStatusSynced:
+      "폴더와 라이브러리가 동기화되었습니다 — 게임이 RetroArch에서 바로 실행됩니다.",
+  AppLocale.iosRetroarchLinkSuccess:
+      "폴더가 연결되었습니다. NeoStation이 복사 없이 해당 위치를 직접 스캔합니다. 여기서 찾은 게임은 RetroArch에서 바로 실행됩니다.",
+  AppLocale.iosArmsx2StatusNeedsLink:
+      "ARMSX2는 RetroArch와 같은 ROM 폴더를 사용합니다. 공유 ROM 폴더를 연결한 뒤 ARMSX2 라이브러리를 동기화하세요.",
+  AppLocale.iosArmsx2StatusNeedsSync:
+      "공유 ROM 폴더가 연결되었습니다. ARMSX2를 동기화하여 PS2 라이브러리를 NeoStation으로 가져오세요.",
+  AppLocale.iosArmsx2StatusSynced:
+      "공유 폴더와 ARMSX2 라이브러리가 동기화되었습니다 — PS2 게임이 ARMSX2에서 바로 실행됩니다.",
+  AppLocale.iosArmsx2LinkSuccess:
+      "공유 ROM 폴더가 연결되었습니다. RetroArch와 ARMSX2가 이제 동일한 NeoStation ROM 소스를 사용합니다.",
+  AppLocale.iosMelonxStatusSynced:
+      "MeloNX 라이브러리가 동기화되었습니다 — Nintendo Switch 게임이 MeloNX에서 바로 실행됩니다.",
+  AppLocale.iosMelonxStatusNeedsSync:
+      "MeloNX를 동기화하여 Nintendo Switch 라이브러리를 NeoStation으로 직접 가져옵니다. ROM 폴더 스캔은 필요하지 않습니다.",
 
   // Rich System Info
   AppLocale.systemArchitecture: '아키텍처',
@@ -968,21 +983,32 @@ const Map<String, dynamic> appLocaleKo = {
   AppLocale.systemNotableGames: '대표 게임',
   AppLocale.systemTechnicalDetails: '기술 정보',
   AppLocale.systemGamesDetected: '감지된 게임',
-  AppLocale.systemInfoDetailedIntro: '{name}은(는) {manufacturer}가 {year}년에 출시한 {type} 시스템입니다.',
-  AppLocale.systemInfoDetailedIntroNoManufacturer: '{name}은(는) {year}년에 등장한 {type} 시스템입니다.',
+  AppLocale.systemInfoDetailedIntro:
+      '{name}은(는) {manufacturer}가 {year}년에 출시한 {type} 시스템입니다.',
+  AppLocale.systemInfoDetailedIntroNoManufacturer:
+      '{name}은(는) {year}년에 등장한 {type} 시스템입니다.',
   AppLocale.systemInfoArchitectureSentence: '하드웨어 아키텍처는 {architecture}입니다.',
   AppLocale.systemInfoGenerationSentence: '{generation}세대에 속합니다.',
   AppLocale.systemInfoProcessorSentence: '주요 프로세서는 {cpu}입니다.',
   AppLocale.systemInfoMediaSentence: '게임과 소프트웨어는 주로 {media} 매체로 배포되었습니다.',
-  AppLocale.systemInfoCollectionRomHacks: '이 항목은 원본 시스템용 ROM 해킹과 커뮤니티 제작 변형을 모아 둔 컬렉션입니다.',
-  AppLocale.systemInfoCollectionAllSystems: '이 가상 컬렉션은 감지된 모든 시스템의 게임을 한곳에 모읍니다.',
-  AppLocale.systemInfoCollectionFavorites: '이 가상 컬렉션에는 사용자가 즐겨찾기로 표시한 게임이 포함됩니다.',
-  AppLocale.systemInfoCollectionDigitalStore: '이 항목은 PC 디지털 게임 스토어를 나타내며 카탈로그와 하드웨어 요구 사항은 게임마다 다릅니다.',
-  AppLocale.systemInfoCollectionEmulationPlatform: '이 항목은 여러 원본 하드웨어 계열을 다루는 에뮬레이션 또는 호환성 플랫폼을 나타냅니다.',
-  AppLocale.systemInfoCollectionFantasyConsole: '작은 게임과 데모를 위해 의도적으로 제한된 가상 하드웨어를 사용하는 판타지 콘솔입니다.',
-  AppLocale.systemInfoCollectionMediaCollection: '고정된 게임 하드웨어 플랫폼이 아니라 미디어 컬렉션입니다.',
-  AppLocale.systemInfoCollectionGameEngine: '이 항목은 게임 엔진 또는 런타임을 나타내며 타이틀이 여러 하드웨어 세대에 걸칠 수 있습니다.',
-  AppLocale.systemInfoCollectionSoftwarePlatform: '이 소프트웨어 플랫폼은 여러 하드웨어 구성에서 동작하므로 아키텍처가 장치나 시대에 따라 달라집니다.',
+  AppLocale.systemInfoCollectionRomHacks:
+      '이 항목은 원본 시스템용 ROM 해킹과 커뮤니티 제작 변형을 모아 둔 컬렉션입니다.',
+  AppLocale.systemInfoCollectionAllSystems:
+      '이 가상 컬렉션은 감지된 모든 시스템의 게임을 한곳에 모읍니다.',
+  AppLocale.systemInfoCollectionFavorites:
+      '이 가상 컬렉션에는 사용자가 즐겨찾기로 표시한 게임이 포함됩니다.',
+  AppLocale.systemInfoCollectionDigitalStore:
+      '이 항목은 PC 디지털 게임 스토어를 나타내며 카탈로그와 하드웨어 요구 사항은 게임마다 다릅니다.',
+  AppLocale.systemInfoCollectionEmulationPlatform:
+      '이 항목은 여러 원본 하드웨어 계열을 다루는 에뮬레이션 또는 호환성 플랫폼을 나타냅니다.',
+  AppLocale.systemInfoCollectionFantasyConsole:
+      '작은 게임과 데모를 위해 의도적으로 제한된 가상 하드웨어를 사용하는 판타지 콘솔입니다.',
+  AppLocale.systemInfoCollectionMediaCollection:
+      '고정된 게임 하드웨어 플랫폼이 아니라 미디어 컬렉션입니다.',
+  AppLocale.systemInfoCollectionGameEngine:
+      '이 항목은 게임 엔진 또는 런타임을 나타내며 타이틀이 여러 하드웨어 세대에 걸칠 수 있습니다.',
+  AppLocale.systemInfoCollectionSoftwarePlatform:
+      '이 소프트웨어 플랫폼은 여러 하드웨어 구성에서 동작하므로 아키텍처가 장치나 시대에 따라 달라집니다.',
   AppLocale.mediaCartridge: '카트리지',
   AppLocale.mediaCdRom: 'CD-ROM',
   AppLocale.mediaDvd: 'DVD',

--- a/lib/l10n/app_locale_pt.dart
+++ b/lib/l10n/app_locale_pt.dart
@@ -184,7 +184,8 @@ const Map<String, dynamic> appLocalePt = {
 
   AppLocale.configureDirectories: 'Configurar Diretórios',
   AppLocale.configureLaunch: 'Configurar inicialização',
-  AppLocale.shortcutSetupOpenError: 'Não foi possível abrir a configuração de inicialização.',
+  AppLocale.shortcutSetupOpenError:
+      'Não foi possível abrir a configuração de inicialização.',
   AppLocale.configureRomsFolder: 'Configurar Pasta de ROMs',
   AppLocale.cannotAccessFolder: 'Não foi possível acessar a pasta',
   AppLocale.backgroundImage: 'Imagem de Fundo',
@@ -552,22 +553,28 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.gameInfo: 'Info do Jogo',
   AppLocale.manage: 'Gerenciar',
   AppLocale.manual: 'Manual',
-  AppLocale.scrapeManualDesc: 'Baixar manuais de jogos em PDF quando disponíveis.',
+  AppLocale.scrapeManualDesc:
+      'Baixar manuais de jogos em PDF quando disponíveis.',
   AppLocale.manualReady: 'Manual baixado',
   AppLocale.manualNotDownloaded: 'Nenhum manual baixado',
-  AppLocale.manualDownloadHint: 'Baixe o manual do jogo do ScreenScraper quando estiver disponível.',
+  AppLocale.manualDownloadHint:
+      'Baixe o manual do jogo do ScreenScraper quando estiver disponível.',
   AppLocale.downloadManual: 'Baixar manual',
-  AppLocale.downloadManualDesc: 'Baixe o melhor PDF disponível para seu idioma e região.',
+  AppLocale.downloadManualDesc:
+      'Baixe o melhor PDF disponível para seu idioma e região.',
   AppLocale.readManual: 'Ler manual',
-  AppLocale.readManualDesc: 'Abra o PDF salvo no leitor integrado do NeoStation.',
+  AppLocale.readManualDesc:
+      'Abra o PDF salvo no leitor integrado do NeoStation.',
   AppLocale.redownloadManual: 'Baixar novamente',
-  AppLocale.redownloadManualDesc: 'Substitua a cópia local pela melhor versão disponível.',
+  AppLocale.redownloadManualDesc:
+      'Substitua a cópia local pela melhor versão disponível.',
   AppLocale.deleteManual: 'Excluir manual',
   AppLocale.deleteManualDesc: 'Remova o PDF salvo deste dispositivo.',
   AppLocale.deleteManualConfirmation: 'Excluir o manual baixado deste jogo?',
   AppLocale.manualDownloaded: 'Manual baixado',
   AppLocale.manualDownloadFailed: 'Falha ao baixar o manual',
-  AppLocale.manualNotAvailable: 'Não há manual disponível para este jogo no ScreenScraper.',
+  AppLocale.manualNotAvailable:
+      'Não há manual disponível para este jogo no ScreenScraper.',
   AppLocale.manualDeleted: 'Manual excluído',
   AppLocale.downloadingManual: 'Baixando manual...',
   AppLocale.pinchToZoom: 'Faça pinça para ampliar',
@@ -733,8 +740,10 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.systemInfo: 'Info do Sistema',
   AppLocale.systemType: 'Tipo',
   AppLocale.supportedFormats: 'Formatos suportados',
-  AppLocale.systemInfoSummary: '{name} é um sistema do tipo {type}, lançado pela {manufacturer} em {year}. O NeoStation deteta atualmente {count} jogos para este sistema.',
-  AppLocale.systemInfoSummaryNoManufacturer: '{name} é um sistema do tipo {type}, introduzido em {year}. O NeoStation deteta atualmente {count} jogos para este sistema.',
+  AppLocale.systemInfoSummary:
+      '{name} é um sistema do tipo {type}, lançado pela {manufacturer} em {year}. O NeoStation deteta atualmente {count} jogos para este sistema.',
+  AppLocale.systemInfoSummaryNoManufacturer:
+      '{name} é um sistema do tipo {type}, introduzido em {year}. O NeoStation deteta atualmente {count} jogos para este sistema.',
   AppLocale.systemTypeConsole: 'console doméstica',
   AppLocale.systemTypeHandheld: 'console portátil',
   AppLocale.systemTypeComputer: 'computador',
@@ -1035,22 +1044,38 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.iosEmuLinkFolder: "Vincular pasta",
   AppLocale.iosEmuChangeFolder: "Alterar pasta",
   AppLocale.iosEmuLinkingFailed: "Falha ao vincular: {error}",
-  AppLocale.iosRetroarchSyncRequested: "A sincronização da biblioteca do RetroArch foi solicitada. Ela ocorre em segundo plano; aguarde alguns segundos.",
-  AppLocale.iosRetroarchUnavailable: "Não foi possível acessar o RetroArch. Ele está instalado?",
-  AppLocale.iosArmsx2SyncRequested: "A sincronização da biblioteca do ARMSX2 foi solicitada. O ARMSX2 retornará automaticamente ao NeoStation quando a exportação estiver pronta.",
-  AppLocale.iosArmsx2Unavailable: "Não foi possível acessar o ARMSX2. Ele está instalado?",
-  AppLocale.iosMelonxSyncRequested: "A sincronização da biblioteca Nintendo Switch do MeloNX foi solicitada. O MeloNX retornará automaticamente ao NeoStation quando a exportação estiver pronta.",
-  AppLocale.iosMelonxUnavailable: "Não foi possível acessar o MeloNX. Ele está instalado?",
-  AppLocale.iosRetroarchStatusNeedsLink: "Vincule a pasta do RetroArch para que o NeoStation acesse seus jogos diretamente, sem copiar.",
-  AppLocale.iosRetroarchStatusNeedsSync: "Pasta vinculada. Sincronize a biblioteca para iniciar os jogos diretamente no RetroArch com um toque.",
-  AppLocale.iosRetroarchStatusSynced: "Pasta vinculada e biblioteca sincronizada — os jogos são iniciados diretamente no RetroArch.",
-  AppLocale.iosRetroarchLinkSuccess: "Pasta vinculada. O NeoStation fará a leitura diretamente, sem copiar. Os jogos encontrados aqui serão iniciados diretamente no RetroArch.",
-  AppLocale.iosArmsx2StatusNeedsLink: "O ARMSX2 usa a mesma pasta de ROMs do RetroArch. Vincule a pasta compartilhada e depois sincronize a biblioteca do ARMSX2.",
-  AppLocale.iosArmsx2StatusNeedsSync: "Pasta de ROMs compartilhada vinculada. Sincronize o ARMSX2 para importar a biblioteca de PS2 para o NeoStation.",
-  AppLocale.iosArmsx2StatusSynced: "Pasta compartilhada e biblioteca do ARMSX2 sincronizadas — os jogos de PS2 são iniciados diretamente no ARMSX2.",
-  AppLocale.iosArmsx2LinkSuccess: "Pasta de ROMs compartilhada vinculada. RetroArch e ARMSX2 agora usam a mesma origem de ROMs do NeoStation.",
-  AppLocale.iosMelonxStatusSynced: "Biblioteca do MeloNX sincronizada — os jogos de Nintendo Switch são iniciados diretamente no MeloNX.",
-  AppLocale.iosMelonxStatusNeedsSync: "Sincronize o MeloNX para importar diretamente sua biblioteca de Nintendo Switch para o NeoStation. Não é necessário analisar uma pasta de ROMs.",
+  AppLocale.iosRetroarchSyncRequested:
+      "A sincronização da biblioteca do RetroArch foi solicitada. Ela ocorre em segundo plano; aguarde alguns segundos.",
+  AppLocale.iosRetroarchUnavailable:
+      "Não foi possível acessar o RetroArch. Ele está instalado?",
+  AppLocale.iosArmsx2SyncRequested:
+      "A sincronização da biblioteca do ARMSX2 foi solicitada. O ARMSX2 retornará automaticamente ao NeoStation quando a exportação estiver pronta.",
+  AppLocale.iosArmsx2Unavailable:
+      "Não foi possível acessar o ARMSX2. Ele está instalado?",
+  AppLocale.iosMelonxSyncRequested:
+      "A sincronização da biblioteca Nintendo Switch do MeloNX foi solicitada. O MeloNX retornará automaticamente ao NeoStation quando a exportação estiver pronta.",
+  AppLocale.iosMelonxUnavailable:
+      "Não foi possível acessar o MeloNX. Ele está instalado?",
+  AppLocale.iosRetroarchStatusNeedsLink:
+      "Vincule a pasta do RetroArch para que o NeoStation acesse seus jogos diretamente, sem copiar.",
+  AppLocale.iosRetroarchStatusNeedsSync:
+      "Pasta vinculada. Sincronize a biblioteca para iniciar os jogos diretamente no RetroArch com um toque.",
+  AppLocale.iosRetroarchStatusSynced:
+      "Pasta vinculada e biblioteca sincronizada — os jogos são iniciados diretamente no RetroArch.",
+  AppLocale.iosRetroarchLinkSuccess:
+      "Pasta vinculada. O NeoStation fará a leitura diretamente, sem copiar. Os jogos encontrados aqui serão iniciados diretamente no RetroArch.",
+  AppLocale.iosArmsx2StatusNeedsLink:
+      "O ARMSX2 usa a mesma pasta de ROMs do RetroArch. Vincule a pasta compartilhada e depois sincronize a biblioteca do ARMSX2.",
+  AppLocale.iosArmsx2StatusNeedsSync:
+      "Pasta de ROMs compartilhada vinculada. Sincronize o ARMSX2 para importar a biblioteca de PS2 para o NeoStation.",
+  AppLocale.iosArmsx2StatusSynced:
+      "Pasta compartilhada e biblioteca do ARMSX2 sincronizadas — os jogos de PS2 são iniciados diretamente no ARMSX2.",
+  AppLocale.iosArmsx2LinkSuccess:
+      "Pasta de ROMs compartilhada vinculada. RetroArch e ARMSX2 agora usam a mesma origem de ROMs do NeoStation.",
+  AppLocale.iosMelonxStatusSynced:
+      "Biblioteca do MeloNX sincronizada — os jogos de Nintendo Switch são iniciados diretamente no MeloNX.",
+  AppLocale.iosMelonxStatusNeedsSync:
+      "Sincronize o MeloNX para importar diretamente sua biblioteca de Nintendo Switch para o NeoStation. Não é necessário analisar uma pasta de ROMs.",
 
   // Rich System Info
   AppLocale.systemArchitecture: 'Arquitetura',
@@ -1060,21 +1085,35 @@ const Map<String, dynamic> appLocalePt = {
   AppLocale.systemNotableGames: 'Jogos marcantes',
   AppLocale.systemTechnicalDetails: 'Detalhes técnicos',
   AppLocale.systemGamesDetected: 'Jogos detectados',
-  AppLocale.systemInfoDetailedIntro: '{name} é um sistema do tipo {type}, lançado pela {manufacturer} em {year}.',
-  AppLocale.systemInfoDetailedIntroNoManufacturer: '{name} é um sistema do tipo {type}, apresentado em {year}.',
-  AppLocale.systemInfoArchitectureSentence: 'Sua arquitetura de hardware é {architecture}.',
-  AppLocale.systemInfoGenerationSentence: 'Ele pertence à geração {generation}.',
+  AppLocale.systemInfoDetailedIntro:
+      '{name} é um sistema do tipo {type}, lançado pela {manufacturer} em {year}.',
+  AppLocale.systemInfoDetailedIntroNoManufacturer:
+      '{name} é um sistema do tipo {type}, apresentado em {year}.',
+  AppLocale.systemInfoArchitectureSentence:
+      'Sua arquitetura de hardware é {architecture}.',
+  AppLocale.systemInfoGenerationSentence:
+      'Ele pertence à geração {generation}.',
   AppLocale.systemInfoProcessorSentence: 'Seu processador principal é {cpu}.',
-  AppLocale.systemInfoMediaSentence: 'Jogos e softwares eram distribuídos principalmente em {media}.',
-  AppLocale.systemInfoCollectionRomHacks: 'Esta entrada reúne ROM hacks e variantes criadas pela comunidade para o sistema original.',
-  AppLocale.systemInfoCollectionAllSystems: 'Esta coleção virtual reúne jogos de todos os sistemas detectados.',
-  AppLocale.systemInfoCollectionFavorites: 'Esta coleção virtual contém os jogos marcados como favoritos pelo usuário.',
-  AppLocale.systemInfoCollectionDigitalStore: 'Esta entrada representa uma loja digital de jogos para PC; catálogo e requisitos de hardware variam conforme o título.',
-  AppLocale.systemInfoCollectionEmulationPlatform: 'Esta entrada representa uma plataforma de emulação ou compatibilidade que cobre várias famílias de hardware original.',
-  AppLocale.systemInfoCollectionFantasyConsole: 'É um console de fantasia com hardware virtual deliberadamente limitado para pequenos jogos e demos.',
-  AppLocale.systemInfoCollectionMediaCollection: 'É uma coleção de mídia, não uma plataforma fixa de hardware para jogos.',
-  AppLocale.systemInfoCollectionGameEngine: 'Esta entrada representa um motor ou runtime cujos jogos podem abranger diferentes gerações de hardware.',
-  AppLocale.systemInfoCollectionSoftwarePlatform: 'Esta plataforma de software abrange várias configurações de hardware, portanto a arquitetura varia conforme o dispositivo ou a época.',
+  AppLocale.systemInfoMediaSentence:
+      'Jogos e softwares eram distribuídos principalmente em {media}.',
+  AppLocale.systemInfoCollectionRomHacks:
+      'Esta entrada reúne ROM hacks e variantes criadas pela comunidade para o sistema original.',
+  AppLocale.systemInfoCollectionAllSystems:
+      'Esta coleção virtual reúne jogos de todos os sistemas detectados.',
+  AppLocale.systemInfoCollectionFavorites:
+      'Esta coleção virtual contém os jogos marcados como favoritos pelo usuário.',
+  AppLocale.systemInfoCollectionDigitalStore:
+      'Esta entrada representa uma loja digital de jogos para PC; catálogo e requisitos de hardware variam conforme o título.',
+  AppLocale.systemInfoCollectionEmulationPlatform:
+      'Esta entrada representa uma plataforma de emulação ou compatibilidade que cobre várias famílias de hardware original.',
+  AppLocale.systemInfoCollectionFantasyConsole:
+      'É um console de fantasia com hardware virtual deliberadamente limitado para pequenos jogos e demos.',
+  AppLocale.systemInfoCollectionMediaCollection:
+      'É uma coleção de mídia, não uma plataforma fixa de hardware para jogos.',
+  AppLocale.systemInfoCollectionGameEngine:
+      'Esta entrada representa um motor ou runtime cujos jogos podem abranger diferentes gerações de hardware.',
+  AppLocale.systemInfoCollectionSoftwarePlatform:
+      'Esta plataforma de software abrange várias configurações de hardware, portanto a arquitetura varia conforme o dispositivo ou a época.',
   AppLocale.mediaCartridge: 'Cartucho',
   AppLocale.mediaCdRom: 'CD-ROM',
   AppLocale.mediaDvd: 'DVD',

--- a/lib/l10n/app_locale_ru.dart
+++ b/lib/l10n/app_locale_ru.dart
@@ -552,22 +552,29 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.gameInfo: 'Инфо об игре',
   AppLocale.manage: 'Управление',
   AppLocale.manual: 'Руководство',
-  AppLocale.scrapeManualDesc: 'Загружать руководства к играм в PDF, если они доступны.',
+  AppLocale.scrapeManualDesc:
+      'Загружать руководства к играм в PDF, если они доступны.',
   AppLocale.manualReady: 'Руководство загружено',
   AppLocale.manualNotDownloaded: 'Руководство не загружено',
-  AppLocale.manualDownloadHint: 'Загрузите руководство к игре из ScreenScraper, если оно доступно.',
+  AppLocale.manualDownloadHint:
+      'Загрузите руководство к игре из ScreenScraper, если оно доступно.',
   AppLocale.downloadManual: 'Скачать руководство',
-  AppLocale.downloadManualDesc: 'Скачать лучший доступный PDF для вашего языка и региона.',
+  AppLocale.downloadManualDesc:
+      'Скачать лучший доступный PDF для вашего языка и региона.',
   AppLocale.readManual: 'Читать руководство',
-  AppLocale.readManualDesc: 'Открыть сохранённый PDF во встроенном просмотрщике NeoStation.',
+  AppLocale.readManualDesc:
+      'Открыть сохранённый PDF во встроенном просмотрщике NeoStation.',
   AppLocale.redownloadManual: 'Скачать заново',
-  AppLocale.redownloadManualDesc: 'Заменить локальную копию лучшей доступной версией.',
+  AppLocale.redownloadManualDesc:
+      'Заменить локальную копию лучшей доступной версией.',
   AppLocale.deleteManual: 'Удалить руководство',
   AppLocale.deleteManualDesc: 'Удалить сохранённый PDF с этого устройства.',
-  AppLocale.deleteManualConfirmation: 'Удалить загруженное руководство для этой игры?',
+  AppLocale.deleteManualConfirmation:
+      'Удалить загруженное руководство для этой игры?',
   AppLocale.manualDownloaded: 'Руководство загружено',
   AppLocale.manualDownloadFailed: 'Не удалось загрузить руководство',
-  AppLocale.manualNotAvailable: 'Для этой игры на ScreenScraper нет доступного руководства.',
+  AppLocale.manualNotAvailable:
+      'Для этой игры на ScreenScraper нет доступного руководства.',
   AppLocale.manualDeleted: 'Руководство удалено',
   AppLocale.downloadingManual: 'Загрузка руководства...',
   AppLocale.pinchToZoom: 'Сведите пальцы для масштаба',
@@ -729,8 +736,10 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.systemInfo: 'О системе',
   AppLocale.systemType: 'Тип',
   AppLocale.supportedFormats: 'Поддерживаемые форматы',
-  AppLocale.systemInfoSummary: '{name} — это {type}, выпущенная компанией {manufacturer} в {year} году. NeoStation сейчас обнаруживает {count} игр для этой системы.',
-  AppLocale.systemInfoSummaryNoManufacturer: '{name} — это {type}, появившаяся в {year} году. NeoStation сейчас обнаруживает {count} игр для этой системы.',
+  AppLocale.systemInfoSummary:
+      '{name} — это {type}, выпущенная компанией {manufacturer} в {year} году. NeoStation сейчас обнаруживает {count} игр для этой системы.',
+  AppLocale.systemInfoSummaryNoManufacturer:
+      '{name} — это {type}, появившаяся в {year} году. NeoStation сейчас обнаруживает {count} игр для этой системы.',
   AppLocale.systemTypeConsole: 'домашняя консоль',
   AppLocale.systemTypeHandheld: 'портативная система',
   AppLocale.systemTypeComputer: 'компьютер',
@@ -1023,22 +1032,38 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.iosEmuLinkFolder: "Подключить папку",
   AppLocale.iosEmuChangeFolder: "Изменить папку",
   AppLocale.iosEmuLinkingFailed: "Не удалось подключить папку: {error}",
-  AppLocale.iosRetroarchSyncRequested: "Запрошена синхронизация библиотеки RetroArch. Она выполняется в фоновом режиме; подождите несколько секунд.",
-  AppLocale.iosRetroarchUnavailable: "Не удалось связаться с RetroArch. Он установлен?",
-  AppLocale.iosArmsx2SyncRequested: "Запрошена синхронизация библиотеки ARMSX2. ARMSX2 автоматически вернётся в NeoStation, когда экспорт будет готов.",
-  AppLocale.iosArmsx2Unavailable: "Не удалось связаться с ARMSX2. Он установлен?",
-  AppLocale.iosMelonxSyncRequested: "Запрошена синхронизация библиотеки Nintendo Switch из MeloNX. MeloNX автоматически вернётся в NeoStation, когда экспорт будет готов.",
-  AppLocale.iosMelonxUnavailable: "Не удалось связаться с MeloNX. Он установлен?",
-  AppLocale.iosRetroarchStatusNeedsLink: "Подключите папку RetroArch, чтобы NeoStation мог обращаться к играм напрямую, без копирования.",
-  AppLocale.iosRetroarchStatusNeedsSync: "Папка подключена. Синхронизируйте библиотеку, чтобы запускать игры прямо в RetroArch одним нажатием.",
-  AppLocale.iosRetroarchStatusSynced: "Папка подключена, библиотека синхронизирована — игры запускаются прямо в RetroArch.",
-  AppLocale.iosRetroarchLinkSuccess: "Папка подключена. NeoStation будет сканировать её напрямую, без копирования. Найденные здесь игры будут запускаться прямо в RetroArch.",
-  AppLocale.iosArmsx2StatusNeedsLink: "ARMSX2 использует ту же папку ROM, что и RetroArch. Подключите общую папку ROM, затем синхронизируйте библиотеку ARMSX2.",
-  AppLocale.iosArmsx2StatusNeedsSync: "Общая папка ROM подключена. Синхронизируйте ARMSX2, чтобы импортировать библиотеку PS2 в NeoStation.",
-  AppLocale.iosArmsx2StatusSynced: "Общая папка и библиотека ARMSX2 синхронизированы — игры PS2 запускаются прямо в ARMSX2.",
-  AppLocale.iosArmsx2LinkSuccess: "Общая папка ROM подключена. RetroArch и ARMSX2 теперь используют один источник ROM в NeoStation.",
-  AppLocale.iosMelonxStatusSynced: "Библиотека MeloNX синхронизирована — игры Nintendo Switch запускаются прямо в MeloNX.",
-  AppLocale.iosMelonxStatusNeedsSync: "Синхронизируйте MeloNX, чтобы напрямую импортировать библиотеку Nintendo Switch в NeoStation. Сканирование папки ROM не требуется.",
+  AppLocale.iosRetroarchSyncRequested:
+      "Запрошена синхронизация библиотеки RetroArch. Она выполняется в фоновом режиме; подождите несколько секунд.",
+  AppLocale.iosRetroarchUnavailable:
+      "Не удалось связаться с RetroArch. Он установлен?",
+  AppLocale.iosArmsx2SyncRequested:
+      "Запрошена синхронизация библиотеки ARMSX2. ARMSX2 автоматически вернётся в NeoStation, когда экспорт будет готов.",
+  AppLocale.iosArmsx2Unavailable:
+      "Не удалось связаться с ARMSX2. Он установлен?",
+  AppLocale.iosMelonxSyncRequested:
+      "Запрошена синхронизация библиотеки Nintendo Switch из MeloNX. MeloNX автоматически вернётся в NeoStation, когда экспорт будет готов.",
+  AppLocale.iosMelonxUnavailable:
+      "Не удалось связаться с MeloNX. Он установлен?",
+  AppLocale.iosRetroarchStatusNeedsLink:
+      "Подключите папку RetroArch, чтобы NeoStation мог обращаться к играм напрямую, без копирования.",
+  AppLocale.iosRetroarchStatusNeedsSync:
+      "Папка подключена. Синхронизируйте библиотеку, чтобы запускать игры прямо в RetroArch одним нажатием.",
+  AppLocale.iosRetroarchStatusSynced:
+      "Папка подключена, библиотека синхронизирована — игры запускаются прямо в RetroArch.",
+  AppLocale.iosRetroarchLinkSuccess:
+      "Папка подключена. NeoStation будет сканировать её напрямую, без копирования. Найденные здесь игры будут запускаться прямо в RetroArch.",
+  AppLocale.iosArmsx2StatusNeedsLink:
+      "ARMSX2 использует ту же папку ROM, что и RetroArch. Подключите общую папку ROM, затем синхронизируйте библиотеку ARMSX2.",
+  AppLocale.iosArmsx2StatusNeedsSync:
+      "Общая папка ROM подключена. Синхронизируйте ARMSX2, чтобы импортировать библиотеку PS2 в NeoStation.",
+  AppLocale.iosArmsx2StatusSynced:
+      "Общая папка и библиотека ARMSX2 синхронизированы — игры PS2 запускаются прямо в ARMSX2.",
+  AppLocale.iosArmsx2LinkSuccess:
+      "Общая папка ROM подключена. RetroArch и ARMSX2 теперь используют один источник ROM в NeoStation.",
+  AppLocale.iosMelonxStatusSynced:
+      "Библиотека MeloNX синхронизирована — игры Nintendo Switch запускаются прямо в MeloNX.",
+  AppLocale.iosMelonxStatusNeedsSync:
+      "Синхронизируйте MeloNX, чтобы напрямую импортировать библиотеку Nintendo Switch в NeoStation. Сканирование папки ROM не требуется.",
 
   // Rich System Info
   AppLocale.systemArchitecture: 'Архитектура',
@@ -1048,21 +1073,34 @@ const Map<String, dynamic> appLocaleRu = {
   AppLocale.systemNotableGames: 'Знаковые игры',
   AppLocale.systemTechnicalDetails: 'Технические сведения',
   AppLocale.systemGamesDetected: 'Найдено игр',
-  AppLocale.systemInfoDetailedIntro: '{name} — система типа {type}, выпущенная компанией {manufacturer} в {year} году.',
-  AppLocale.systemInfoDetailedIntroNoManufacturer: '{name} — система типа {type}, появившаяся в {year} году.',
-  AppLocale.systemInfoArchitectureSentence: 'Аппаратная архитектура: {architecture}.',
+  AppLocale.systemInfoDetailedIntro:
+      '{name} — система типа {type}, выпущенная компанией {manufacturer} в {year} году.',
+  AppLocale.systemInfoDetailedIntroNoManufacturer:
+      '{name} — система типа {type}, появившаяся в {year} году.',
+  AppLocale.systemInfoArchitectureSentence:
+      'Аппаратная архитектура: {architecture}.',
   AppLocale.systemInfoGenerationSentence: 'Относится к поколению {generation}.',
   AppLocale.systemInfoProcessorSentence: 'Основной процессор — {cpu}.',
-  AppLocale.systemInfoMediaSentence: 'Игры и программы в основном распространялись на {media}.',
-  AppLocale.systemInfoCollectionRomHacks: 'Эта запись объединяет ROM-хаки и фанатские варианты для исходной системы.',
-  AppLocale.systemInfoCollectionAllSystems: 'Эта виртуальная коллекция объединяет игры всех обнаруженных систем.',
-  AppLocale.systemInfoCollectionFavorites: 'Эта виртуальная коллекция содержит игры, отмеченные пользователем как избранные.',
-  AppLocale.systemInfoCollectionDigitalStore: 'Эта запись представляет цифровой магазин ПК-игр; каталог и требования к оборудованию зависят от конкретной игры.',
-  AppLocale.systemInfoCollectionEmulationPlatform: 'Эта запись представляет платформу эмуляции или совместимости, охватывающую несколько семейств исходного оборудования.',
-  AppLocale.systemInfoCollectionFantasyConsole: 'Это фантазийная консоль с намеренно ограниченным виртуальным оборудованием для небольших игр и демо.',
-  AppLocale.systemInfoCollectionMediaCollection: 'Это медиаколлекция, а не фиксированная игровая аппаратная платформа.',
-  AppLocale.systemInfoCollectionGameEngine: 'Эта запись представляет игровой движок или среду выполнения, игры которой могут относиться к разным поколениям оборудования.',
-  AppLocale.systemInfoCollectionSoftwarePlatform: 'Эта программная платформа работает на разных конфигурациях оборудования, поэтому архитектура зависит от устройства или эпохи.',
+  AppLocale.systemInfoMediaSentence:
+      'Игры и программы в основном распространялись на {media}.',
+  AppLocale.systemInfoCollectionRomHacks:
+      'Эта запись объединяет ROM-хаки и фанатские варианты для исходной системы.',
+  AppLocale.systemInfoCollectionAllSystems:
+      'Эта виртуальная коллекция объединяет игры всех обнаруженных систем.',
+  AppLocale.systemInfoCollectionFavorites:
+      'Эта виртуальная коллекция содержит игры, отмеченные пользователем как избранные.',
+  AppLocale.systemInfoCollectionDigitalStore:
+      'Эта запись представляет цифровой магазин ПК-игр; каталог и требования к оборудованию зависят от конкретной игры.',
+  AppLocale.systemInfoCollectionEmulationPlatform:
+      'Эта запись представляет платформу эмуляции или совместимости, охватывающую несколько семейств исходного оборудования.',
+  AppLocale.systemInfoCollectionFantasyConsole:
+      'Это фантазийная консоль с намеренно ограниченным виртуальным оборудованием для небольших игр и демо.',
+  AppLocale.systemInfoCollectionMediaCollection:
+      'Это медиаколлекция, а не фиксированная игровая аппаратная платформа.',
+  AppLocale.systemInfoCollectionGameEngine:
+      'Эта запись представляет игровой движок или среду выполнения, игры которой могут относиться к разным поколениям оборудования.',
+  AppLocale.systemInfoCollectionSoftwarePlatform:
+      'Эта программная платформа работает на разных конфигурациях оборудования, поэтому архитектура зависит от устройства или эпохи.',
   AppLocale.mediaCartridge: 'Картридж',
   AppLocale.mediaCdRom: 'CD-ROM',
   AppLocale.mediaDvd: 'DVD',

--- a/lib/l10n/app_locale_zh.dart
+++ b/lib/l10n/app_locale_zh.dart
@@ -649,8 +649,10 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.systemInfo: '系统信息',
   AppLocale.systemType: '类型',
   AppLocale.supportedFormats: '支持的格式',
-  AppLocale.systemInfoSummary: '{name} 是由 {manufacturer} 于 {year} 年推出的{type}。NeoStation 当前检测到该系统共有 {count} 款游戏。',
-  AppLocale.systemInfoSummaryNoManufacturer: '{name} 是于 {year} 年推出的{type}。NeoStation 当前检测到该系统共有 {count} 款游戏。',
+  AppLocale.systemInfoSummary:
+      '{name} 是由 {manufacturer} 于 {year} 年推出的{type}。NeoStation 当前检测到该系统共有 {count} 款游戏。',
+  AppLocale.systemInfoSummaryNoManufacturer:
+      '{name} 是于 {year} 年推出的{type}。NeoStation 当前检测到该系统共有 {count} 款游戏。',
   AppLocale.systemTypeConsole: '家用游戏机',
   AppLocale.systemTypeHandheld: '掌上游戏机',
   AppLocale.systemTypeComputer: '电脑系统',
@@ -919,20 +921,31 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.iosEmuLinkingFailed: "关联失败：{error}",
   AppLocale.iosRetroarchSyncRequested: "已请求同步 RetroArch 游戏库。同步将在后台进行，请等待几秒钟。",
   AppLocale.iosRetroarchUnavailable: "无法连接 RetroArch。是否已安装？",
-  AppLocale.iosArmsx2SyncRequested: "已请求同步 ARMSX2 游戏库。导出准备完成后，ARMSX2 会自动返回 NeoStation。",
+  AppLocale.iosArmsx2SyncRequested:
+      "已请求同步 ARMSX2 游戏库。导出准备完成后，ARMSX2 会自动返回 NeoStation。",
   AppLocale.iosArmsx2Unavailable: "无法连接 ARMSX2。是否已安装？",
-  AppLocale.iosMelonxSyncRequested: "已请求同步 MeloNX 的 Nintendo Switch 游戏库。导出准备完成后，MeloNX 会自动返回 NeoStation。",
+  AppLocale.iosMelonxSyncRequested:
+      "已请求同步 MeloNX 的 Nintendo Switch 游戏库。导出准备完成后，MeloNX 会自动返回 NeoStation。",
   AppLocale.iosMelonxUnavailable: "无法连接 MeloNX。是否已安装？",
-  AppLocale.iosRetroarchStatusNeedsLink: "关联 RetroArch 文件夹，让 NeoStation 直接访问游戏，无需复制。",
-  AppLocale.iosRetroarchStatusNeedsSync: "文件夹已关联。同步游戏库后，即可一键直接在 RetroArch 中启动游戏。",
+  AppLocale.iosRetroarchStatusNeedsLink:
+      "关联 RetroArch 文件夹，让 NeoStation 直接访问游戏，无需复制。",
+  AppLocale.iosRetroarchStatusNeedsSync:
+      "文件夹已关联。同步游戏库后，即可一键直接在 RetroArch 中启动游戏。",
   AppLocale.iosRetroarchStatusSynced: "文件夹已关联且游戏库已同步——游戏可直接在 RetroArch 中启动。",
-  AppLocale.iosRetroarchLinkSuccess: "文件夹已关联。NeoStation 将直接扫描该文件夹，无需复制。此处找到的游戏将直接在 RetroArch 中启动。",
-  AppLocale.iosArmsx2StatusNeedsLink: "ARMSX2 与 RetroArch 使用同一个 ROM 文件夹。先关联共享 ROM 文件夹，然后同步 ARMSX2 游戏库。",
-  AppLocale.iosArmsx2StatusNeedsSync: "共享 ROM 文件夹已关联。同步 ARMSX2，将 PS2 游戏库导入 NeoStation。",
-  AppLocale.iosArmsx2StatusSynced: "共享文件夹和 ARMSX2 游戏库已同步——PS2 游戏可直接在 ARMSX2 中启动。",
-  AppLocale.iosArmsx2LinkSuccess: "共享 ROM 文件夹已关联。RetroArch 和 ARMSX2 现在使用同一个 NeoStation ROM 来源。",
-  AppLocale.iosMelonxStatusSynced: "MeloNX 游戏库已同步——Nintendo Switch 游戏可直接在 MeloNX 中启动。",
-  AppLocale.iosMelonxStatusNeedsSync: "同步 MeloNX，将其 Nintendo Switch 游戏库直接导入 NeoStation。无需扫描 ROM 文件夹。",
+  AppLocale.iosRetroarchLinkSuccess:
+      "文件夹已关联。NeoStation 将直接扫描该文件夹，无需复制。此处找到的游戏将直接在 RetroArch 中启动。",
+  AppLocale.iosArmsx2StatusNeedsLink:
+      "ARMSX2 与 RetroArch 使用同一个 ROM 文件夹。先关联共享 ROM 文件夹，然后同步 ARMSX2 游戏库。",
+  AppLocale.iosArmsx2StatusNeedsSync:
+      "共享 ROM 文件夹已关联。同步 ARMSX2，将 PS2 游戏库导入 NeoStation。",
+  AppLocale.iosArmsx2StatusSynced:
+      "共享文件夹和 ARMSX2 游戏库已同步——PS2 游戏可直接在 ARMSX2 中启动。",
+  AppLocale.iosArmsx2LinkSuccess:
+      "共享 ROM 文件夹已关联。RetroArch 和 ARMSX2 现在使用同一个 NeoStation ROM 来源。",
+  AppLocale.iosMelonxStatusSynced:
+      "MeloNX 游戏库已同步——Nintendo Switch 游戏可直接在 MeloNX 中启动。",
+  AppLocale.iosMelonxStatusNeedsSync:
+      "同步 MeloNX，将其 Nintendo Switch 游戏库直接导入 NeoStation。无需扫描 ROM 文件夹。",
 
   // Rich System Info
   AppLocale.systemArchitecture: '架构',
@@ -942,8 +955,10 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.systemNotableGames: '代表游戏',
   AppLocale.systemTechnicalDetails: '技术信息',
   AppLocale.systemGamesDetected: '已检测游戏',
-  AppLocale.systemInfoDetailedIntro: '{name} 是一款由 {manufacturer} 于 {year} 年推出的{type}。',
-  AppLocale.systemInfoDetailedIntroNoManufacturer: '{name} 是一款于 {year} 年推出的{type}。',
+  AppLocale.systemInfoDetailedIntro:
+      '{name} 是一款由 {manufacturer} 于 {year} 年推出的{type}。',
+  AppLocale.systemInfoDetailedIntroNoManufacturer:
+      '{name} 是一款于 {year} 年推出的{type}。',
   AppLocale.systemInfoArchitectureSentence: '其硬件架构为 {architecture}。',
   AppLocale.systemInfoGenerationSentence: '它属于第 {generation} 世代。',
   AppLocale.systemInfoProcessorSentence: '主要处理器为 {cpu}。',
@@ -951,12 +966,15 @@ const Map<String, dynamic> appLocaleZh = {
   AppLocale.systemInfoCollectionRomHacks: '此条目汇集原系统的 ROM Hack 与玩家自制变体。',
   AppLocale.systemInfoCollectionAllSystems: '此虚拟合集汇集所有已检测系统中的游戏。',
   AppLocale.systemInfoCollectionFavorites: '此虚拟合集包含用户标记为收藏的游戏。',
-  AppLocale.systemInfoCollectionDigitalStore: '此条目代表 PC 数字游戏商店；游戏目录和硬件需求会因作品而异。',
+  AppLocale.systemInfoCollectionDigitalStore:
+      '此条目代表 PC 数字游戏商店；游戏目录和硬件需求会因作品而异。',
   AppLocale.systemInfoCollectionEmulationPlatform: '此条目代表覆盖多种原始硬件系列的模拟或兼容平台。',
-  AppLocale.systemInfoCollectionFantasyConsole: '这是一种使用刻意受限虚拟硬件的幻想主机，面向小型游戏和演示。',
+  AppLocale.systemInfoCollectionFantasyConsole:
+      '这是一种使用刻意受限虚拟硬件的幻想主机，面向小型游戏和演示。',
   AppLocale.systemInfoCollectionMediaCollection: '这是媒体合集，而不是固定的游戏硬件平台。',
   AppLocale.systemInfoCollectionGameEngine: '此条目代表游戏引擎或运行环境，其作品可能跨越多个硬件世代。',
-  AppLocale.systemInfoCollectionSoftwarePlatform: '此软件平台覆盖多种硬件配置，因此架构会随设备或时代而变化。',
+  AppLocale.systemInfoCollectionSoftwarePlatform:
+      '此软件平台覆盖多种硬件配置，因此架构会随设备或时代而变化。',
   AppLocale.mediaCartridge: '卡带',
   AppLocale.mediaCdRom: 'CD-ROM',
   AppLocale.mediaDvd: 'DVD',

--- a/lib/l10n/app_locale_zh_hant.dart
+++ b/lib/l10n/app_locale_zh_hant.dart
@@ -649,8 +649,10 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.systemInfo: '系統資訊',
   AppLocale.systemType: '類型',
   AppLocale.supportedFormats: '支援格式',
-  AppLocale.systemInfoSummary: '{name} 是由 {manufacturer} 於 {year} 年推出的{type}。NeoStation 目前偵測到此系統共有 {count} 款遊戲。',
-  AppLocale.systemInfoSummaryNoManufacturer: '{name} 是於 {year} 年推出的{type}。NeoStation 目前偵測到此系統共有 {count} 款遊戲。',
+  AppLocale.systemInfoSummary:
+      '{name} 是由 {manufacturer} 於 {year} 年推出的{type}。NeoStation 目前偵測到此系統共有 {count} 款遊戲。',
+  AppLocale.systemInfoSummaryNoManufacturer:
+      '{name} 是於 {year} 年推出的{type}。NeoStation 目前偵測到此系統共有 {count} 款遊戲。',
   AppLocale.systemTypeConsole: '家用遊戲機',
   AppLocale.systemTypeHandheld: '掌上遊戲機',
   AppLocale.systemTypeComputer: '電腦系統',
@@ -919,20 +921,31 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.iosEmuLinkingFailed: "連結失敗：{error}",
   AppLocale.iosRetroarchSyncRequested: "已要求同步 RetroArch 遊戲庫。同步會在背景執行，請稍候幾秒。",
   AppLocale.iosRetroarchUnavailable: "無法連線到 RetroArch。是否已安裝？",
-  AppLocale.iosArmsx2SyncRequested: "已要求同步 ARMSX2 遊戲庫。匯出準備完成後，ARMSX2 會自動返回 NeoStation。",
+  AppLocale.iosArmsx2SyncRequested:
+      "已要求同步 ARMSX2 遊戲庫。匯出準備完成後，ARMSX2 會自動返回 NeoStation。",
   AppLocale.iosArmsx2Unavailable: "無法連線到 ARMSX2。是否已安裝？",
-  AppLocale.iosMelonxSyncRequested: "已要求同步 MeloNX 的 Nintendo Switch 遊戲庫。匯出準備完成後，MeloNX 會自動返回 NeoStation。",
+  AppLocale.iosMelonxSyncRequested:
+      "已要求同步 MeloNX 的 Nintendo Switch 遊戲庫。匯出準備完成後，MeloNX 會自動返回 NeoStation。",
   AppLocale.iosMelonxUnavailable: "無法連線到 MeloNX。是否已安裝？",
-  AppLocale.iosRetroarchStatusNeedsLink: "連結 RetroArch 資料夾，讓 NeoStation 直接存取遊戲，無需複製。",
-  AppLocale.iosRetroarchStatusNeedsSync: "資料夾已連結。同步遊戲庫後，即可一鍵直接在 RetroArch 中啟動遊戲。",
+  AppLocale.iosRetroarchStatusNeedsLink:
+      "連結 RetroArch 資料夾，讓 NeoStation 直接存取遊戲，無需複製。",
+  AppLocale.iosRetroarchStatusNeedsSync:
+      "資料夾已連結。同步遊戲庫後，即可一鍵直接在 RetroArch 中啟動遊戲。",
   AppLocale.iosRetroarchStatusSynced: "資料夾已連結且遊戲庫已同步——遊戲可直接在 RetroArch 中啟動。",
-  AppLocale.iosRetroarchLinkSuccess: "資料夾已連結。NeoStation 會直接掃描此資料夾，無需複製。在此找到的遊戲將直接在 RetroArch 中啟動。",
-  AppLocale.iosArmsx2StatusNeedsLink: "ARMSX2 與 RetroArch 使用相同的 ROM 資料夾。先連結共用 ROM 資料夾，再同步 ARMSX2 遊戲庫。",
-  AppLocale.iosArmsx2StatusNeedsSync: "共用 ROM 資料夾已連結。同步 ARMSX2，將 PS2 遊戲庫匯入 NeoStation。",
-  AppLocale.iosArmsx2StatusSynced: "共用資料夾與 ARMSX2 遊戲庫已同步——PS2 遊戲可直接在 ARMSX2 中啟動。",
-  AppLocale.iosArmsx2LinkSuccess: "共用 ROM 資料夾已連結。RetroArch 與 ARMSX2 現在使用相同的 NeoStation ROM 來源。",
-  AppLocale.iosMelonxStatusSynced: "MeloNX 遊戲庫已同步——Nintendo Switch 遊戲可直接在 MeloNX 中啟動。",
-  AppLocale.iosMelonxStatusNeedsSync: "同步 MeloNX，將其 Nintendo Switch 遊戲庫直接匯入 NeoStation。無需掃描 ROM 資料夾。",
+  AppLocale.iosRetroarchLinkSuccess:
+      "資料夾已連結。NeoStation 會直接掃描此資料夾，無需複製。在此找到的遊戲將直接在 RetroArch 中啟動。",
+  AppLocale.iosArmsx2StatusNeedsLink:
+      "ARMSX2 與 RetroArch 使用相同的 ROM 資料夾。先連結共用 ROM 資料夾，再同步 ARMSX2 遊戲庫。",
+  AppLocale.iosArmsx2StatusNeedsSync:
+      "共用 ROM 資料夾已連結。同步 ARMSX2，將 PS2 遊戲庫匯入 NeoStation。",
+  AppLocale.iosArmsx2StatusSynced:
+      "共用資料夾與 ARMSX2 遊戲庫已同步——PS2 遊戲可直接在 ARMSX2 中啟動。",
+  AppLocale.iosArmsx2LinkSuccess:
+      "共用 ROM 資料夾已連結。RetroArch 與 ARMSX2 現在使用相同的 NeoStation ROM 來源。",
+  AppLocale.iosMelonxStatusSynced:
+      "MeloNX 遊戲庫已同步——Nintendo Switch 遊戲可直接在 MeloNX 中啟動。",
+  AppLocale.iosMelonxStatusNeedsSync:
+      "同步 MeloNX，將其 Nintendo Switch 遊戲庫直接匯入 NeoStation。無需掃描 ROM 資料夾。",
 
   // Rich System Info
   AppLocale.systemArchitecture: '架構',
@@ -942,8 +955,10 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.systemNotableGames: '代表遊戲',
   AppLocale.systemTechnicalDetails: '技術資訊',
   AppLocale.systemGamesDetected: '已偵測遊戲',
-  AppLocale.systemInfoDetailedIntro: '{name} 是由 {manufacturer} 於 {year} 年推出的{type}。',
-  AppLocale.systemInfoDetailedIntroNoManufacturer: '{name} 是於 {year} 年推出的{type}。',
+  AppLocale.systemInfoDetailedIntro:
+      '{name} 是由 {manufacturer} 於 {year} 年推出的{type}。',
+  AppLocale.systemInfoDetailedIntroNoManufacturer:
+      '{name} 是於 {year} 年推出的{type}。',
   AppLocale.systemInfoArchitectureSentence: '其硬體架構為 {architecture}。',
   AppLocale.systemInfoGenerationSentence: '它屬於第 {generation} 世代。',
   AppLocale.systemInfoProcessorSentence: '主要處理器為 {cpu}。',
@@ -951,12 +966,15 @@ const Map<String, dynamic> appLocaleZhHant = {
   AppLocale.systemInfoCollectionRomHacks: '此項目彙整原系統的 ROM Hack 與玩家自製變體。',
   AppLocale.systemInfoCollectionAllSystems: '此虛擬合集彙整所有已偵測系統中的遊戲。',
   AppLocale.systemInfoCollectionFavorites: '此虛擬合集包含使用者標記為最愛的遊戲。',
-  AppLocale.systemInfoCollectionDigitalStore: '此項目代表 PC 數位遊戲商店；遊戲目錄與硬體需求會依作品而異。',
+  AppLocale.systemInfoCollectionDigitalStore:
+      '此項目代表 PC 數位遊戲商店；遊戲目錄與硬體需求會依作品而異。',
   AppLocale.systemInfoCollectionEmulationPlatform: '此項目代表涵蓋多種原始硬體系列的模擬或相容平台。',
-  AppLocale.systemInfoCollectionFantasyConsole: '這是一種使用刻意受限虛擬硬體的幻想主機，適合小型遊戲與展示作品。',
+  AppLocale.systemInfoCollectionFantasyConsole:
+      '這是一種使用刻意受限虛擬硬體的幻想主機，適合小型遊戲與展示作品。',
   AppLocale.systemInfoCollectionMediaCollection: '這是媒體合集，而不是固定的遊戲硬體平台。',
   AppLocale.systemInfoCollectionGameEngine: '此項目代表遊戲引擎或執行環境，其作品可能橫跨多個硬體世代。',
-  AppLocale.systemInfoCollectionSoftwarePlatform: '此軟體平台涵蓋多種硬體配置，因此架構會隨裝置或時代而變化。',
+  AppLocale.systemInfoCollectionSoftwarePlatform:
+      '此軟體平台涵蓋多種硬體配置，因此架構會隨裝置或時代而變化。',
   AppLocale.mediaCartridge: '卡匣',
   AppLocale.mediaCdRom: 'CD-ROM',
   AppLocale.mediaDvd: 'DVD',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,7 +51,7 @@ import 'package:neostation/services/melonx_library_service.dart';
 import 'package:neostation/data/datasources/sqlite_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-// Politica personalizada para deshabilitar navegacion por teclado
+/// Disables keyboard focus traversal for controller-first navigation.
 class NoFocusTraversalPolicy extends FocusTraversalPolicy {
   @override
   FocusNode? findFirstFocus(
@@ -82,7 +82,7 @@ class NoFocusTraversalPolicy extends FocusTraversalPolicy {
   ) => [];
 }
 
-// Notifier global para cambios de fullscreen
+/// Tracks fullscreen state across desktop window implementations.
 class FullscreenNotifier extends ChangeNotifier {
   static final FullscreenNotifier _instance = FullscreenNotifier._internal();
   factory FullscreenNotifier() => _instance;
@@ -102,12 +102,12 @@ class FullscreenNotifier extends ChangeNotifier {
   }
 }
 
-// Intent para toggle fullscreen
+/// Intent used to toggle desktop fullscreen mode.
 class ToggleFullscreenIntent extends Intent {
   const ToggleFullscreenIntent();
 }
 
-// Action para toggle fullscreen
+/// Handles desktop fullscreen toggling.
 class ToggleFullscreenAction extends Action<ToggleFullscreenIntent> {
   @override
   Future<void> invoke(ToggleFullscreenIntent intent) async {
@@ -117,7 +117,6 @@ class ToggleFullscreenAction extends Action<ToggleFullscreenIntent> {
       LoggerService.instance.i('Toggle fullscreen (Native): $newState');
       FullScreenWindow.setFullScreen(newState);
 
-      // Notificar el cambio de fullscreen
       FullscreenNotifier().notifyFullscreenChanged(newState);
     } else if (Platform.isMacOS) {
       final isFullscreen = await windowManager.isFullScreen();
@@ -126,7 +125,6 @@ class ToggleFullscreenAction extends Action<ToggleFullscreenIntent> {
       );
       await windowManager.setFullScreen(!isFullscreen);
 
-      // Notificar el cambio de fullscreen
       await Future.delayed(const Duration(milliseconds: 100));
       final newState = await windowManager.isFullScreen();
       FullscreenNotifier().notifyFullscreenChanged(newState);
@@ -234,10 +232,7 @@ Future<void> _cleanupRemovedIflyIntegration({
     await ExternalFolderAccess.clearBookmark(key: bookmarkKey);
 
     final docsDir = await getApplicationDocumentsDirectory();
-    for (final name in const [
-      'ifly_sync_debug.txt',
-      'ifly_launch_debug.txt',
-    ]) {
+    for (final name in const ['ifly_sync_debug.txt', 'ifly_launch_debug.txt']) {
       final file = File(path.join(docsDir.path, name));
       if (await file.exists()) {
         await file.delete();
@@ -250,7 +245,9 @@ Future<void> _cleanupRemovedIflyIntegration({
   } catch (e) {
     // iFly is no longer part of NeoStation, so cleanup failure must never block
     // application startup. The migration will be attempted again next launch.
-    LoggerService.instance.w('Could not clean legacy iFly integration data: $e');
+    LoggerService.instance.w(
+      'Could not clean legacy iFly integration data: $e',
+    );
   }
 }
 
@@ -305,7 +302,7 @@ void main() async {
     });
   }
 
-  // Inicializar window_manager para desktop con tamano minimo 640x480
+  // Configure the desktop window with a 640x480 minimum size.
   if (Platform.isWindows || Platform.isMacOS || Platform.isLinux) {
     await windowManager.ensureInitialized();
 
@@ -321,7 +318,7 @@ void main() async {
       await windowManager.focus();
     });
 
-    // Cargar configuracion de fullscreen
+    // Restore the persisted fullscreen preference.
     bool isFullscreen = true;
     try {
       final config = await ConfigRepository.getUserConfig();
@@ -351,12 +348,11 @@ void main() async {
     log.i('Window manager initialized');
   }
 
-  // Inicializar fvp para soporte extendido de video (Windows, Linux, etc.)
+  // Register FVP for extended desktop video support.
   registerWith();
 
-  // Configurar manejo global de errores para evitar crashes
+  // Keep framework errors visible in the console.
   FlutterError.onError = (FlutterErrorDetails details) {
-    // Para otros errores, usar el handler por defecto en debug
     if (details.stack != null) {
       FlutterError.dumpErrorToConsole(details);
     }
@@ -371,12 +367,10 @@ void main() async {
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.landscapeLeft,
       DeviceOrientation.landscapeRight,
-      //DeviceOrientation.portraitUp,
-      //DeviceOrientation.portraitDown,
     ]);
   }
 
-  // Inicializar FileProvider
+  // Initialize application storage paths.
   final fileProvider = FileProvider();
   try {
     await fileProvider.initialize();
@@ -384,43 +378,7 @@ void main() async {
     log.e('Error initializing FileProvider: $e');
   }
 
-  // TEMPORARY iOS DIAGNOSTIC — remove once the media-display issue is
-  // resolved. Writes FileProvider's post-init state to a plain text file
-  // under the app's Documents folder (readable via the Files app, "On My
-  // iPhone > NeoStation > neostation_debug.txt") since there's no Xcode
-  // console access to check this from otherwise.
-  if (Platform.isIOS) {
-    try {
-      final docsDir = await getApplicationDocumentsDirectory();
-      final debugFile = File(path.join(docsDir.path, 'neostation_debug.txt'));
-      final buffer = StringBuffer();
-      buffer.writeln('--- NeoStation iOS debug: ${DateTime.now()} ---');
-      buffer.writeln('fileProvider.isInitialized: ${fileProvider.isInitialized}');
-      buffer.writeln('fileProvider.mediaPath: ${fileProvider.mediaPath}');
-      buffer.writeln('fileProvider.userDataPath: ${fileProvider.userDataPath}');
-      buffer.writeln('fileProvider.documentsPath: ${fileProvider.documentsPath}');
-      try {
-        final configMediaPath = await ConfigService.getMediaPath();
-        buffer.writeln('ConfigService.getMediaPath(): $configMediaPath');
-      } catch (e) {
-        buffer.writeln('ConfigService.getMediaPath() threw: $e');
-      }
-      if (fileProvider.mediaPath != null) {
-        final testDir = Directory(
-          path.join(fileProvider.mediaPath!, 'media'),
-        );
-        buffer.writeln(
-          'media dir exists at fileProvider.mediaPath/media: '
-          '${testDir.existsSync()} (${testDir.path})',
-        );
-      }
-      await debugFile.writeAsString(buffer.toString());
-    } catch (e) {
-      log.e('Failed to write iOS debug file: $e');
-    }
-  }
-
-  // Inicializar localizacion con idioma persistido
+  // Restore the persisted application language.
   String initLang = 'en';
   try {
     final rawConfig = await ConfigRepository.getUserConfig();
@@ -449,11 +407,11 @@ void main() async {
     initLanguageCode: initLang.isNotEmpty ? initLang : 'en',
   );
 
-  // Inicializar AuthService antes de mostrar la app
+  // Initialize authentication before displaying the main interface.
   final authService = AuthService();
   await authService.initialize();
 
-  // Inicializar providers criticos
+  // Initialize core providers.
   final sqliteConfigProvider = SqliteConfigProvider();
   final sqliteDatabaseProvider = SqliteDatabaseProvider();
 
@@ -468,7 +426,7 @@ void main() async {
       persist: sqliteConfigProvider.updateLegendHidden,
     );
 
-    // 2. Inicializar DatabaseProvider (carga juegos basandose en sistemas sincronizados)
+    // 2. Initialize the database using synchronized system state.
     await sqliteDatabaseProvider.initialize(
       romFolders: sqliteConfigProvider.config.romFolders,
       availableSystems: sqliteConfigProvider.availableSystems,

--- a/lib/models/game_model.dart
+++ b/lib/models/game_model.dart
@@ -375,12 +375,7 @@ class GameModel {
     }
 
     final fallbackBase = _stripRomExtension(lookupNames.first);
-    return path.join(
-      'media',
-      systemFolderName,
-      imageType,
-      '$fallbackBase.png',
-    );
+    return path.join('media', systemFolderName, imageType, '$fallbackBase.png');
   }
 
   /// Resolves the local PDF manual for this game.
@@ -389,10 +384,7 @@ class GameModel {
   /// prefer their stable Title ID, while regular ROMs use the ROM filename
   /// without its system-specific extension. The canonical location is
   /// `media/<system>/manuals/<key>.pdf`.
-  String getManualPath(
-    String systemFolderName, [
-    FileProvider? fileProvider,
-  ]) {
+  String getManualPath(String systemFolderName, [FileProvider? fileProvider]) {
     final lookupNames = _mediaLookupNames();
 
     if (fileProvider != null && fileProvider.isInitialized) {
@@ -503,10 +495,7 @@ class GameModel {
 
       // Return the canonical NeoStation path even if the file does not exist
       // yet, so media caching and later downloads use the same Title-ID key.
-      return fileProvider.getVideoPath(
-        systemFolderName,
-        lookupNames.first,
-      );
+      return fileProvider.getVideoPath(systemFolderName, lookupNames.first);
     }
 
     // Manual filesystem lookup logic mirrors getImagePath().
@@ -530,12 +519,7 @@ class GameModel {
     }
 
     final fallbackBase = _stripRomExtension(lookupNames.first);
-    return path.join(
-      'media',
-      systemFolderName,
-      'videos',
-      '$fallbackBase.mp4',
-    );
+    return path.join('media', systemFolderName, 'videos', '$fallbackBase.mp4');
   }
 
   /// Verifies if a preview video exists for this game.

--- a/lib/providers/file_provider.dart
+++ b/lib/providers/file_provider.dart
@@ -359,7 +359,7 @@ class FileProvider extends ChangeNotifier {
     try {
       final directory = Directory(directoryPath);
       if (await directory.exists()) {
-        return directory.list().toList();
+        return await directory.list().toList();
       }
       return [];
     } catch (e) {

--- a/lib/providers/neosync/neosync_path_resolver.dart
+++ b/lib/providers/neosync/neosync_path_resolver.dart
@@ -488,7 +488,7 @@ extension NeoSyncPathResolver on NeoSyncProvider {
     if (!await dir.exists()) return [];
 
     try {
-      return dir
+      return await dir
           .list(recursive: true)
           .where((entity) => entity is File)
           .cast<File>()

--- a/lib/repositories/game_repository.dart
+++ b/lib/repositories/game_repository.dart
@@ -125,7 +125,14 @@ class GameRepository {
     final strippedBase = _stripExtension(romBaseName);
     final strippedFilename = _stripExtension(filename);
 
-    const mediaTypes = ['screenshots', 'fanarts', 'wheels', 'box2d', 'videos', 'manuals'];
+    const mediaTypes = [
+      'screenshots',
+      'fanarts',
+      'wheels',
+      'box2d',
+      'videos',
+      'manuals',
+    ];
     const extensions = ['png', 'jpg', 'jpeg', 'webp', 'mp4', 'pdf'];
     int deletedMedia = 0;
 

--- a/lib/screens/game_screen/game_details_card/tabs/game_details_game_info_tab.dart
+++ b/lib/screens/game_screen/game_details_card/tabs/game_details_game_info_tab.dart
@@ -96,9 +96,7 @@ class GameDetailsGameInfoTab extends StatelessWidget {
             BorderRadius.circular(14.r),
         boxShadow: [
           BoxShadow(
-            color: Theme.of(
-              context,
-            ).colorScheme.shadow.withValues(alpha: 0.22),
+            color: Theme.of(context).colorScheme.shadow.withValues(alpha: 0.22),
             blurRadius: 3.r,
             offset: Offset(2.0.r, 2.0.r),
           ),

--- a/lib/screens/game_screen/game_manual_reader_screen.dart
+++ b/lib/screens/game_screen/game_manual_reader_screen.dart
@@ -34,9 +34,7 @@ class _GameManualReaderScreenState extends State<GameManualReaderScreen> {
   @override
   void initState() {
     super.initState();
-    _gamepadNav = GamepadNavigation(
-      onBack: _close,
-    );
+    _gamepadNav = GamepadNavigation(onBack: _close);
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -70,9 +68,7 @@ class _GameManualReaderScreenState extends State<GameManualReaderScreen> {
       body: SafeArea(
         child: Stack(
           children: [
-            Positioned.fill(
-              child: PdfViewer.file(widget.manualPath),
-            ),
+            Positioned.fill(child: PdfViewer.file(widget.manualPath)),
             Positioned(
               left: 12.r,
               right: 12.r,
@@ -136,7 +132,9 @@ class _GameManualReaderScreenState extends State<GameManualReaderScreen> {
                       AppLocale.pinchToZoom.getString(context),
                       style: TextStyle(
                         fontSize: 8.r,
-                        color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                        color: theme.colorScheme.onSurface.withValues(
+                          alpha: 0.5,
+                        ),
                       ),
                     ),
                   ],

--- a/lib/screens/game_screen/game_settings_dialog/game_settings_dialog.dart
+++ b/lib/screens/game_screen/game_settings_dialog/game_settings_dialog.dart
@@ -213,47 +213,47 @@ class _GameSettingsDialogState extends State<GameSettingsDialog> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-            _buildHeader(theme, displayName),
-            _buildTabsHeader(theme),
-            Expanded(
-              child: IndexedStack(
-                index: _currentTab,
-                children: [
-                  GameSettingsEmulatorTab(
-                    key: _emulatorTabKey,
-                    game: widget.game,
-                    system: widget.system,
-                    isAllMode: widget.isAllMode,
-                    onGameUpdated: widget.onGameUpdated,
-                  ),
-                  GameSettingsScrappingTab(
-                    key: _scrappingTabKey,
-                    game: widget.game,
-                    system: widget.system,
-                    fileProvider: widget.fileProvider,
-                    isAllMode: widget.isAllMode,
-                    onGameUpdated: widget.onGameUpdated,
-                  ),
-                  GameSettingsManageTab(
-                    key: _manageTabKey,
-                    game: widget.game,
-                    system: widget.system,
-                    fileProvider: widget.fileProvider,
-                    syncProvider: widget.syncProvider,
-                    isAllMode: widget.isAllMode,
-                    onGameUpdated: widget.onGameUpdated,
-                    onGameDeleted: _handleGameDeleted,
-                  ),
-                  GameSettingsManualTab(
-                    key: _manualTabKey,
-                    game: widget.game,
-                    system: widget.system,
-                    fileProvider: widget.fileProvider,
-                    isAllMode: widget.isAllMode,
-                  ),
-                ],
+              _buildHeader(theme, displayName),
+              _buildTabsHeader(theme),
+              Expanded(
+                child: IndexedStack(
+                  index: _currentTab,
+                  children: [
+                    GameSettingsEmulatorTab(
+                      key: _emulatorTabKey,
+                      game: widget.game,
+                      system: widget.system,
+                      isAllMode: widget.isAllMode,
+                      onGameUpdated: widget.onGameUpdated,
+                    ),
+                    GameSettingsScrappingTab(
+                      key: _scrappingTabKey,
+                      game: widget.game,
+                      system: widget.system,
+                      fileProvider: widget.fileProvider,
+                      isAllMode: widget.isAllMode,
+                      onGameUpdated: widget.onGameUpdated,
+                    ),
+                    GameSettingsManageTab(
+                      key: _manageTabKey,
+                      game: widget.game,
+                      system: widget.system,
+                      fileProvider: widget.fileProvider,
+                      syncProvider: widget.syncProvider,
+                      isAllMode: widget.isAllMode,
+                      onGameUpdated: widget.onGameUpdated,
+                      onGameDeleted: _handleGameDeleted,
+                    ),
+                    GameSettingsManualTab(
+                      key: _manualTabKey,
+                      game: widget.game,
+                      system: widget.system,
+                      fileProvider: widget.fileProvider,
+                      isAllMode: widget.isAllMode,
+                    ),
+                  ],
+                ),
               ),
-            ),
               _buildFooter(theme),
             ],
           ),

--- a/lib/screens/game_screen/game_settings_dialog/game_settings_emulator_tab.dart
+++ b/lib/screens/game_screen/game_settings_dialog/game_settings_emulator_tab.dart
@@ -14,12 +14,10 @@ import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/utils/emulator_loader.dart';
 import 'package:neostation/widgets/settings_rows.dart';
 
-/// Per-game emulator override tab for [GameSettingsDialog].
+/// Per-game emulator override settings.
 ///
-/// Lists the emulators available for the game's system.
-///
-/// On iOS, each supported system maps to one external emulator app, so the
-/// generic 'System Default' pseudo-option is intentionally hidden.
+/// iOS exposes the supported external emulator directly instead of the
+/// desktop-style "System Default" option.
 class GameSettingsEmulatorTab extends StatefulWidget {
   final GameModel game;
   final SystemModel system;
@@ -45,8 +43,8 @@ class GameSettingsEmulatorTabState extends State<GameSettingsEmulatorTab> {
   List<CoreEmulatorModel> _availableEmulators = [];
   int _selectedIndex = 0;
 
-  /// Tracks the active emulator override. Uses a sentinel to differentiate
-  /// between 'not yet loaded' and 'explicit null' (system default).
+  // The sentinel distinguishes an unloaded value from an explicit null
+  // override, which represents the system default on non-iOS platforms.
   Object? _activeEmulatorId = _sentinel;
   static const Object _sentinel = Object();
 
@@ -62,9 +60,6 @@ class GameSettingsEmulatorTabState extends State<GameSettingsEmulatorTab> {
 
   int get _totalItems {
     if (_availableEmulators.isEmpty) return 0;
-    // iOS exposes exactly one supported external emulator app per system
-    // (RetroArch, MeloNX or ARMSX2). Do not add the desktop-style
-    // "System Default" pseudo-option there; it only creates confusion.
     return Platform.isIOS
         ? _availableEmulators.length
         : 1 + _availableEmulators.length;
@@ -136,9 +131,7 @@ class GameSettingsEmulatorTabState extends State<GameSettingsEmulatorTab> {
     });
   }
 
-  /// Persists a manual emulator override for this specific game.
   Future<void> _setEmulatorOverride(CoreEmulatorModel? emulator) async {
-    // Optimistic update: reflect changes in UI immediately.
     if (mounted) setState(() => _activeEmulatorId = emulator?.uniqueId);
     try {
       final targetSystemFolder =
@@ -154,7 +147,6 @@ class GameSettingsEmulatorTabState extends State<GameSettingsEmulatorTab> {
       widget.onGameUpdated?.call();
     } catch (e) {
       _log.e('Emulator override persistence failed: $e');
-      // Rollback: revert UI state on failure.
       if (mounted) {
         setState(() => _activeEmulatorId = widget.game.emulatorName);
       }
@@ -208,9 +200,6 @@ class GameSettingsEmulatorTabState extends State<GameSettingsEmulatorTab> {
               ],
             ),
           ),
-          // Keep the generic "System Default" choice on platforms where
-          // multiple emulator/core choices are meaningful. On iOS there is one
-          // supported external app per system, so show only that real emulator.
           if (!Platform.isIOS)
             EmulatorRow(
               key: _itemKey(0),
@@ -227,7 +216,6 @@ class GameSettingsEmulatorTabState extends State<GameSettingsEmulatorTab> {
                 _setEmulatorOverride(null);
               },
             ),
-          // Individual Emulator Options.
           ..._availableEmulators.asMap().entries.map((entry) {
             final i = entry.key;
             final e = entry.value;

--- a/lib/screens/game_screen/game_settings_dialog/game_settings_manual_tab.dart
+++ b/lib/screens/game_screen/game_settings_dialog/game_settings_manual_tab.dart
@@ -112,8 +112,11 @@ class GameSettingsManualTabState extends State<GameSettingsManualTab> {
 
       if (!mounted) return;
       final success = result['success'] == true;
-      final messageKey = result['message']?.toString() ??
-          (success ? AppLocale.manualDownloaded : AppLocale.manualDownloadFailed);
+      final messageKey =
+          result['message']?.toString() ??
+          (success
+              ? AppLocale.manualDownloaded
+              : AppLocale.manualDownloadFailed);
       AppNotification.showNotification(
         context,
         messageKey.getString(context),
@@ -286,7 +289,9 @@ class GameSettingsManualTabState extends State<GameSettingsManualTab> {
                     textAlign: TextAlign.center,
                     style: TextStyle(
                       fontSize: 8.5.r,
-                      color: theme.colorScheme.onSurface.withValues(alpha: 0.58),
+                      color: theme.colorScheme.onSurface.withValues(
+                        alpha: 0.58,
+                      ),
                     ),
                   ),
                   if (_isDownloading) ...[
@@ -297,7 +302,9 @@ class GameSettingsManualTabState extends State<GameSettingsManualTab> {
                       AppLocale.downloadingManual.getString(context),
                       style: TextStyle(
                         fontSize: 8.r,
-                        color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                        color: theme.colorScheme.onSurface.withValues(
+                          alpha: 0.6,
+                        ),
                       ),
                     ),
                   ],
@@ -326,7 +333,9 @@ class GameSettingsManualTabState extends State<GameSettingsManualTab> {
                         index: 1,
                         icon: Symbols.download_rounded,
                         title: AppLocale.redownloadManual.getString(context),
-                        subtitle: AppLocale.redownloadManualDesc.getString(context),
+                        subtitle: AppLocale.redownloadManualDesc.getString(
+                          context,
+                        ),
                         onTap: () => _downloadManual(forceOverwrite: true),
                       ),
                       SizedBox(height: 8.r),
@@ -346,7 +355,9 @@ class GameSettingsManualTabState extends State<GameSettingsManualTab> {
                         index: 0,
                         icon: Symbols.download_rounded,
                         title: AppLocale.downloadManual.getString(context),
-                        subtitle: AppLocale.downloadManualDesc.getString(context),
+                        subtitle: AppLocale.downloadManualDesc.getString(
+                          context,
+                        ),
                         onTap: () => _downloadManual(),
                       ),
                     ],
@@ -415,7 +426,9 @@ class GameSettingsManualTabState extends State<GameSettingsManualTab> {
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(
                         fontSize: 7.8.r,
-                        color: theme.colorScheme.onSurface.withValues(alpha: 0.55),
+                        color: theme.colorScheme.onSurface.withValues(
+                          alpha: 0.55,
+                        ),
                       ),
                     ),
                   ],

--- a/lib/screens/scraper_screen/scraper_contents/media_content.dart
+++ b/lib/screens/scraper_screen/scraper_contents/media_content.dart
@@ -24,7 +24,14 @@ class MediaContent extends StatefulWidget {
 }
 
 class MediaContentState extends State<MediaContent> {
-  static const _orderedKeys = ['fanart', 'ss', 'wheel', 'box2D', 'video', 'manuel'];
+  static const _orderedKeys = [
+    'fanart',
+    'ss',
+    'wheel',
+    'box2D',
+    'video',
+    'manuel',
+  ];
 
   void selectItem(int index) {
     if (index >= 0 && index < _orderedKeys.length) {

--- a/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
+++ b/lib/screens/settings_screen/new_settings_options/directories_settings_content.dart
@@ -728,8 +728,8 @@ class DirectoriesSettingsContentState
                 icon: Icon(Symbols.bolt_rounded, size: 20.r),
                 label: Text(
                   hasSynced
-                ? AppLocale.iosEmuResync.getString(context)
-                : AppLocale.iosEmuSync.getString(context),
+                      ? AppLocale.iosEmuResync.getString(context)
+                      : AppLocale.iosEmuSync.getString(context),
                   style: TextStyle(fontSize: 14.r),
                 ),
               ),
@@ -785,8 +785,8 @@ class DirectoriesSettingsContentState
                 icon: Icon(Symbols.bolt_rounded, size: 20.r),
                 label: Text(
                   hasSynced
-                ? AppLocale.iosEmuResync.getString(context)
-                : AppLocale.iosEmuSync.getString(context),
+                      ? AppLocale.iosEmuResync.getString(context)
+                      : AppLocale.iosEmuSync.getString(context),
                   style: TextStyle(fontSize: 14.r),
                 ),
               ),
@@ -884,10 +884,7 @@ class DirectoriesSettingsContentState
                 SizedBox(width: 10.r),
                 Text(
                   name,
-                  style: TextStyle(
-                    fontSize: 16.r,
-                    fontWeight: FontWeight.bold,
-                  ),
+                  style: TextStyle(fontSize: 16.r, fontWeight: FontWeight.bold),
                 ),
               ],
             ),
@@ -952,13 +949,12 @@ class DirectoriesSettingsContentState
         // Same internal-folder approach as the setup wizard — no external
         // picker on iOS, see ConfigService.getDefaultIOSRomsFolder().
         selected = await ConfigService.getDefaultIOSRomsFolder();
-        if (selected != null &&
-            configProvider.config.romFolders.contains(selected)) {
+        if (configProvider.config.romFolders.contains(selected)) {
           if (mounted) {
             AppNotification.showNotification(
               context,
               'Already using the internal roms folder. Drop ROMs into it '
-                  'via the Files app under "On My iPhone > NeoStation > roms".',
+              'via the Files app under "On My iPhone > NeoStation > roms".',
               type: NotificationType.info,
             );
           }

--- a/lib/screens/systems_screen/my_systems_section/initial_setup_widget.dart
+++ b/lib/screens/systems_screen/my_systems_section/initial_setup_widget.dart
@@ -39,7 +39,7 @@ class InitialSetupWidget extends StatelessWidget {
             const SizedBox(height: 8),
             Text(
               'RetroArch is linked. Relaunch NeoStation to see your '
-                  'synced games here.',
+              'synced games here.',
               textAlign: TextAlign.center,
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,

--- a/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
+++ b/lib/screens/systems_screen/my_systems_section/my_systems_grid.dart
@@ -945,12 +945,8 @@ class _SystemCardGridViewState extends State<SystemCardGridView> {
             // designed for wide TV/desktop layouts. On iOS's phone-sized
             // screens it dwarfs every other card, so keep it at the same
             // 1x1 size as everything else there.
-            final spanW = (card.isGame && cols >= 3 && !Platform.isIOS)
-                ? 3
-                : 1;
-            final spanH = (card.isGame && cols >= 3 && !Platform.isIOS)
-                ? 2
-                : 1;
+            final spanW = (card.isGame && cols >= 3 && !Platform.isIOS) ? 3 : 1;
+            final spanH = (card.isGame && cols >= 3 && !Platform.isIOS) ? 2 : 1;
 
             final left = c * (colWidth + spX);
             final width = spanW * colWidth + (spanW - 1) * spX;

--- a/lib/services/armsx2_library_service.dart
+++ b/lib/services/armsx2_library_service.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/widgets.dart';
 import 'package:neostation/data/datasources/sqlite_service.dart';
 import 'package:neostation/main.dart' show rootNavigatorKey;
 import 'package:neostation/providers/sqlite_config_provider.dart';
@@ -22,7 +21,7 @@ import 'package:url_launcher/url_launcher.dart';
 ///   armsx2://library?callback=neostation://armsx2
 ///
 /// It calls NeoStation back with:
-///   neostation://armsx2?source=armsx2-ios&payload=<base64url>
+///   `neostation://armsx2?source=armsx2-ios&payload=<base64url>`
 ///
 /// Unlike the normal NeoStation filesystem scanner, this service does not
 /// require ARMSX2 games to live inside a `ps2/` subfolder. ARMSX2's exported
@@ -214,12 +213,10 @@ class Armsx2LibraryService {
   /// Existing physical rows are preferred. Games which NeoStation has never
   /// scanned get a virtual `armsx2://launch?...` row, which is enough for the
   /// PS2 system and game list to render and launch directly through ARMSX2.
-  static Future<({
-    int virtualRows,
-    int physicalRows,
-    int removedRows,
-    int totalPs2Rows,
-  })> _importIntoNeoStation(List<Map<String, dynamic>> games) async {
+  static Future<
+    ({int virtualRows, int physicalRows, int removedRows, int totalPs2Rows})
+  >
+  _importIntoNeoStation(List<Map<String, dynamic>> games) async {
     final ps2 = await SystemRepository.getSystemByFolderName('ps2');
     if (ps2?.id == null) {
       throw StateError('NeoStation PS2 system definition was not found');
@@ -261,7 +258,8 @@ class Armsx2LibraryService {
         final parsedExported = exportedLaunchUrl == null
             ? null
             : Uri.tryParse(exportedLaunchUrl);
-        final launchUri = parsedExported != null &&
+        final launchUri =
+            parsedExported != null &&
                 parsedExported.scheme.toLowerCase() == _virtualScheme
             ? parsedExported
             : Uri(
@@ -353,14 +351,17 @@ class Armsx2LibraryService {
       final context = rootNavigatorKey.currentContext;
       if (context == null) return;
 
-      await Provider.of<SqliteDatabaseProvider>(
+      final databaseProvider = Provider.of<SqliteDatabaseProvider>(
         context,
         listen: false,
-      ).loadGamesForSystem('ps2');
-      await Provider.of<SqliteConfigProvider>(
+      );
+      final configProvider = Provider.of<SqliteConfigProvider>(
         context,
         listen: false,
-      ).refreshDetectedSystems();
+      );
+
+      await databaseProvider.loadGamesForSystem('ps2');
+      await configProvider.refreshDetectedSystems();
     } catch (e) {
       _log.e('Armsx2LibraryService: UI refresh failed: $e');
     }
@@ -391,10 +392,8 @@ class Armsx2LibraryService {
       final decoded = jsonDecode(raw);
       if (decoded is Map) {
         _cache = decoded.map(
-          (key, value) => MapEntry(
-            key.toString(),
-            Map<String, dynamic>.from(value as Map),
-          ),
+          (key, value) =>
+              MapEntry(key.toString(), Map<String, dynamic>.from(value as Map)),
         );
       } else {
         _cache = {};
@@ -480,7 +479,8 @@ class Armsx2LibraryService {
         ? null
         : Uri.tryParse(exportedLaunchUrl);
 
-    final uri = exportedUri ??
+    final uri =
+        exportedUri ??
         Uri(
           scheme: 'armsx2',
           host: 'launch',
@@ -500,7 +500,9 @@ class Armsx2LibraryService {
         input: uri.toString(),
       );
     } catch (e) {
-      _log.e('Armsx2LibraryService: failed to launch $uri through Shortcut: $e');
+      _log.e(
+        'Armsx2LibraryService: failed to launch $uri through Shortcut: $e',
+      );
       await _writeDebugFile(
         'armsx2_shortcut_launch_debug.txt',
         'STATE: ERROR\n'

--- a/lib/services/config_service.dart
+++ b/lib/services/config_service.dart
@@ -259,7 +259,9 @@ class ConfigService {
     final sourceDir = Directory(sourcePath);
 
     if (!await sourceDir.exists()) {
-      _log.w('importFilesFromExternalFolder: source does not exist: $sourcePath');
+      _log.w(
+        'importFilesFromExternalFolder: source does not exist: $sourcePath',
+      );
       return 0;
     }
 

--- a/lib/services/game/game_launch_service.dart
+++ b/lib/services/game/game_launch_service.dart
@@ -113,7 +113,8 @@ class GameLaunchService {
           // rather than filesystem paths. They remain launchable even when
           // NeoStation cannot see the underlying ROM file itself.
           romExists = true;
-        } else if (Platform.isAndroid && game.romPath!.startsWith('content://')) {
+        } else if (Platform.isAndroid &&
+            game.romPath!.startsWith('content://')) {
           romExists = true;
         } else {
           romExists = await File(game.romPath!).exists();
@@ -138,7 +139,11 @@ class GameLaunchService {
       // This needs one extra tap the first few times; iOS promotes
       // frequently-used apps to the front of that list afterwards.
       if (Platform.isIOS) {
-        GameSessionManager.registerGameLaunch(system, game, 'ios_direct_launch');
+        GameSessionManager.registerGameLaunch(
+          system,
+          game,
+          'ios_direct_launch',
+        );
         await FavoritesService.recordGamePlayed(game);
 
         // Nintendo Switch: MeloNX exposes an alternate-frontend library export
@@ -229,9 +234,7 @@ class GameLaunchService {
             );
             if (updated) {
               final opened = await launchUrl(
-                Uri.parse(
-                  'shortcuts://run-shortcut?name=ResumeNeoStation',
-                ),
+                Uri.parse('shortcuts://run-shortcut?name=ResumeNeoStation'),
               );
               if (opened) return GameLaunchResult.success();
             }
@@ -269,10 +272,12 @@ class GameLaunchService {
         // context we were handed; falls back to a small on-screen rect if
         // the render tree isn't available for some reason.
         Rect sharePositionOrigin = const Rect.fromLTWH(0, 0, 1, 1);
-        final renderObject = context.findRenderObject();
-        if (renderObject is RenderBox && renderObject.hasSize) {
-          sharePositionOrigin =
-              renderObject.localToGlobal(Offset.zero) & renderObject.size;
+        if (context.mounted) {
+          final renderObject = context.findRenderObject();
+          if (renderObject is RenderBox && renderObject.hasSize) {
+            sharePositionOrigin =
+                renderObject.localToGlobal(Offset.zero) & renderObject.size;
+          }
         }
 
         try {

--- a/lib/services/game/game_list_service.dart
+++ b/lib/services/game/game_list_service.dart
@@ -125,7 +125,7 @@ class GameListService {
   static Future<List<GameModel>> loadGamesForSystem(SystemModel system) async {
     try {
       if (system.folderName == SystemFolderNames.favorites) {
-        return _loadFavoriteGames();
+        return await _loadFavoriteGames();
       }
 
       if (system.folderName == 'all') {

--- a/lib/services/ios_shortcut_jit_launch_service.dart
+++ b/lib/services/ios_shortcut_jit_launch_service.dart
@@ -3,44 +3,33 @@ import 'dart:io';
 import 'package:neostation/services/logger_service.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-/// Runs user-configured Apple Shortcuts used by NeoStation's iOS emulator
-/// launch flow and opens their one-time installation links.
+/// Handles iOS Shortcut installation and JIT-assisted emulator launches.
+///
+/// Shortcut setup and payload construction live here so MeloNX and ARMSX2
+/// share the same launch behavior.
 class IosShortcutJitLaunchService {
   IosShortcutJitLaunchService._();
 
   static final _log = LoggerService.instance;
 
-  /// Keep this name in sync with the shared Shortcut. The `+` characters are
-  /// part of the actual Shortcut name and are percent-encoded by [Uri] below.
+  /// Keep these names in sync with the shared Shortcuts. The `+` characters
+  /// are part of the Shortcut names and are percent-encoded by [Uri].
   static const String melonxShortcutName = 'NeoStation+MeloNX+JIT';
   static const String armsx2ShortcutName = 'NeoStation+ARMSX2+JIT';
 
-  /// One-time installer for the exact NeoStation MeloNX launch Shortcut.
-  ///
-  /// Replace the placeholder with the iCloud sharing URL copied from the
-  /// Shortcuts app before shipping the patch. Keeping the URL here gives the
-  /// settings card one stable place to manage the installer.
   static const String _melonxShortcutInstallUrl =
       'https://www.icloud.com/shortcuts/84b9d0fbdd714c6c9596ba2e3c699031';
 
-  /// One-time installer for the exact NeoStation ARMSX2 launch Shortcut.
   static const String _armsx2ShortcutInstallUrl =
       'https://www.icloud.com/shortcuts/1419632b150747f5bcd7b9bc65e36114';
 
   static bool get hasMeloNXShortcutInstaller =>
-      _melonxShortcutInstallUrl.startsWith(
-        'https://www.icloud.com/shortcuts/',
-      );
+      _melonxShortcutInstallUrl.startsWith('https://www.icloud.com/shortcuts/');
 
   static bool get hasArmsx2ShortcutInstaller =>
-      _armsx2ShortcutInstallUrl.startsWith(
-        'https://www.icloud.com/shortcuts/',
-      );
+      _armsx2ShortcutInstallUrl.startsWith('https://www.icloud.com/shortcuts/');
 
-  /// Opens the shared ARMSX2 launch Shortcut. While the iCloud sharing link
-  /// is not configured yet, fall back to Apple's official create-shortcut
-  /// URL so the user can create/duplicate the Shortcut without leaving the
-  /// NeoStation setup flow.
+  /// Opens the shared ARMSX2 Shortcut installer.
   static Future<bool> openArmsx2ShortcutInstaller() async {
     if (!Platform.isIOS) return false;
 
@@ -49,19 +38,14 @@ class IosShortcutJitLaunchService {
         : Uri.parse('shortcuts://create-shortcut');
 
     try {
-      return await launchUrl(
-        target,
-        mode: LaunchMode.externalApplication,
-      );
+      return await launchUrl(target, mode: LaunchMode.externalApplication);
     } catch (e) {
-      _log.e(
-        'IosShortcutJitLaunchService: failed to open ARMSX2 setup: $e',
-      );
+      _log.e('IosShortcutJitLaunchService: failed to open ARMSX2 setup: $e');
       return false;
     }
   }
 
-  /// Opens Apple's import sheet for the shared MeloNX Shortcut.
+  /// Opens the shared MeloNX Shortcut installer.
   static Future<bool> openMeloNXShortcutInstaller() async {
     if (!Platform.isIOS || !hasMeloNXShortcutInstaller) return false;
 
@@ -78,9 +62,9 @@ class IosShortcutJitLaunchService {
     }
   }
 
-  /// Runs an installed Shortcut and passes an emulator game deeplink as text
-  /// input. The Shortcut owns the foreground sequence so StikDebug can finish
-  /// enabling JIT before it opens the game URL.
+  /// Runs an installed Shortcut with an emulator game deeplink as text input.
+  /// The Shortcut keeps control while StikDebug enables JIT, then opens the
+  /// game URL.
   static Future<bool> run({
     required String shortcutName,
     required String input,
@@ -98,14 +82,9 @@ class IosShortcutJitLaunchService {
     );
 
     try {
-      return await launchUrl(
-        shortcutUri,
-        mode: LaunchMode.externalApplication,
-      );
+      return await launchUrl(shortcutUri, mode: LaunchMode.externalApplication);
     } catch (e) {
-      _log.e(
-        'IosShortcutJitLaunchService: failed to run $shortcutName: $e',
-      );
+      _log.e('IosShortcutJitLaunchService: failed to run $shortcutName: $e');
       return false;
     }
   }

--- a/lib/services/melonx_library_service.dart
+++ b/lib/services/melonx_library_service.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/widgets.dart';
 import 'package:external_folder_access/external_folder_access.dart';
 import 'package:neostation/data/datasources/sqlite_service.dart';
 import 'package:neostation/main.dart' show rootNavigatorKey;
@@ -24,7 +23,7 @@ import 'package:url_launcher/url_launcher.dart';
 ///   melonx://gameInfo?scheme=neostation
 ///
 /// MeloNX callback:
-///   neostation://melonx?games=<base64url(JSON [GameScheme])>
+///   `neostation://melonx?games=<base64url(JSON [GameScheme])>`
 ///
 /// A MeloNX GameScheme contains titleName, titleId, developer, version and
 /// iconData. NeoStation imports the human-readable metadata and uses iconData
@@ -236,16 +235,21 @@ class MelonxLibraryService {
   /// the same title name), that row is reused and enriched. Otherwise a virtual
   /// `melonx://game?...` row is created. A normal ROM-folder rescan therefore
   /// isn't required for MeloNX-only games to appear in the main Switch library.
-  static Future<({
-    int virtualRows,
-    int physicalRows,
-    int artworkRows,
-    int removedRows,
-    int totalSwitchRows,
-  })> _importIntoNeoStation(List<Map<String, dynamic>> games) async {
+  static Future<
+    ({
+      int virtualRows,
+      int physicalRows,
+      int artworkRows,
+      int removedRows,
+      int totalSwitchRows,
+    })
+  >
+  _importIntoNeoStation(List<Map<String, dynamic>> games) async {
     final switchSystem = await SystemRepository.getSystemByFolderName('switch');
     if (switchSystem?.id == null) {
-      throw StateError('NeoStation Nintendo Switch system definition was not found');
+      throw StateError(
+        'NeoStation Nintendo Switch system definition was not found',
+      );
     }
 
     final systemId = switchSystem!.id!;
@@ -513,14 +517,17 @@ class MelonxLibraryService {
       final context = rootNavigatorKey.currentContext;
       if (context == null) return;
 
-      await Provider.of<SqliteDatabaseProvider>(
+      final databaseProvider = Provider.of<SqliteDatabaseProvider>(
         context,
         listen: false,
-      ).loadGamesForSystem('switch');
-      await Provider.of<SqliteConfigProvider>(
+      );
+      final configProvider = Provider.of<SqliteConfigProvider>(
         context,
         listen: false,
-      ).refreshDetectedSystems();
+      );
+
+      await databaseProvider.loadGamesForSystem('switch');
+      await configProvider.refreshDetectedSystems();
     } catch (e) {
       _log.e('MelonxLibraryService: UI refresh failed: $e');
     }
@@ -578,10 +585,8 @@ class MelonxLibraryService {
       final decoded = jsonDecode(raw);
       if (decoded is Map) {
         _cache = decoded.map(
-          (key, value) => MapEntry(
-            key.toString(),
-            Map<String, dynamic>.from(value as Map),
-          ),
+          (key, value) =>
+              MapEntry(key.toString(), Map<String, dynamic>.from(value as Map)),
         );
       } else {
         _cache = {};
@@ -650,7 +655,7 @@ class MelonxLibraryService {
             : null) ??
         (normalizedTitleName.isNotEmpty
             ? cache[normalizedTitleName] ??
-                cache[normalizedTitleName.toLowerCase()]
+                  cache[normalizedTitleName.toLowerCase()]
             : null);
 
     await _writeDebugFile(

--- a/lib/services/neo_assets_service.dart
+++ b/lib/services/neo_assets_service.dart
@@ -247,7 +247,7 @@ class NeoAssetsService {
           .cast<Map<String, dynamic>>()
           .map(NeoAssetsTheme.fromJson)
           .toList();
-      return Future.wait(
+      return await Future.wait(
         baseList.map((theme) async {
           final metadata = await _fetchThemeMetadata(theme.folder);
           if (metadata == null) return theme;

--- a/lib/services/retroarch_library_service.dart
+++ b/lib/services/retroarch_library_service.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:io';
-import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
@@ -50,9 +49,7 @@ class RetroArchLibraryService {
   /// app_links package. Returns whether the request URL was opened at all
   /// (not whether RetroArch actually responded).
   static Future<bool> requestLibrarySync() async {
-    return launchUrl(
-      Uri.parse('retroarch://library?scheme=$_callbackScheme'),
-    );
+    return launchUrl(Uri.parse('retroarch://library?scheme=$_callbackScheme'));
   }
 
   /// Call this with every incoming URI the app receives (from
@@ -62,6 +59,11 @@ class RetroArchLibraryService {
     if (uri.scheme != _callbackScheme || uri.host != 'retroarch') {
       return false;
     }
+
+    final context = rootNavigatorKey.currentContext;
+    final configProvider = context == null
+        ? null
+        : Provider.of<SqliteConfigProvider>(context, listen: false);
 
     final gamesParam = uri.queryParameters['games'];
     if (gamesParam == null) {
@@ -136,13 +138,7 @@ class RetroArchLibraryService {
       // root navigator's context since this is a plain service class with
       // no BuildContext of its own.
       try {
-        final context = rootNavigatorKey.currentContext;
-        if (context != null) {
-          await Provider.of<SqliteConfigProvider>(
-            context,
-            listen: false,
-          ).scanSystems();
-        }
+        await configProvider?.scanSystems();
       } catch (e) {
         _log.e('RetroArchLibraryService: post-sync rescan failed: $e');
       }
@@ -169,10 +165,8 @@ class RetroArchLibraryService {
       final decoded = jsonDecode(raw);
       if (decoded is Map) {
         _cache = decoded.map(
-          (key, value) => MapEntry(
-            key.toString(),
-            Map<String, dynamic>.from(value as Map),
-          ),
+          (key, value) =>
+              MapEntry(key.toString(), Map<String, dynamic>.from(value as Map)),
         );
       } else {
         _cache = {};
@@ -246,14 +240,12 @@ class RetroArchLibraryService {
 
   /// Writes diagnostic info to a plain text file under the app's Documents
   /// folder, readable via the Files app ("On My iPhone > NeoStation >
-  /// <name>") — there's no Xcode console access to check this otherwise.
+  /// `<name>`) — there's no Xcode console access to check this otherwise.
   static Future<void> _writeDebugFile(String name, String content) async {
     try {
       final docsDir = await getApplicationDocumentsDirectory();
       final file = File(path.join(docsDir.path, name));
-      await file.writeAsString(
-        '--- ${DateTime.now()} ---\n$content',
-      );
+      await file.writeAsString('--- ${DateTime.now()} ---\n$content');
     } catch (e) {
       _log.e('RetroArchLibraryService: failed writing debug file $name: $e');
     }

--- a/lib/services/retroarch_playlist_service.dart
+++ b/lib/services/retroarch_playlist_service.dart
@@ -115,10 +115,14 @@ class RetroArchPlaylistService {
       }
 
       debug.writeln('matchedInFile: $matchedInFile');
-      debug.writeln('matchingEntry: ${matchingEntry != null ? jsonEncode(matchingEntry) : "null"}');
+      debug.writeln(
+        'matchingEntry: ${matchingEntry != null ? jsonEncode(matchingEntry) : "null"}',
+      );
 
       if (matchingEntry == null) {
-        debug.writeln('RESULT: false (no matching entry found in any playlist)');
+        debug.writeln(
+          'RESULT: false (no matching entry found in any playlist)',
+        );
         return false;
       }
 
@@ -131,12 +135,16 @@ class RetroArchPlaylistService {
         try {
           final decoded = jsonDecode(await historyFile.readAsString());
           if (decoded is! Map<String, dynamic>) {
-            debug.writeln('RESULT: false ($_historyFileName is not a JSON object)');
+            debug.writeln(
+              'RESULT: false ($_historyFileName is not a JSON object)',
+            );
             return false;
           }
           history = decoded;
         } catch (e) {
-          debug.writeln('RESULT: false (failed to parse $_historyFileName: $e)');
+          debug.writeln(
+            'RESULT: false (failed to parse $_historyFileName: $e)',
+          );
           return false;
         }
       } else {

--- a/lib/services/screenscraper/media_downloader.dart
+++ b/lib/services/screenscraper/media_downloader.dart
@@ -31,7 +31,10 @@ class ScreenscraperMediaDownloader {
   /// fallback permanently win even though the ScreenScraper image downloaded
   /// successfully.
   static Future<void> _removeCompetingImageVariants(String fullPath) async {
-    final targetExt = path.extension(fullPath).replaceFirst('.', '').toLowerCase();
+    final targetExt = path
+        .extension(fullPath)
+        .replaceFirst('.', '')
+        .toLowerCase();
     if (!const {'png', 'jpg', 'jpeg'}.contains(targetExt)) return;
 
     final base = path.withoutExtension(fullPath);

--- a/lib/services/screenscraper/melonx_media_fallback.dart
+++ b/lib/services/screenscraper/melonx_media_fallback.dart
@@ -55,7 +55,9 @@ class ScreenscraperMeloNxMediaFallback {
     final failures = <String>[];
 
     final imageTypes = allowedMediaTypes
-        .where((type) => const ['fanart', 'ss', 'wheel', 'box2D'].contains(type))
+        .where(
+          (type) => const ['fanart', 'ss', 'wheel', 'box2D'].contains(type),
+        )
         .toList();
 
     final sourceTypes = <String>{};
@@ -168,7 +170,8 @@ class ScreenscraperMeloNxMediaFallback {
 
           final contentType = response.headers['content-type'] ?? '';
           final bodyPrefix = _safeBodyPrefix(response.bodyBytes);
-          final isImage = response.statusCode == 200 &&
+          final isImage =
+              response.statusCode == 200 &&
               _looksLikeImage(response.bodyBytes, contentType);
 
           await _appendDebug(
@@ -238,7 +241,8 @@ class ScreenscraperMeloNxMediaFallback {
       _ => [mediaType],
     };
     for (final sourceType in relevantSourceTypes) {
-      for (final region in sourceRegionsByType[sourceType] ?? const <String>[]) {
+      for (final region
+          in sourceRegionsByType[sourceType] ?? const <String>[]) {
         addRegion(region);
       }
     }
@@ -330,7 +334,8 @@ class ScreenscraperMeloNxMediaFallback {
     final lowerType = contentType.toLowerCase();
     if (lowerType.startsWith('image/')) return true;
 
-    final isPng = bytes.length >= 8 &&
+    final isPng =
+        bytes.length >= 8 &&
         bytes[0] == 0x89 &&
         bytes[1] == 0x50 &&
         bytes[2] == 0x4e &&
@@ -344,7 +349,8 @@ class ScreenscraperMeloNxMediaFallback {
     final isJpeg = bytes[0] == 0xff && bytes[1] == 0xd8 && bytes[2] == 0xff;
     if (isJpeg) return true;
 
-    final isWebP = bytes.length >= 12 &&
+    final isWebP =
+        bytes.length >= 12 &&
         ascii.decode(bytes.sublist(0, 4), allowInvalid: true) == 'RIFF' &&
         ascii.decode(bytes.sublist(8, 12), allowInvalid: true) == 'WEBP';
     return isWebP;

--- a/lib/services/screenscraper/screenscraper_client.dart
+++ b/lib/services/screenscraper/screenscraper_client.dart
@@ -58,8 +58,10 @@ class ScreenscraperClient {
       _appVersion = '$name-$version-$platform';
       return _appVersion!;
     } catch (e) {
-      _log.w('Could not resolve app identity for ScreenScraper ($e) — '
-          'falling back to a generic softname.');
+      _log.w(
+        'Could not resolve app identity for ScreenScraper ($e) — '
+        'falling back to a generic softname.',
+      );
       _appVersion = 'neostation';
       return _appVersion!;
     }

--- a/lib/services/screenscraper_service.dart
+++ b/lib/services/screenscraper_service.dart
@@ -683,9 +683,11 @@ class ScreenScraperService {
                 password: credentials['password']?.toString() ?? '',
                 allowedMediaTypes: allowedMediaTypes,
                 alreadyDownloadedTypes: [
-                  ...(downloadResult['downloadedTypes'] as List<dynamic>? ?? const [])
+                  ...(downloadResult['downloadedTypes'] as List<dynamic>? ??
+                          const [])
                       .map((e) => e.toString()),
-                  ...(downloadResult['existingTypes'] as List<dynamic>? ?? const [])
+                  ...(downloadResult['existingTypes'] as List<dynamic>? ??
+                          const [])
                       .map((e) => e.toString()),
                 ],
                 sourceMedias: medias,
@@ -698,10 +700,12 @@ class ScreenScraperService {
                   .toSet();
           final requestedImageTypes = allowedMediaTypes
               .where(
-                (type) => const ['fanart', 'ss', 'wheel', 'box2D'].contains(type),
+                (type) =>
+                    const ['fanart', 'ss', 'wheel', 'box2D'].contains(type),
               )
               .toSet();
-          mediaSuccess = requestedImageTypes.isEmpty ||
+          mediaSuccess =
+              requestedImageTypes.isEmpty ||
               requestedImageTypes.any(successfulTypes.contains);
         }
       }
@@ -779,7 +783,8 @@ class ScreenScraperService {
       final medias = gameInfo['medias'] as List<dynamic>? ?? const [];
       final credentials = await getSavedCredentials();
       final preferredLanguage = credentials?['preferred_language'] ?? 'en';
-      final regionPriority = await ScreenscraperRegionConfig.getRegionPriority();
+      final regionPriority =
+          await ScreenscraperRegionConfig.getRegionPriority();
       final selectedManual = ScreenscraperMediaResolver.selectBestMedia(
         medias,
         'manuel',
@@ -820,7 +825,8 @@ class ScreenScraperService {
         '$cleanRomName.$extension',
       );
 
-      final downloaded = result['success'] == true && await File(manualPath).exists();
+      final downloaded =
+          result['success'] == true && await File(manualPath).exists();
       return {
         'success': downloaded,
         'message': downloaded
@@ -1179,10 +1185,12 @@ class ScreenScraperService {
                       .toSet();
               final requestedImageTypes = allowedTypes
                   .where(
-                    (type) => const ['fanart', 'ss', 'wheel', 'box2D'].contains(type),
+                    (type) =>
+                        const ['fanart', 'ss', 'wheel', 'box2D'].contains(type),
                   )
                   .toSet();
-              mediaSucceeded = requestedImageTypes.isEmpty ||
+              mediaSucceeded =
+                  requestedImageTypes.isEmpty ||
                   requestedImageTypes.any(successfulTypes.contains);
             }
           }

--- a/lib/themes/chrome_surface.dart
+++ b/lib/themes/chrome_surface.dart
@@ -83,9 +83,8 @@ class ChromeSurface extends ThemeExtension<ChromeSurface> {
     double min = 0.0,
     double max = 1.0,
   }) {
-    final value = darkBase +
-        (_isLight(theme) ? lightBoost : 0.0) +
-        _vividBoost(theme);
+    final value =
+        darkBase + (_isLight(theme) ? lightBoost : 0.0) + _vividBoost(theme);
     return value.clamp(min, max).toDouble();
   }
 
@@ -162,7 +161,8 @@ class ChromeSurface extends ThemeExtension<ChromeSurface> {
   static Color glassRim(BuildContext context, GlassSurfaceRole role) {
     final theme = Theme.of(context);
     final isLight = _isLight(theme);
-    final mix = Color.lerp(
+    final mix =
+        Color.lerp(
           theme.colorScheme.outline,
           theme.colorScheme.onSurface,
           isLight ? 0.16 : 0.28,

--- a/lib/utils/emulator_loader.dart
+++ b/lib/utils/emulator_loader.dart
@@ -66,13 +66,11 @@ Future<List<CoreEmulatorModel>> loadEmulatorsForSystem(
                 e.isRetroArch &&
                 e.coreFilename != null &&
                 e.coreFilename!.isNotEmpty) {
-              final coreInstalled = await ch.invokeMethod<bool>(
-                'isCoreInstalled',
-                {
-                  'packageName': e.androidPackageName,
-                  'coreFilename': e.coreFilename,
-                },
-              );
+              final coreInstalled = await ch
+                  .invokeMethod<bool>('isCoreInstalled', {
+                    'packageName': e.androidPackageName,
+                    'coreFilename': e.coreFilename,
+                  });
               if (coreInstalled != null) installed = coreInstalled;
             }
             updated.add(e.copyWith(isInstalled: installed));

--- a/lib/widgets/game_action_buttons.dart
+++ b/lib/widgets/game_action_buttons.dart
@@ -184,7 +184,6 @@ class GameActionButtons extends StatelessWidget {
         sound: GameActionButtonSound.nav,
         onTap: selectedGame != null ? onSettings : null,
       ),
-
     ];
   }
 

--- a/lib/widgets/header.dart
+++ b/lib/widgets/header.dart
@@ -233,63 +233,63 @@ class HeaderState extends State<Header> {
                         ],
                         child: Builder(
                           builder: (context) {
-                          final visibleTabs = visibleNavTabs(
-                            configProvider.config,
-                          );
-                          // The indicator tracks the tab's slot in the *rendered*
-                          // strip, not its canonical index — otherwise hiding a tab
-                          // parks it past the end of a shortened strip.
-                          final selectedSlot = visibleTabs.indexOf(
-                            NavTab.values[widget.selectedTabIndex],
-                          );
+                            final visibleTabs = visibleNavTabs(
+                              configProvider.config,
+                            );
+                            // The indicator tracks the tab's slot in the *rendered*
+                            // strip, not its canonical index — otherwise hiding a tab
+                            // parks it past the end of a shortened strip.
+                            final selectedSlot = visibleTabs.indexOf(
+                              NavTab.values[widget.selectedTabIndex],
+                            );
 
-                          return Stack(
-                            children: [
-                              // Moving indicator
-                              AnimatedPositioned(
-                                left:
-                                    (selectedSlot < 0 ? 0 : selectedSlot) *
-                                    32.r,
-                                top: 4.r,
-                                bottom: 4.r,
-                                width: 32.r,
-                                duration: const Duration(milliseconds: 160),
-                                curve: Curves.easeInOut,
-                                child: Container(
-                                  decoration: BoxDecoration(
-                                    color: Theme.of(
-                                      context,
-                                    ).colorScheme.primary,
-                                    borderRadius:
-                                        Theme.of(context)
-                                            .extension<CornerRadii>()
-                                            ?.radiusInternal ??
-                                        BorderRadius.circular(4.r),
+                            return Stack(
+                              children: [
+                                // Moving indicator
+                                AnimatedPositioned(
+                                  left:
+                                      (selectedSlot < 0 ? 0 : selectedSlot) *
+                                      32.r,
+                                  top: 4.r,
+                                  bottom: 4.r,
+                                  width: 32.r,
+                                  duration: const Duration(milliseconds: 160),
+                                  curve: Curves.easeInOut,
+                                  child: Container(
+                                    decoration: BoxDecoration(
+                                      color: Theme.of(
+                                        context,
+                                      ).colorScheme.primary,
+                                      borderRadius:
+                                          Theme.of(context)
+                                              .extension<CornerRadii>()
+                                              ?.radiusInternal ??
+                                          BorderRadius.circular(4.r),
+                                    ),
                                   ),
                                 ),
-                              ),
-                              // Tab buttons
-                              Row(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  for (final tab in visibleTabs)
-                                    SizedBox(
-                                      width: 32.r,
-                                      height: 32.r,
-                                      child: _buildTabButton(
-                                        context,
-                                        tab.index,
-                                        navTabSpec(tab).icon,
-                                        navTabSpec(
-                                          tab,
-                                        ).labelKey.getString(context),
-                                        iconData: navTabSpec(tab).iconData,
+                                // Tab buttons
+                                Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    for (final tab in visibleTabs)
+                                      SizedBox(
+                                        width: 32.r,
+                                        height: 32.r,
+                                        child: _buildTabButton(
+                                          context,
+                                          tab.index,
+                                          navTabSpec(tab).icon,
+                                          navTabSpec(
+                                            tab,
+                                          ).labelKey.getString(context),
+                                          iconData: navTabSpec(tab).iconData,
+                                        ),
                                       ),
-                                    ),
-                                ],
-                              ),
-                            ],
-                          );
+                                  ],
+                                ),
+                              ],
+                            );
                           },
                         ),
                       ),
@@ -327,50 +327,50 @@ class HeaderState extends State<Header> {
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                      const NotificationBell(),
-                      SizedBox(width: 10.r),
-                      Icon(
-                        Symbols.schedule,
-                        color: Theme.of(context).colorScheme.onSurface,
-                        size: 14.r,
-                      ),
-                      SizedBox(width: 4.r),
-                      Text(
-                        formatClockTime(
-                          _now,
-                          use12Hour: configProvider.config.use12HourClock,
-                        ),
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.onSurface,
-                          fontSize: 12.r,
-                          fontWeight: FontWeight.w500,
-                          letterSpacing: 0.3.r,
-                        ),
-                      ),
-                      if (_batteryLevel != -1 &&
-                          !_isTelevision &&
-                          !Responsive.isHandheldXS(context)) ...[
-                        SizedBox(width: 12.r),
+                        const NotificationBell(),
+                        SizedBox(width: 10.r),
                         Icon(
-                          _getBatteryIconData(),
-                          color: _getBatteryColor(customColors),
-                          size: 16.r,
+                          Symbols.schedule,
+                          color: Theme.of(context).colorScheme.onSurface,
+                          size: 14.r,
                         ),
                         SizedBox(width: 4.r),
                         Text(
-                          "$_batteryLevel%",
+                          formatClockTime(
+                            _now,
+                            use12Hour: configProvider.config.use12HourClock,
+                          ),
                           style: TextStyle(
-                            color: _getBatteryColor(customColors),
+                            color: Theme.of(context).colorScheme.onSurface,
                             fontSize: 12.r,
                             fontWeight: FontWeight.w500,
                             letterSpacing: 0.3.r,
                           ),
                         ),
+                        if (_batteryLevel != -1 &&
+                            !_isTelevision &&
+                            !Responsive.isHandheldXS(context)) ...[
+                          SizedBox(width: 12.r),
+                          Icon(
+                            _getBatteryIconData(),
+                            color: _getBatteryColor(customColors),
+                            size: 16.r,
+                          ),
+                          SizedBox(width: 4.r),
+                          Text(
+                            "$_batteryLevel%",
+                            style: TextStyle(
+                              color: _getBatteryColor(customColors),
+                              fontSize: 12.r,
+                              fontWeight: FontWeight.w500,
+                              letterSpacing: 0.3.r,
+                            ),
+                          ),
+                        ],
                       ],
-                    ],
+                    ),
                   ),
                 ),
-              ),
               ),
             ],
           ),

--- a/lib/widgets/setup_wizard.dart
+++ b/lib/widgets/setup_wizard.dart
@@ -100,9 +100,7 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
   // moves up into the slot ES-DE would have occupied so the progress dots
   // match the steps the user actually walks through.
   int get _stepEsde => Platform.isIOS ? -1 : (Platform.isAndroid ? 4 : 3);
-  int get _stepArtPack => Platform.isAndroid
-      ? 5
-      : (Platform.isIOS ? 3 : 4);
+  int get _stepArtPack => Platform.isAndroid ? 5 : (Platform.isIOS ? 3 : 4);
 
   /// The art-pack step is always the final step of the wizard.
   bool get _isLastStep => _currentStep == _stepArtPack;
@@ -280,9 +278,7 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
   // Desktop: 0=UserData, 1=FolderSelect, 2=Scanning, 3=EsdeImport,
   //          4=ArtPack (5 steps)
   // iOS:     0=UserData, 1=FolderSelect, 2=Scanning, 3=ArtPack (4 steps)
-  int get _totalSteps => Platform.isAndroid
-      ? 6
-      : (Platform.isIOS ? 4 : 5);
+  int get _totalSteps => Platform.isAndroid ? 6 : (Platform.isIOS ? 4 : 5);
 
   @override
   Widget build(BuildContext context) {
@@ -2018,7 +2014,7 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
             AppNotification.showNotification(
               context,
               'Linked! If your games don\'t show up in a few seconds, '
-                  'relaunch NeoStation to see them.',
+              'relaunch NeoStation to see them.',
               type: NotificationType.info,
             );
           }

--- a/lib/widgets/system_emulator_settings_dialog/gamepad_nav.dart
+++ b/lib/widgets/system_emulator_settings_dialog/gamepad_nav.dart
@@ -121,9 +121,7 @@ extension _GamepadNav on _SystemEmulatorSettingsDialogState {
   }
 
   void _navigateLeft() {
-    if (_currentTab != 1 ||
-        !_usesExecutablePicker ||
-        _openMenuIndex != -1) {
+    if (_currentTab != 1 || !_usesExecutablePicker || _openMenuIndex != -1) {
       return;
     }
     if (_emulatorActionIndex == 0) return;
@@ -132,9 +130,7 @@ extension _GamepadNav on _SystemEmulatorSettingsDialogState {
   }
 
   void _navigateRight() {
-    if (_currentTab != 1 ||
-        !_usesExecutablePicker ||
-        _openMenuIndex != -1) {
+    if (_currentTab != 1 || !_usesExecutablePicker || _openMenuIndex != -1) {
       return;
     }
     if (_emulatorActionIndex == 1) return;

--- a/lib/widgets/system_emulator_settings_dialog/system_info.dart
+++ b/lib/widgets/system_emulator_settings_dialog/system_info.dart
@@ -481,9 +481,7 @@ extension _SystemInfoTab on _SystemEmulatorSettingsDialogState {
       decoration: BoxDecoration(
         color: scheme.onSurface.withValues(alpha: 0.06),
         borderRadius: BorderRadius.circular(20.r),
-        border: Border.all(
-          color: scheme.outline.withValues(alpha: 0.12),
-        ),
+        border: Border.all(color: scheme.outline.withValues(alpha: 0.12)),
       ),
       child: Text(
         text,

--- a/packages/external_folder_access/lib/external_folder_access.dart
+++ b/packages/external_folder_access/lib/external_folder_access.dart
@@ -92,7 +92,6 @@ class ExternalFolderAccess {
     }
   }
 
-
   /// Opens an arbitrary URL string on iOS without round-tripping through
   /// Dart's [Uri] class. This matters for custom URL schemes whose handler
   /// (incorrectly, but in practice) treats the host as case-sensitive, e.g.
@@ -183,7 +182,7 @@ class ExternalFolderAccess {
   }
 
   /// Registers a callback for URLs opened while the app is running — e.g.
-  /// RetroArch calling back via neostation://retroarch?games=<base64url>
+  /// RetroArch calling back via `neostation://retroarch?games=<base64url>`
   /// after a library export request. Replaces the app_links package for
   /// this single use case, since the native side already forwards
   /// `application(_:open:options:)` through this same channel (see

--- a/test/database_test_helper.dart
+++ b/test/database_test_helper.dart
@@ -143,6 +143,7 @@ class DatabaseTestHelper {
         core_filename TEXT,
         android_package_name TEXT,
         android_activity_name TEXT,
+        ios_url_scheme TEXT,
         is_default INTEGER,
         is_default_core INTEGER,
         is_default_standalone INTEGER NOT NULL DEFAULT 0,
@@ -233,12 +234,10 @@ class DatabaseTestHelper {
         updated_at TEXT
       )
     ''');
-    await db.execute(
-      r'''INSERT INTO user_screenscraper_config
+    await db.execute(r'''INSERT INTO user_screenscraper_config
         (id, scrape_mode, scrape_metadata, scrape_images, scrape_videos, scrape_media_types)
         VALUES
-        (1, 'new_only', 1, 1, 1, '["fanart","ss","wheel","box2D","video"]')''',
-    );
+        (1, 'new_only', 1, 1, 1, '["fanart","ss","wheel","box2D","video"]')''');
 
     await db.execute('''
       CREATE TABLE user_screenscraper_system_config (

--- a/test/emulator_seed_default_test.dart
+++ b/test/emulator_seed_default_test.dart
@@ -140,7 +140,8 @@ void main() {
     expect(
       offenders,
       isEmpty,
-      reason: 'iOS emulator definitions need url_scheme for install detection:\n'
+      reason:
+          'iOS emulator definitions need url_scheme for install detection:\n'
           '${offenders.join('\n')}',
     );
   });
@@ -165,35 +166,43 @@ void main() {
     expect(ios['url_scheme'], 'melonx');
   });
 
-  test('systems with RetroArch definitions expose one generic iOS RetroArch app', () {
-    final offenders = <String>[];
+  test(
+    'systems with iOS RetroArch definitions expose one generic iOS RetroArch app',
+    () {
+      final offenders = <String>[];
 
-    for (final system in systems) {
-      final hasRetroArchDefinition = system.emulators.any((e) {
-        final uid = e.uniqueId.toLowerCase();
-        final platformText = jsonEncode(e.platforms).toLowerCase();
-        return uid.contains('.ra.') ||
-            uid.contains('.ra32.') ||
-            uid.contains('.ra64.') ||
-            platformText.contains('retroarch');
-      });
-      if (!hasRetroArchDefinition) continue;
+      for (final system in systems) {
+        final hasIosRetroArchDefinition = system.emulators.any((e) {
+          final uid = e.uniqueId.toLowerCase();
+          final platformText = jsonEncode(e.platforms).toLowerCase();
+          final isRetroArchDefinition =
+              uid.contains('.ra.') ||
+              uid.contains('.ra32.') ||
+              uid.contains('.ra64.') ||
+              platformText.contains('retroarch');
+          if (!isRetroArchDefinition) return false;
 
-      final iosRetroArch = system.emulators.where((e) {
-        final ios = e.platforms['ios'];
-        return ios is Map &&
-            ios['url_scheme']?.toString().toLowerCase() == 'retroarch';
-      }).toList();
+          final ios = e.platforms['ios'];
+          return ios is Map && ios.isNotEmpty;
+        });
+        if (!hasIosRetroArchDefinition) continue;
 
-      if (iosRetroArch.length != 1) {
-        offenders.add(
-          '${system.name}: expected 1 generic iOS RetroArch entry, found ${iosRetroArch.length}',
-        );
+        final iosRetroArch = system.emulators.where((e) {
+          final ios = e.platforms['ios'];
+          return ios is Map &&
+              ios['url_scheme']?.toString().toLowerCase() == 'retroarch';
+        }).toList();
+
+        if (iosRetroArch.length != 1) {
+          offenders.add(
+            '${system.name}: expected 1 generic iOS RetroArch entry, found ${iosRetroArch.length}',
+          );
+        }
       }
-    }
 
-    expect(offenders, isEmpty, reason: offenders.join('\n'));
-  });
+      expect(offenders, isEmpty, reason: offenders.join('\n'));
+    },
+  );
 
   test('the two systems fixed on this branch resolve to a single default', () {
     // Regression pins for the pair found on the AYN Thor.

--- a/test/system_info_catalog_coverage_test.dart
+++ b/test/system_info_catalog_coverage_test.dart
@@ -4,80 +4,86 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('every bundled system definition contains rich System Info metadata', () {
-    final systemFiles = Directory('assets/systems')
-        .listSync()
-        .whereType<File>()
-        .where((file) => file.path.endsWith('.json'))
-        .toList();
+  test(
+    'every bundled system definition contains rich System Info metadata',
+    () {
+      final systemFiles = Directory('assets/systems')
+          .listSync()
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.json'))
+          .toList();
 
-    expect(systemFiles, isNotEmpty);
+      expect(systemFiles, isNotEmpty);
 
-    final definitions = <String, Map<String, dynamic>>{};
-    for (final file in systemFiles) {
-      final root = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
-      final system = Map<String, dynamic>.from(root['system'] as Map);
-      definitions[system['id'].toString()] = system;
-    }
-
-    for (final entry in definitions.entries) {
-      final id = entry.key;
-      final system = entry.value;
-      final details = Map<String, dynamic>.from(system['details'] as Map? ?? {});
-      final parent = details['info_inherits']?.toString();
-      final collectionKind = details['collection_kind']?.toString();
-      final notableGames = (details['notable_games'] as List?) ?? const [];
-      final media = (details['media'] as List?) ?? const [];
-
-      final hasDirectRichInfo =
-          (details['architecture']?.toString().isNotEmpty ?? false) ||
-          details['generation'] != null ||
-          (details['cpu']?.toString().isNotEmpty ?? false) ||
-          media.isNotEmpty ||
-          notableGames.isNotEmpty ||
-          (collectionKind?.isNotEmpty ?? false);
-
-      expect(
-        hasDirectRichInfo || (parent?.isNotEmpty ?? false),
-        isTrue,
-        reason: '$id has no rich System Info metadata',
-      );
-
-      if (parent != null && parent.isNotEmpty) {
-        expect(
-          definitions.containsKey(parent),
-          isTrue,
-          reason: '$id inherits missing system $parent',
-        );
+      final definitions = <String, Map<String, dynamic>>{};
+      for (final file in systemFiles) {
+        final root =
+            jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+        final system = Map<String, dynamic>.from(root['system'] as Map);
+        definitions[system['id'].toString()] = system;
       }
 
-      expect(
-        notableGames.every((game) => game.toString().trim().isNotEmpty),
-        isTrue,
-        reason: '$id contains an empty notable game title',
-      );
-      expect(
-        media.every((item) => item.toString().trim().isNotEmpty),
-        isTrue,
-        reason: '$id contains an empty media identifier',
-      );
-    }
-
-    // Inheritance is intentionally used by hack/variant definitions. Guard
-    // against accidental cycles so a future system-definition update cannot
-    // make SystemInfoCatalog recurse forever.
-    for (final id in definitions.keys) {
-      final seen = <String>{};
-      var current = id;
-      while (true) {
-        expect(seen.add(current), isTrue, reason: 'inheritance cycle at $id');
+      for (final entry in definitions.entries) {
+        final id = entry.key;
+        final system = entry.value;
         final details = Map<String, dynamic>.from(
-          definitions[current]?['details'] as Map? ?? {},
+          system['details'] as Map? ?? {},
         );
         final parent = details['info_inherits']?.toString();
-        if (parent == null || parent.isEmpty) break;
-        current = parent;
+        final collectionKind = details['collection_kind']?.toString();
+        final notableGames = (details['notable_games'] as List?) ?? const [];
+        final media = (details['media'] as List?) ?? const [];
+
+        final hasDirectRichInfo =
+            (details['architecture']?.toString().isNotEmpty ?? false) ||
+            details['generation'] != null ||
+            (details['cpu']?.toString().isNotEmpty ?? false) ||
+            media.isNotEmpty ||
+            notableGames.isNotEmpty ||
+            (collectionKind?.isNotEmpty ?? false);
+
+        expect(
+          hasDirectRichInfo || (parent?.isNotEmpty ?? false),
+          isTrue,
+          reason: '$id has no rich System Info metadata',
+        );
+
+        if (parent != null && parent.isNotEmpty) {
+          expect(
+            definitions.containsKey(parent),
+            isTrue,
+            reason: '$id inherits missing system $parent',
+          );
+        }
+
+        expect(
+          notableGames.every((game) => game.toString().trim().isNotEmpty),
+          isTrue,
+          reason: '$id contains an empty notable game title',
+        );
+        expect(
+          media.every((item) => item.toString().trim().isNotEmpty),
+          isTrue,
+          reason: '$id contains an empty media identifier',
+        );
       }
-    }
-  });
+
+      // Inheritance is intentionally used by hack/variant definitions. Guard
+      // against accidental cycles so a future system-definition update cannot
+      // make SystemInfoCatalog recurse forever.
+      for (final id in definitions.keys) {
+        final seen = <String>{};
+        var current = id;
+        while (true) {
+          expect(seen.add(current), isTrue, reason: 'inheritance cycle at $id');
+          final details = Map<String, dynamic>.from(
+            definitions[current]?['details'] as Map? ?? {},
+          );
+          final parent = details['info_inherits']?.toString();
+          if (parent == null || parent.isEmpty) break;
+          current = parent;
+        }
+      }
+    },
+  );
 }


### PR DESCRIPTION
Conservative maintenance pass focused on readability, consistency, and validation without changing the intended application behavior.

Changes included:
- normalize Dart formatting across the modified iOS-port sources;
- simplify and professionalize comments in iOS Shortcut/JIT, emulator settings, and build workflow code;
- remove the temporary startup diagnostic file writer from `main.dart`;
- resolve all static-analysis findings introduced or exposed by the iOS port;
- avoid `BuildContext` usage across async gaps in emulator synchronization paths;
- remove unused imports and tighten async return handling;
- align the SQLite test schema with the iOS `ios_url_scheme` emulator field;
- update the RetroArch seed test so it only requires a generic iOS RetroArch entry for systems that actually expose a RetroArch definition on iOS;
- keep dependency lock/configuration migrations out of this cleanup.

Validation performed on the final tree:
- Dart formatting: clean;
- `flutter analyze`: **No issues found**;
- full Flutter test suite: **passed** after aligning the stale iOS-specific tests.

The branch has been squashed to a single maintenance commit on top of `main` for a clean public history.