### PR TITLE
Bump NeoStation build to 125

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,62 +19,99 @@ environment:
   sdk: '>=3.9.2'
 
 dependencies:
-  archive: ^4.0.7
-  cached_network_image: ^3.4.1
-  crypto: ^3.0.7
-  cupertino_icons: ^1.0.8
-  device_apps:
-    git:
-      url: https://github.com/franzsilva/device_apps
-      ref: f90baa40979f98f43970899a19e363cfb3f082e7
-  device_info_plus: ^12.1.0
-  dio: ^5.9.0
-  equatable: ^2.0.7
-  external_folder_access: ^1.0.0
-  file_picker: 12.0.0-beta.3
   flutter:
     sdk: flutter
-  flutter_7zip: ^1.0.0
-  flutter_localization: ^0.3.3
-  flutter_screenutil: ^5.9.3
-  flutter_soloud: ^4.0.12
-  flutter_svg: ^2.2.1
-  fullscreen_window: ^1.2.1
-  gamepads: ^0.2.2
-  google_fonts: ^6.3.2
-  http: ^1.5.0
-  image: ^4.5.4
-  intl: ^0.20.2
-  material_symbols_icons: ^4.2815.0
-  package_info_plus: ^8.3.1
-  path: ^1.9.1
-  path_provider: ^2.1.5
-  permission_handler: ^12.0.1
+  flutter_localizations:
+    sdk: flutter
+
+  gamepads:
+    path: packages/gamepads
+  flutter_7zip:
+    path: packages/flutter_7zip
+  external_folder_access:
+    path: packages/external_folder_access
+    
+  file_picker: 12.0.0-beta.3
+  device_info_plus: ^13.2.0
+  package_info_plus: ^10.2.1
+  google_fonts: ^8.1.0
+  material_symbols_icons: ^4.2960.0
   provider: ^6.1.5+1
-  shared_preferences: ^2.5.3
-  sqflite_common_ffi: ^2.3.6
-  sqlite3_flutter_libs: ^0.5.40
+  battery_plus: ^7.1.1
+  path: ^1.9.1
+  path_provider: ^2.1.6
+  xml: ^6.6.1
+  video_player: ^2.13.0
+  fvp: ^0.37.3
+  flutter_secure_storage: ^10.3.1
+  shared_preferences: ^2.5.5
+  http: ^1.6.0
+  crypto: ^3.0.7
+  archive: ^4.0.9
+  web_socket_channel: ^3.0.3
   url_launcher: ^6.3.2
-  video_player: ^2.10.0
-  wakelock_plus: ^1.3.2
-  window_manager: ^0.5.1
+  share_plus: ^13.0.0
+  widget_mask: ^1.0.0
+  flutter_screenutil: 5.9.3
+  window_manager: ^0.5.2
+  permission_handler: ^12.0.3
+  pointycastle: ^4.0.0
+  sqlite3: ^3.5.0
+  fullscreen_window: ^1.2.1
+  animated_toggle_switch: ^0.8.7
+  marquee: ^2.3.0
+  logger: ^2.7.0
+  sub_screen: ^0.1.9
+  flutter_soloud: ^4.0.12
+  audio_metadata_reader: ^1.7.1
+  wakelock_plus: ^1.7.0
+  flutter_localization: ^0.4.1
+  flutter_tilt: ^4.1.0
+  pdfrx: ^2.4.6
 
 dev_dependencies:
-  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
+  flutter_lints: ^6.0.0
+  flutter_launcher_icons: "^0.14.4"
+  mocktail: ^1.0.5
+
+flutter_launcher_icons:
+  android: "launcher_icon"
+  ios: true
+  image_path: "assets/images/logo.png"
+  adaptive_icon_background: "assets/images/logo-background.png"
+  adaptive_icon_foreground: "assets/images/logo-foreground.png"
+  adaptive_icon_monochrome: "assets/images/logo-monochrome.png"
+  adaptive_icon_foreground_inset: 20
+  min_sdk_android: 21 # android min sdk min:16, default 21 
+  windows:
+    generate: true
+    image_path: "assets/images/logo.png"
+    icon_size: 48
+  macos:
+    generate: true
+    image_path: "assets/images/logo.png"
+  linux:
+    generate: true
+    image_path: "assets/images/logo.png"
 
 flutter:
   uses-material-design: true
-
   assets:
     - assets/images/
+    - assets/images/logos/
+    - assets/images/emulators/
     - assets/images/gamepad/
-    - assets/images/logo/
-    - assets/l10n/
-    - assets/sounds/
-    - assets/sql/
-    - assets/system_backgrounds/
-    - assets/system_icons/
-    - assets/system_logos/
+    - assets/images/icons/
+    - assets/images/music/
+    - assets/manifest.json
+    - assets/data/
     - assets/systems/
+    - assets/sounds/
+  shaders:
+    - assets/shaders/stripes.frag
+    - assets/shaders/fluid.frag
+    - assets/shaders/gif_player.frag
+    - assets/shaders/music_visualizer.frag
+    - assets/shaders/music_card_background.frag

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,105 +13,68 @@ workspace:
   - packages/gamepads_platform_interface
   - packages/gamepads_windows
 
-version: 0.9.9+124
+version: 0.9.9+125
 
 environment:
   sdk: '>=3.9.2'
 
 dependencies:
+  archive: ^4.0.7
+  cached_network_image: ^3.4.1
+  crypto: ^3.0.7
+  cupertino_icons: ^1.0.8
+  device_apps:
+    git:
+      url: https://github.com/franzsilva/device_apps
+      ref: f90baa40979f98f43970899a19e363cfb3f082e7
+  device_info_plus: ^12.1.0
+  dio: ^5.9.0
+  equatable: ^2.0.7
+  external_folder_access: ^1.0.0
+  file_picker: 12.0.0-beta.3
   flutter:
     sdk: flutter
-  flutter_localizations:
-    sdk: flutter
-
-  gamepads:
-    path: packages/gamepads
-  flutter_7zip:
-    path: packages/flutter_7zip
-  external_folder_access:
-    path: packages/external_folder_access
-    
-  file_picker: 12.0.0-beta.3
-  device_info_plus: ^13.2.0
-  package_info_plus: ^10.2.1
-  google_fonts: ^8.1.0
-  material_symbols_icons: ^4.2960.0
-  provider: ^6.1.5+1
-  battery_plus: ^7.1.1
-  path: ^1.9.1
-  path_provider: ^2.1.6
-  xml: ^6.6.1
-  video_player: ^2.13.0
-  fvp: ^0.37.3
-  flutter_secure_storage: ^10.3.1
-  shared_preferences: ^2.5.5
-  http: ^1.6.0
-  crypto: ^3.0.7
-  archive: ^4.0.9
-  web_socket_channel: ^3.0.3
-  url_launcher: ^6.3.2
-  share_plus: ^13.0.0
-  widget_mask: ^1.0.0
-  flutter_screenutil: 5.9.3
-  window_manager: ^0.5.2
-  permission_handler: ^12.0.3
-  pointycastle: ^4.0.0
-  sqlite3: ^3.5.0
-  fullscreen_window: ^1.2.1
-  animated_toggle_switch: ^0.8.7
-  marquee: ^2.3.0
-  logger: ^2.7.0
-  sub_screen: ^0.1.9
+  flutter_7zip: ^1.0.0
+  flutter_localization: ^0.3.3
+  flutter_screenutil: ^5.9.3
   flutter_soloud: ^4.0.12
-  audio_metadata_reader: ^1.7.1
-  wakelock_plus: ^1.7.0
-  flutter_localization: ^0.4.1
-  flutter_tilt: ^4.1.0
-  pdfrx: ^2.4.6
+  flutter_svg: ^2.2.1
+  fullscreen_window: ^1.2.1
+  gamepads: ^0.2.2
+  google_fonts: ^6.3.2
+  http: ^1.5.0
+  image: ^4.5.4
+  intl: ^0.20.2
+  material_symbols_icons: ^4.2815.0
+  package_info_plus: ^8.3.1
+  path: ^1.9.1
+  path_provider: ^2.1.5
+  permission_handler: ^12.0.1
+  provider: ^6.1.5+1
+  shared_preferences: ^2.5.3
+  sqflite_common_ffi: ^2.3.6
+  sqlite3_flutter_libs: ^0.5.40
+  url_launcher: ^6.3.2
+  video_player: ^2.10.0
+  wakelock_plus: ^1.3.2
+  window_manager: ^0.5.1
 
 dev_dependencies:
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
-  flutter_lints: ^6.0.0
-  flutter_launcher_icons: "^0.14.4"
-  mocktail: ^1.0.5
-
-flutter_launcher_icons:
-  android: "launcher_icon"
-  ios: true
-  image_path: "assets/images/logo.png"
-  adaptive_icon_background: "assets/images/logo-background.png"
-  adaptive_icon_foreground: "assets/images/logo-foreground.png"
-  adaptive_icon_monochrome: "assets/images/logo-monochrome.png"
-  adaptive_icon_foreground_inset: 20
-  min_sdk_android: 21 # android min sdk min:16, default 21 
-  windows:
-    generate: true
-    image_path: "assets/images/logo.png"
-    icon_size: 48
-  macos:
-    generate: true
-    image_path: "assets/images/logo.png"
-  linux:
-    generate: true
-    image_path: "assets/images/logo.png"
 
 flutter:
   uses-material-design: true
+
   assets:
     - assets/images/
-    - assets/images/logos/
-    - assets/images/emulators/
     - assets/images/gamepad/
-    - assets/images/icons/
-    - assets/images/music/
-    - assets/manifest.json
-    - assets/data/
-    - assets/systems/
+    - assets/images/logo/
+    - assets/l10n/
     - assets/sounds/
-  shaders:
-    - assets/shaders/stripes.frag
-    - assets/shaders/fluid.frag
-    - assets/shaders/gif_player.frag
-    - assets/shaders/music_visualizer.frag
-    - assets/shaders/music_card_background.frag
+    - assets/sql/
+    - assets/system_backgrounds/
+    - assets/system_icons/
+    - assets/system_logos/
+    - assets/systems/


### PR DESCRIPTION
Increment the build number only so the corrected iOS package is unambiguously newer than build 124 during sideloading.