### PR TITLE
Normalize broken import paths

### DIFF
--- a/lib/screens/systems_screen/system_content.dart
+++ b/lib/screens/systems_screen/system_content.dart
@@ -5,8 +5,8 @@ import 'package:neostation/l10n/app_locale.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:provider/provider.dart';
 import 'package:neostation/providers/theme_provider.dart';
+import 'package:neostation/providers/sqlite_config_provider.dart';
 import 'package:neostation/widgets/shimmering_logo.dart';
-import '../../../providers/sqlite_config_provider.dart';
 import 'my_systems_section/my_systems_grid.dart';
 import 'my_systems_section/initial_setup_widget.dart';
 

--- a/lib/widgets/game_view_footer.dart
+++ b/lib/widgets/game_view_footer.dart
@@ -9,10 +9,10 @@ import 'package:neostation/models/game_model.dart';
 import 'package:neostation/models/retro_achievements_game_info.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/themes/app_themes.dart';
+import 'package:neostation/themes/corner_radii.dart';
 import 'package:neostation/utils/game_utils.dart';
 import 'package:neostation/widgets/marquee_text.dart';
 import 'package:neostation/themes/chrome_surface.dart';
-import '../../themes/corner_radii.dart';
 
 /// A reusable footer used by the game grid and carousel views.
 ///


### PR DESCRIPTION
Replaces the two fragile upward-relative imports identified after the repository cleanup with stable package imports.

Changes:
- `lib/screens/systems_screen/system_content.dart`: use `package:neostation/providers/sqlite_config_provider.dart`
- `lib/widgets/game_view_footer.dart`: use `package:neostation/themes/corner_radii.dart`

No ScreenScraper behavior is changed in this PR. The goal is to remove invalid/brittle path traversal from the shared app code and validate the project cleanly before merging.