### PR TITLE
Fix iOS build file_picker compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   external_folder_access:
     path: packages/external_folder_access
     
-  file_picker: ^12.0.0-beta.7
+  file_picker: 12.0.0-beta.3
   device_info_plus: ^13.2.0
   package_info_plus: ^10.2.1
   google_fonts: ^8.1.0


### PR DESCRIPTION
Fixes the compile errors seen in Build iOS #103 without touching application logic.

`file_picker 12.0.0-beta.4+` introduced new single-file selection behavior and defaults. NeoStation's current picker call sites are written against the earlier `FilePickerResult.files` behavior. Pinning to `12.0.0-beta.3` keeps the existing API while retaining the `win32 6.x` migration required by `wakelock_plus`, unlike the attempted stable 11.0.2 downgrade.

Only `pubspec.yaml` is changed. `main` is untouched pending CI/build validation.