### PR TITLE
Trigger badge workflow when automation changes

### DIFF
--- a/.github/workflows/update-readme-badges.yml
+++ b/.github/workflows/update-readme-badges.yml
@@ -2,6 +2,11 @@ name: Update README badges
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/update-readme-badges.yml'
   schedule:
     - cron: '17 */6 * * *'
   issues:


### PR DESCRIPTION
Adds a narrow `push` trigger for changes to `.github/workflows/update-readme-badges.yml` on `main`.

Purpose: bootstrap-test the protected badge automation immediately after this PR is merged, without creating artificial issues or waiting for the six-hour schedule. Normal badge refresh triggers remain unchanged.