### PR TITLE
Validate and finalize RPCS3 stage 3

### DIFF
--- a/.github/workflows/rpcs3-stage3-auto-final.yml
+++ b/.github/workflows/rpcs3-stage3-auto-final.yml
@@ -1,0 +1,195 @@
+name: Finalize RPCS3 stage 3
+
+on:
+  pull_request:
+    branches:
+      - feature/rpcs3-stage3
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  GH_TOKEN: ${{ github.token }}
+
+concurrency:
+  group: rpcs3-stage3-auto-final
+  cancel-in-progress: true
+
+jobs:
+  finalize:
+    name: Patch, analyze, test and merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout feature branch
+        uses: actions/checkout@v7
+        with:
+          ref: feature/rpcs3-stage3
+          fetch-depth: 0
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2.23.0
+        with:
+          channel: stable
+          cache: true
+
+      - name: Resolve dependencies
+        run: flutter pub get
+
+      - name: Prefer scraped names for RPCS3 virtual titles
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+
+          model_path = Path('lib/models/game_model.dart')
+          model = model_path.read_text(encoding='utf-8')
+          old_factory = """  factory GameModel.fromDatabaseModel(DatabaseGameModel db) {
+    return GameModel(
+      romname: db.romname,
+      realname: db.realName ?? db.filename,
+      name: db.titleName ?? db.realName ?? db.filename,
+"""
+          new_factory = """  factory GameModel.fromDatabaseModel(DatabaseGameModel db) {
+    final scrapedName = db.screenscraperRealName?.trim();
+    final isRpcs3Virtual = db.romPath.toLowerCase().startsWith(
+      'rpcs3-library://',
+    );
+    final displayName =
+        isRpcs3Virtual && scrapedName != null && scrapedName.isNotEmpty
+        ? scrapedName
+        : db.titleName ?? db.realName ?? db.filename;
+
+    return GameModel(
+      romname: db.romname,
+      realname: db.realName ?? db.filename,
+      name: displayName,
+"""
+          if new_factory not in model:
+              if old_factory not in model:
+                  raise SystemExit('GameModel database factory marker not found')
+              model = model.replace(old_factory, new_factory, 1)
+              model_path.write_text(model, encoding='utf-8')
+
+          test_path = Path('test/rpcs3_stage3_test.dart')
+          test = test_path.read_text(encoding='utf-8')
+          import_marker = "import 'package:flutter_test/flutter_test.dart';\n"
+          extra_imports = (
+              "import 'package:neostation/models/database_game_model.dart';\n"
+              "import 'package:neostation/models/game_model.dart';\n"
+          )
+          if extra_imports not in test:
+              if import_marker not in test:
+                  raise SystemExit('RPCS3 test import marker not found')
+              test = test.replace(import_marker, import_marker + extra_imports, 1)
+
+          test_name = "scraped RPCS3 name replaces the raw Title ID"
+          if test_name not in test:
+              insertion = r'''
+
+    test('scraped RPCS3 name replaces the raw Title ID', () {
+      final game = GameModel.fromDatabaseModel(
+        DatabaseGameModel(
+          filename: 'BLES00113',
+          romPath: 'rpcs3-library://game?title-id=BLES00113',
+          titleId: 'BLES00113',
+          titleName: 'BLES00113',
+          screenscraperRealName: 'LittleBigPlanet',
+        ),
+      );
+
+      expect(game.name, 'LittleBigPlanet');
+      expect(game.titleId, 'BLES00113');
+    });
+
+    test('regular games keep their existing internal-title precedence', () {
+      final game = GameModel.fromDatabaseModel(
+        DatabaseGameModel(
+          filename: 'game.iso',
+          romPath: '/roms/ps3/game.iso',
+          titleName: 'Internal Header Title',
+          screenscraperRealName: 'Scraped Name',
+        ),
+      );
+
+      expect(game.name, 'Internal Header Title');
+    });
+'''
+              closing = '\n  });\n}\n'
+              if not test.endswith(closing):
+                  raise SystemExit('RPCS3 test group closing marker not found')
+              test = test[:-len(closing)] + insertion + closing
+
+          test_path.write_text(test, encoding='utf-8')
+          PY
+
+      - name: Format changed Dart files
+        run: dart format lib/models/game_model.dart test/rpcs3_stage3_test.dart
+
+      - name: Verify final implementation
+        run: |
+          set -euo pipefail
+          grep -Fq "version: 0.9.9+131" pubspec.yaml
+          grep -Fq "restoreAfterDatabaseReady" lib/services/rpcs3_library_service.dart
+          grep -Fq "virtualDetections" lib/data/datasources/sqlite_service.dart
+          grep -Fq "serialnum" lib/services/screenscraper_service.dart
+          grep -Fq "screenscraperRealName" lib/models/game_model.dart
+          grep -Fq "scraped RPCS3 name replaces the raw Title ID" test/rpcs3_stage3_test.dart
+          grep -Fq "openAppAfterJitPreflight" packages/external_folder_access/lib/external_folder_access.dart
+          grep -Fq "Rpcs3LaunchService.launchTitle" lib/services/game/game_launch_service.dart
+          grep -Fq "CFE15492-152B-331E-8395-9A3CF9AC8A9F" lib/services/rpcs3_launch_service.dart
+          grep -Fq "NEOSTATION_RPC_BOOT_REQUEST" assets/data/rpcs3_stikdebug_launch.js
+
+      - name: Analyze Dart and Flutter code
+        run: flutter analyze --no-fatal-infos --no-fatal-warnings
+
+      - name: Run dedicated RPCS3 tests
+        run: flutter test test/rpcs3_library_service_test.dart test/rpcs3_stage3_test.dart
+
+      - name: Run full Flutter test suite
+        run: flutter test
+
+      - name: Commit final validated source
+        run: |
+          set -euo pipefail
+          git checkout -- pubspec.lock analysis_options.yaml || true
+          git checkout -- packages/flutter_7zip/analysis_options.yaml || true
+          git checkout -- packages/gamepads/analysis_options.yaml || true
+          rm -f .github/workflows/rpcs3-stage3-v2-once.yml
+          rm -f .github/workflows/rpcs3-stage3-final-trigger.yml
+          rm -f _rpcs3_stage3_pr_marker
+          rm -f .github/ISSUE_TEMPLATE/_noop_should_not_exist
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "fix(ios): display scraped RPCS3 game names"
+            git push origin HEAD:feature/rpcs3-stage3
+          fi
+
+      - name: Merge validated RPCS3 stage 3 pull request
+        env:
+          VALIDATION_PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh pr reopen 42 --repo TarbleFR/neostation-ios || true
+          gh pr ready 42 --repo TarbleFR/neostation-ios || true
+          for attempt in $(seq 1 12); do
+            if gh pr merge 42 \
+              --repo TarbleFR/neostation-ios \
+              --squash \
+              --subject "feat(ios): persist, scrape and launch RPCS3 titles" \
+              --body "Restore the RPCS3 library after restart, scrape PS3 titles by serial/Title ID, display scraped names, and add a build-fingerprinted experimental StikDebug launch bridge for RPCS3 iOS. Validated with Flutter analysis, dedicated RPCS3 tests and the full Flutter test suite."; then
+              break
+            fi
+            if [ "$attempt" -eq 12 ]; then
+              echo "RPCS3 PR could not be merged after validation." >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          gh pr close "$VALIDATION_PR" --repo TarbleFR/neostation-ios || true
+          gh pr close 43 --repo TarbleFR/neostation-ios || true


### PR DESCRIPTION
Temporary same-repository validation PR. It checks out `feature/rpcs3-stage3`, applies the final scraped-name polish, runs Flutter analysis, dedicated RPCS3 tests and the full suite, then cleans temporary automation and squash-merges PR #42 only if every validation step succeeds.