### PR TITLE
Use auto-merge for README badge updates

### DIFF
--- a/.github/workflows/update-readme-badges.yml
+++ b/.github/workflows/update-readme-badges.yml
@@ -223,5 +223,6 @@ jobs:
         run: |
           gh pr merge "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
+            --auto \
             --squash \
             --delete-branch


### PR DESCRIPTION
Updates the README badge automation so the generated badge PR is queued with GitHub auto-merge instead of attempting an immediate merge that the protected `main` ruleset rejects.

The workflow still waits for PR checks, verifies that only badge SVG files are changed, and uses squash merge.