### PR TITLE
Fix iOS build by using stable file_picker

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   external_folder_access:
     path: packages/external_folder_access
     
-  file_picker: ^12.0.0-beta.7
+  file_picker: ^11.0.2
   device_info_plus: ^13.2.0
   package_info_plus: ^10.2.1
   google_fonts: ^8.1.0


### PR DESCRIPTION
Superseded by #6.

The attempted stable `file_picker ^11.0.2` pin cannot resolve with the current `wakelock_plus` dependency because of incompatible `win32` constraints. No changes from this PR should be merged.