### PR TITLE
Fix first-run language order and art-pack completion

### DIFF
--- a/lib/providers/neo_assets_provider.dart
+++ b/lib/providers/neo_assets_provider.dart
@@ -84,9 +84,12 @@ class NeoAssetsProvider extends ChangeNotifier {
 
   /// Downloads all required assets for the specified theme and applies it.
   ///
-  /// Existing WebP/GIF packs keep the normal bulk path. If a system has no
-  /// image/GIF background, NeoStation then probes the supported video containers
-  /// so a theme pack may provide `<system>.mp4`, `.m4v` or `.mov` instead.
+  /// Existing WebP/GIF packs keep the normal bulk path. Video backgrounds stay
+  /// supported as an on-demand fallback through [getBackgroundForSystem], but
+  /// are deliberately not probed here after the bulk download reaches 100%.
+  /// Eagerly probing mp4/m4v/mov for every system made the first-run art-pack
+  /// screen appear frozen at 100% while sequential 404/network requests were
+  /// still running in the background.
   Future<void> downloadAndApplyTheme(
     String themeFolder,
     List<String> systemFolderNames,
@@ -123,23 +126,6 @@ class NeoAssetsProvider extends ChangeNotifier {
             },
           );
         }
-      }
-
-      // The upstream asset service historically probes only WebP/GIF. Keep that
-      // fast path untouched and add video as a fallback so existing theme packs
-      // do not change behaviour or precedence.
-      for (final system in plan.systemsToDownload) {
-        final imagePath = NeoAssetsService.resolveBackgroundPathSync(
-          themeFolder,
-          system,
-        );
-        if (imagePath != null && File(imagePath).existsSync()) continue;
-
-        if (!_downloading) {
-          _downloading = true;
-          notifyListeners();
-        }
-        await _getCachedVideoBackground(themeFolder, system);
       }
 
       if (plan.remoteMetadata != null) {

--- a/lib/screens/systems_screen/fork_first_run_onboarding.dart
+++ b/lib/screens/systems_screen/fork_first_run_onboarding.dart
@@ -5,11 +5,15 @@ import 'package:neostation/l10n/fork_onboarding_locale.dart';
 import 'package:neostation/providers/sqlite_config_provider.dart';
 import 'package:provider/provider.dart';
 
-/// One-time fork introduction shown before NeoStation's existing library setup.
+/// Shared preference used to record that the fork's first-run language gate
+/// has already been completed.
+const forkOnboardingCompletedKey = 'neostation_fork_onboarding_v1';
+
+/// One-time language gate shown before NeoStation's existing setup wizard.
 ///
 /// The device language is preselected and applied immediately when supported,
-/// while all twelve application languages remain available. The second page is
-/// therefore rendered directly in the language the user just chose.
+/// while all application languages remain available. Once the user confirms
+/// the choice, the normal NeoStation setup continues in that language.
 class ForkFirstRunOnboarding extends StatefulWidget {
   const ForkFirstRunOnboarding({super.key, required this.onFinished});
 
@@ -21,7 +25,6 @@ class ForkFirstRunOnboarding extends StatefulWidget {
 }
 
 class _ForkFirstRunOnboardingState extends State<ForkFirstRunOnboarding> {
-  int _step = 0;
   late String _selectedLanguage;
   bool _finishing = false;
 
@@ -65,15 +68,10 @@ class _ForkFirstRunOnboardingState extends State<ForkFirstRunOnboarding> {
     await context.read<SqliteConfigProvider>().updateAppLanguage(code);
   }
 
-  Future<void> _continueToWelcome() async {
-    await _applyLanguage(_selectedLanguage);
-    if (!mounted) return;
-    setState(() => _step = 1);
-  }
-
-  Future<void> _finish() async {
+  Future<void> _continue() async {
     if (_finishing) return;
     setState(() => _finishing = true);
+    await _applyLanguage(_selectedLanguage);
     await widget.onFinished();
     if (mounted) setState(() => _finishing = false);
   }
@@ -81,6 +79,7 @@ class _ForkFirstRunOnboardingState extends State<ForkFirstRunOnboarding> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final entries = AppLocale.supportedLanguages.entries.toList();
 
     return SafeArea(
       child: Center(
@@ -88,135 +87,92 @@ class _ForkFirstRunOnboardingState extends State<ForkFirstRunOnboarding> {
           constraints: BoxConstraints(maxWidth: 760.w),
           child: Padding(
             padding: EdgeInsets.symmetric(horizontal: 28.w, vertical: 24.h),
-            child: AnimatedSwitcher(
-              duration: const Duration(milliseconds: 300),
-              child: _step == 0
-                  ? _buildLanguageStep(theme)
-                  : _buildWelcomeStep(theme),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildLanguageStep(ThemeData theme) {
-    final entries = AppLocale.supportedLanguages.entries.toList();
-
-    return Column(
-      key: const ValueKey('fork_language_step'),
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        Icon(
-          Icons.language_rounded,
-          size: 48.r,
-          color: theme.colorScheme.primary,
-        ),
-        SizedBox(height: 14.h),
-        Text(
-          ForkOnboardingLocale.languageTitle(context),
-          textAlign: TextAlign.center,
-          style: theme.textTheme.headlineSmall?.copyWith(
-            fontWeight: FontWeight.w800,
-          ),
-        ),
-        SizedBox(height: 8.h),
-        ConstrainedBox(
-          constraints: BoxConstraints(maxWidth: 620.w),
-          child: Text(
-            ForkOnboardingLocale.languageSubtitle(context),
-            textAlign: TextAlign.center,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
-            ),
-          ),
-        ),
-        SizedBox(height: 22.h),
-        Flexible(
-          child: SingleChildScrollView(
-            child: Wrap(
-              alignment: WrapAlignment.center,
-              spacing: 10.w,
-              runSpacing: 10.h,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                for (final entry in entries)
-                  ChoiceChip(
-                    label: Text(entry.value),
-                    selected: _selectedLanguage == entry.key,
-                    onSelected: (_) => _applyLanguage(entry.key),
-                    selectedColor: theme.colorScheme.primaryContainer,
-                    side: BorderSide(
-                      color: _selectedLanguage == entry.key
-                          ? theme.colorScheme.primary
-                          : theme.colorScheme.outlineVariant,
-                    ),
-                    labelStyle: TextStyle(
-                      color: _selectedLanguage == entry.key
-                          ? theme.colorScheme.onPrimaryContainer
-                          : theme.colorScheme.onSurface,
-                      fontWeight: _selectedLanguage == entry.key
-                          ? FontWeight.w700
-                          : FontWeight.w500,
+                Image.asset(
+                  'assets/images/logo_transparent.png',
+                  width: 78.r,
+                  height: 78.r,
+                ),
+                SizedBox(height: 16.h),
+                Text(
+                  ForkOnboardingLocale.welcomeTitle(context),
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.headlineMedium?.copyWith(
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+                SizedBox(height: 8.h),
+                Text(
+                  ForkOnboardingLocale.languageTitle(context),
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.w800,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+                SizedBox(height: 8.h),
+                ConstrainedBox(
+                  constraints: BoxConstraints(maxWidth: 620.w),
+                  child: Text(
+                    ForkOnboardingLocale.languageSubtitle(context),
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
                     ),
                   ),
+                ),
+                SizedBox(height: 22.h),
+                Flexible(
+                  child: SingleChildScrollView(
+                    child: Wrap(
+                      alignment: WrapAlignment.center,
+                      spacing: 10.w,
+                      runSpacing: 10.h,
+                      children: [
+                        for (final entry in entries)
+                          ChoiceChip(
+                            label: Text(entry.value),
+                            selected: _selectedLanguage == entry.key,
+                            onSelected: _finishing
+                                ? null
+                                : (_) => _applyLanguage(entry.key),
+                            selectedColor: theme.colorScheme.primaryContainer,
+                            side: BorderSide(
+                              color: _selectedLanguage == entry.key
+                                  ? theme.colorScheme.primary
+                                  : theme.colorScheme.outlineVariant,
+                            ),
+                            labelStyle: TextStyle(
+                              color: _selectedLanguage == entry.key
+                                  ? theme.colorScheme.onPrimaryContainer
+                                  : theme.colorScheme.onSurface,
+                              fontWeight: _selectedLanguage == entry.key
+                                  ? FontWeight.w700
+                                  : FontWeight.w500,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+                SizedBox(height: 22.h),
+                FilledButton.icon(
+                  onPressed: _finishing ? null : _continue,
+                  icon: _finishing
+                      ? SizedBox(
+                          width: 16.r,
+                          height: 16.r,
+                          child: const CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.arrow_forward_rounded),
+                  label: Text(ForkOnboardingLocale.continueLabel(context)),
+                ),
               ],
             ),
           ),
         ),
-        SizedBox(height: 22.h),
-        FilledButton.icon(
-          onPressed: _continueToWelcome,
-          icon: const Icon(Icons.arrow_forward_rounded),
-          label: Text(ForkOnboardingLocale.continueLabel(context)),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildWelcomeStep(ThemeData theme) {
-    return SingleChildScrollView(
-      key: const ValueKey('fork_welcome_step'),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Image.asset(
-            'assets/images/logo_transparent.png',
-            width: 92.r,
-            height: 92.r,
-          ),
-          SizedBox(height: 18.h),
-          Text(
-            ForkOnboardingLocale.welcomeTitle(context),
-            textAlign: TextAlign.center,
-            style: theme.textTheme.headlineMedium?.copyWith(
-              fontWeight: FontWeight.w900,
-            ),
-          ),
-          SizedBox(height: 14.h),
-          ConstrainedBox(
-            constraints: BoxConstraints(maxWidth: 560.w),
-            child: Text(
-              ForkOnboardingLocale.welcomeBody(context),
-              textAlign: TextAlign.center,
-              style: theme.textTheme.bodyLarge?.copyWith(
-                height: 1.45,
-                color: theme.colorScheme.onSurface.withValues(alpha: 0.78),
-              ),
-            ),
-          ),
-          SizedBox(height: 28.h),
-          FilledButton.icon(
-            onPressed: _finishing ? null : _finish,
-            icon: _finishing
-                ? SizedBox(
-                    width: 16.r,
-                    height: 16.r,
-                    child: const CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(Icons.sports_esports_rounded),
-            label: Text(ForkOnboardingLocale.startLabel(context)),
-          ),
-        ],
       ),
     );
   }

--- a/lib/screens/systems_screen/system_content.dart
+++ b/lib/screens/systems_screen/system_content.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:neostation/l10n/app_locale.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:neostation/providers/theme_provider.dart';
 import 'package:neostation/providers/sqlite_config_provider.dart';
 import 'package:neostation/services/home_music_service.dart';
@@ -12,7 +11,6 @@ import 'package:neostation/widgets/shimmering_logo.dart';
 import 'my_systems_section/my_systems_grid.dart';
 import 'my_systems_section/initial_setup_widget.dart';
 import 'custom_main_menu_background.dart';
-import 'fork_first_run_onboarding.dart';
 
 /// Orchestrator for the 'Systems' tab content.
 ///
@@ -31,86 +29,16 @@ class SystemContent extends StatefulWidget {
 
 class _SystemContentState extends State<SystemContent> {
   static const _minSplashDuration = Duration(milliseconds: 2500);
-  static const _forkOnboardingKey = 'neostation_fork_onboarding_v1';
 
   DateTime? _splashShownAt;
   Timer? _releaseTimer;
   bool? _lastHomeMusicActive;
-
-  bool _onboardingCheckStarted = false;
-  bool _forkOnboardingResolved = false;
-  bool _showForkOnboarding = false;
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (!_onboardingCheckStarted) {
-      _onboardingCheckStarted = true;
-      unawaited(_resolveForkOnboarding());
-    }
-  }
 
   @override
   void dispose() {
     _releaseTimer?.cancel();
     unawaited(HomeMusicService().setMainMenuActive(false));
     super.dispose();
-  }
-
-  /// Decides whether this installation should see the fork introduction.
-  ///
-  /// Existing NeoStation users upgrading to this fork are silently marked as
-  /// migrated when they already have setup history, so the new welcome flow is
-  /// reserved for genuinely fresh installs rather than interrupting upgrades.
-  Future<void> _resolveForkOnboarding() async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      final alreadyCompleted = prefs.getBool(_forkOnboardingKey) ?? false;
-
-      if (alreadyCompleted) {
-        if (mounted) {
-          setState(() {
-            _forkOnboardingResolved = true;
-            _showForkOnboarding = false;
-          });
-        }
-        return;
-      }
-
-      if (!mounted) return;
-      final configProvider = context.read<SqliteConfigProvider>();
-      final existingInstall =
-          configProvider.config.setupCompleted ||
-          configProvider.hasDetectedSystems ||
-          configProvider.config.lastScan != null;
-
-      if (existingInstall) {
-        await prefs.setBool(_forkOnboardingKey, true);
-      }
-
-      if (mounted) {
-        setState(() {
-          _forkOnboardingResolved = true;
-          _showForkOnboarding = !existingInstall;
-        });
-      }
-    } catch (_) {
-      // A preferences failure should never trap the application before its
-      // normal setup. Skip the optional introduction for this launch.
-      if (mounted) {
-        setState(() {
-          _forkOnboardingResolved = true;
-          _showForkOnboarding = false;
-        });
-      }
-    }
-  }
-
-  Future<void> _completeForkOnboarding() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_forkOnboardingKey, true);
-    if (!mounted) return;
-    setState(() => _showForkOnboarding = false);
   }
 
   bool _holdSplash(bool isLoading) {
@@ -153,20 +81,15 @@ class _SystemContentState extends State<SystemContent> {
     return Consumer2<SqliteConfigProvider, ThemeProvider>(
       builder: (context, configProvider, themeProvider, child) {
         final isLoading = configProvider.isLoading || configProvider.isScanning;
-        final normalSplash = isLoading || _holdSplash(isLoading);
-        final showSplash = normalSplash || !_forkOnboardingResolved;
-        final showForkOnboarding =
-            !showSplash && _forkOnboardingResolved && _showForkOnboarding;
+        final showSplash = isLoading || _holdSplash(isLoading);
 
         final showInitialSetup =
             !showSplash &&
-            !showForkOnboarding &&
             !configProvider.hasDetectedSystems &&
             configProvider.scanCompleted;
 
         final showContent =
             !showSplash &&
-            !showForkOnboarding &&
             configProvider.scanCompleted &&
             !showInitialSetup;
 
@@ -179,16 +102,9 @@ class _SystemContentState extends State<SystemContent> {
             key: const ValueKey('splash'),
             child: _buildSplash(context, configProvider),
           );
-        } else if (showForkOnboarding) {
-          phase = KeyedSubtree(
-            key: const ValueKey('fork_onboarding'),
-            child: ForkFirstRunOnboarding(
-              onFinished: _completeForkOnboarding,
-            ),
-          );
         } else if (showInitialSetup) {
-          phase = KeyedSubtree(
-            key: const ValueKey('setup'),
+          phase = const KeyedSubtree(
+            key: ValueKey('setup'),
             child: InitialSetupWidget(),
           );
         } else if (showContent) {
@@ -209,7 +125,7 @@ class _SystemContentState extends State<SystemContent> {
         );
 
         // Only the actual Systems main menu receives the custom background.
-        // Splash/setup/onboarding screens and pushed playlists remain unchanged.
+        // Splash/setup screens and pushed playlists remain unchanged.
         final customBackground = showContent
             ? themeProvider.customBackgroundPath
             : null;

--- a/lib/widgets/permission_check_wrapper.dart
+++ b/lib/widgets/permission_check_wrapper.dart
@@ -3,10 +3,11 @@ import 'package:provider/provider.dart';
 import 'package:neostation/services/logger_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../providers/sqlite_config_provider.dart';
+import '../screens/systems_screen/fork_first_run_onboarding.dart';
 import 'setup_wizard.dart';
 import 'shimmering_logo.dart';
 
-/// Widget that checks the initial configuration and shows the wizard if necessary
+/// Widget that checks the initial configuration and shows the first-run flow if necessary.
 class PermissionCheckWrapper extends StatefulWidget {
   final Widget child;
 
@@ -21,6 +22,7 @@ class PermissionCheckWrapper extends StatefulWidget {
 class _PermissionCheckWrapperState extends State<PermissionCheckWrapper> {
   bool _needsSetup = false;
   bool _isChecking = true;
+  bool _showForkLanguageGate = false;
 
   static final _log = LoggerService.instance;
 
@@ -28,23 +30,26 @@ class _PermissionCheckWrapperState extends State<PermissionCheckWrapper> {
   void initState() {
     super.initState();
 
-    // Check whether initial configuration is needed
+    // Check whether initial configuration is needed.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _checkInitialSetup();
     });
   }
 
-  static const String setupCompletedKey = 'setup_completed_prefs';
-
   Future<void> _checkInitialSetup() async {
     try {
-      // Fast-path: SharedPreferences flag survives SD-card unavailability and
-      // early-launcher boot races. If set, skip the wizard unconditionally.
       final prefs = await SharedPreferences.getInstance();
+
+      // Fast-path: this flag survives SD-card unavailability and early-launcher
+      // boot races. Existing installations must never be interrupted by the
+      // new first-run language gate.
       if (prefs.getBool(PermissionCheckWrapper.setupCompletedKey) == true) {
+        await prefs.setBool(forkOnboardingCompletedKey, true);
+        if (!mounted) return;
         _pushWizardActive(false);
         setState(() {
           _needsSetup = false;
+          _showForkLanguageGate = false;
           _isChecking = false;
         });
         return;
@@ -64,25 +69,39 @@ class _PermissionCheckWrapperState extends State<PermissionCheckWrapper> {
       final setupCompleted = configProvider.config.setupCompleted;
 
       if (hasRomFolder || setupCompleted) {
-        // Backfill the SharedPreferences flag for existing users upgrading.
+        // Backfill both preferences for users upgrading from an older build.
         await prefs.setBool(PermissionCheckWrapper.setupCompletedKey, true);
+        await prefs.setBool(forkOnboardingCompletedKey, true);
+        if (!mounted) return;
         _pushWizardActive(false);
         setState(() {
           _needsSetup = false;
+          _showForkLanguageGate = false;
           _isChecking = false;
         });
-      } else {
-        _pushWizardActive(true);
-        setState(() {
-          _needsSetup = true;
-          _isChecking = false;
-        });
+        return;
       }
+
+      // Genuinely fresh install. The fork language choice is now the very first
+      // interactive screen. If it was already confirmed before an interrupted
+      // setup, resume directly in NeoStation's normal SetupWizard instead.
+      final languageGateCompleted =
+          prefs.getBool(forkOnboardingCompletedKey) ?? false;
+
+      if (!mounted) return;
+      _pushWizardActive(true);
+      setState(() {
+        _needsSetup = true;
+        _showForkLanguageGate = !languageGateCompleted;
+        _isChecking = false;
+      });
     } catch (e) {
       _log.e('Error checking initial setup: $e');
+      if (!mounted) return;
       _pushWizardActive(false);
       setState(() {
         _needsSetup = false;
+        _showForkLanguageGate = false;
         _isChecking = false;
       });
     }
@@ -100,6 +119,20 @@ class _PermissionCheckWrapperState extends State<PermissionCheckWrapper> {
     ).setSetupWizardActive(active);
   }
 
+  Future<void> _completeForkLanguageGate() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(forkOnboardingCompletedKey, true);
+    } catch (e) {
+      // A preference write failure must not trap the user before setup. The
+      // language itself is already persisted by SqliteConfigProvider.
+      _log.w('Could not persist first-run language gate state: $e');
+    }
+
+    if (!mounted) return;
+    setState(() => _showForkLanguageGate = false);
+  }
+
   void _completeSetup() async {
     final configProvider = Provider.of<SqliteConfigProvider>(
       context,
@@ -113,10 +146,13 @@ class _PermissionCheckWrapperState extends State<PermissionCheckWrapper> {
     // Persist flag to SharedPreferences so the wizard is never shown again
     // even if the SQLite DB is temporarily inaccessible (e.g. SD card not ready).
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(setupCompletedKey, true);
+    await prefs.setBool(PermissionCheckWrapper.setupCompletedKey, true);
+    await prefs.setBool(forkOnboardingCompletedKey, true);
 
+    if (!mounted) return;
     setState(() {
       _needsSetup = false;
+      _showForkLanguageGate = false;
     });
   }
 
@@ -129,11 +165,20 @@ class _PermissionCheckWrapperState extends State<PermissionCheckWrapper> {
     }
 
     if (_needsSetup) {
-      // Show configuration wizard
+      if (_showForkLanguageGate) {
+        return Scaffold(
+          body: ForkFirstRunOnboarding(
+            onFinished: _completeForkLanguageGate,
+          ),
+        );
+      }
+
+      // Continue with NeoStation's original configuration wizard in the
+      // language the user selected on the preceding screen.
       return SetupWizard(onComplete: _completeSetup);
     }
 
-    // Show the normal app
+    // Show the normal app.
     return widget.child;
   }
 }


### PR DESCRIPTION
Moves the fork language choice ahead of NeoStation's existing SetupWizard on genuinely fresh installs, removes the duplicate post-setup onboarding gate, and stops eager video fallback probes from making the art-pack step appear stuck at 100%. Existing installs are backfilled and remain uninterrupted. Video backgrounds remain supported lazily when needed.