### PR TITLE
Directly invoke RPCS3 Start Shortcut after JIT

### DIFF
--- a/docs/RPCS3_SHORTCUT_SWITCH_CONTROL.md
+++ b/docs/RPCS3_SHORTCUT_SWITCH_CONTROL.md
@@ -1,31 +1,27 @@
-# RPCS3 iOS — optional Switch Control auto-Start
+# RPCS3 iOS — Switch Control auto-Start
 
-NeoStation Build 140 removes the experimental RPCS3Core memory-injection / second-pass StikDebug launcher. The stable PS3 launch path is now:
+NeoStation keeps the experimental RPCS3Core memory-injection / second-pass StikDebug launcher retired. The current PS3 launch path is intentionally simpler:
 
-1. NeoStation asks StikDebug to enable JIT for RPCS3 with `universal.js`.
-2. RPCS3 opens normally.
-3. Without any automation, the user presses **Start / Commencer** and chooses a game in RPCS3.
+1. NeoStation starts the normal StikDebug Universal JIT flow for RPCS3 with `universal.js`.
+2. The native iOS preflight helper keeps a short background task alive and waits about 8 seconds for the JIT/RPCS3 foreground transition.
+3. NeoStation then opens Apple's `shortcuts://run-shortcut` URL for the exact helper named `NeoStation+RPCS3+Start`.
+4. The Shortcut selects the `NeoStation RPCS3` Switch Control set and activates the configured `Full Screen` switch.
+5. The Switch Control recipe/macro runs its custom gesture and taps RPCS3's **Start / Commencer** button.
 
-An optional **device-local** iOS automation can try to press RPCS3's Start button automatically when RPCS3 opens. This is intentionally separate from NeoStation because iOS does not provide third-party apps with a public API to create Switch Control switches, recipes, saved gestures, or Personal Automations.
+The Accessibility configuration is still device-local. iOS does not give NeoStation a public API to create the user's Switch Control switch, switch set, recipe/macro, or custom tap gesture, so those pieces must be configured once on the iPhone.
 
-## Why the automation cannot be pre-bound by NeoStation
-
-The tap coordinate and the Switch Control switch/recipe belong to the user's Accessibility configuration. A shared Shortcut cannot safely create or bind those private device entities for another user. NeoStation therefore opens Apple's official Shortcut editor from its setup service, but the following one-time Accessibility setup must be done on the iPhone.
-
-## 1. Create the Switch Control gesture
+## 1. Configure Switch Control
 
 On the iPhone:
 
 1. Open **Settings > Accessibility > Switch Control > Switches**.
-2. Add a local switch. A convenient test source is **Screen > Full Screen**.
-3. Assign a normal action such as **Select Item** for the base switch.
-4. Go back to **Switch Control > Recipes**.
-5. Create a recipe named **NeoStation RPCS3 Start**.
-6. Assign the switch created above to a **Custom Gesture**.
-7. Record a single tap at the exact location of RPCS3's **Start / Commencer** button, using the same orientation in which RPCS3 is normally opened.
-8. Save the recipe.
+2. Add **Screen > Full Screen** and use a normal base action such as **Select Item**.
+3. Create a recipe/macro named **NeoStation RPCS3 Start**.
+4. Assign **Full Screen** to a **Custom Gesture**.
+5. Record a single tap at the exact position of RPCS3's **Start / Commencer** button, using the same device orientation in which RPCS3 opens.
+6. Create a Switch Control set named **NeoStation RPCS3** and keep the configured Full Screen switch/recipe in that set.
 
-If the device exposes **Switch Sets**, a dedicated set named `NeoStation RPCS3` can be created to isolate this switch/recipe from normal Switch Control usage.
+The exact labels can vary slightly by iOS language/version. On iOS 27, the configuration observed during NeoStation testing exposes the switch set, `Full Screen` switch state, and recipe/macro directly.
 
 ## 2. Create the Shortcut
 
@@ -33,38 +29,29 @@ Create a Shortcut named exactly:
 
 `NeoStation+RPCS3+Start`
 
-Recommended actions:
+For the current iOS 27 setup, use these actions in this order:
 
-1. **Set Switch Control** -> On.
-2. If available on the installed iOS version, **Set Switch Control Switch Set** -> `NeoStation RPCS3`.
-3. **Set Switch Control Switch State** -> select the switch used by the recipe and toggle/activate it.
-4. **Set Switch Control** -> Off.
+1. **Set Switch Control Switch Set** -> `NeoStation RPCS3`.
+2. **Set Switch Control Switch State** -> activate `Full Screen`.
+3. **Wait** -> 1 second.
+4. **Set Switch Control Switch State** -> deactivate `Full Screen`.
 
-If the tap happens before RPCS3 has rendered its Start screen, add the shortest Wait action that is actually required on that device. Do not increase it unless on-device testing shows that RPCS3 is not ready yet.
+The 1-second wait is only there to keep the switch active briefly enough for the configured recipe/gesture to run. Adjust it only if on-device testing proves that a different delay is required.
 
-The important experiment is whether **Set Switch Control Switch State** causes the assigned recipe/custom gesture to execute on the installed iOS build. Apple documents that the action can manipulate configured Switch Control switches, but does not promise that every switch source/recipe combination will synthesize a gesture.
+## 3. Personal Automation is not required
 
-## 3. Create the Personal Automation
+Older NeoStation builds relied on a **Personal Automation** triggered when RPCS3 opened. Builds containing the direct Shortcut handoff now invoke `NeoStation+RPCS3+Start` themselves after the JIT warm-up, so that Personal Automation is **not required**.
 
-In **Shortcuts > Automation**:
+If an old Personal Automation such as **When RPCS3 is opened -> Run NeoStation+RPCS3+Start** is still enabled, disable it before testing the direct NeoStation path. Otherwise the Shortcut can run twice.
 
-1. Create a new Personal Automation.
-2. Choose **App**.
-3. Select **RPCS3**.
-4. Choose **Is Opened**.
-5. Select **Run Immediately** when that option is available.
-6. Add **Run Shortcut** -> `NeoStation+RPCS3+Start`.
+## Expected path
 
-This event-based trigger is preferred over NeoStation timers: the shortcut starts because iOS reports that RPCS3 actually opened.
+`NeoStation -> StikDebug / universal.js -> RPCS3 -> NeoStation+RPCS3+Start -> Switch Control -> Start / Commencer`
 
-## Expected outcomes
+The selected RPCS3 Title ID is also passed to the Shortcut as optional text input for diagnostics/future revisions. The current Switch Control helper does not need to consume that input.
 
-### Automation works
+## On-device fallback
 
-NeoStation -> StikDebug -> RPCS3 -> Switch Control gesture -> Start screen is pressed automatically.
+The final foreground behavior of Apple's Shortcuts URL scheme can vary by iOS release. If on-device testing shows that running the Shortcut leaves the Shortcuts app in the foreground when the custom gesture fires, add an **Open App -> RPCS3** action immediately before activating `Full Screen`, then test again. If that still does not behave reliably, the previous Personal Automation remains a valid fallback while NeoStation keeps the stable Universal JIT launch path.
 
-The user still chooses the game in RPCS3 unless RPCS3 later exposes a supported deep link/App Intent for a specific title.
-
-### Automation does not execute the gesture
-
-Leave the Personal Automation disabled or remove it. NeoStation continues to use the stable standard RPCS3 launch, so the user simply presses Start manually and selects the game. No second-pass injection, RPCS3Core UUID, boot offset, or internal boot call is involved anymore.
+No RPCS3Core UUID, boot offset, internal boot call, or second-pass injection is used by this flow.

--- a/lib/services/ios_shortcut_jit_launch_service.dart
+++ b/lib/services/ios_shortcut_jit_launch_service.dart
@@ -27,11 +27,11 @@ class IosShortcutJitLaunchService {
 
   /// RPCS3 intentionally has no shared iCloud installer yet.
   ///
-  /// The automation depends on a Switch Control switch/gesture created on the
-  /// user's own device, and Apple does not provide a public API for an app to
-  /// create that accessibility configuration. NeoStation therefore opens the
-  /// official Shortcuts editor and shows the required device-local steps in
-  /// its settings UI instead of shipping a misleading pre-bound Shortcut.
+  /// The Switch Control set, switch and gesture are device-local accessibility
+  /// configuration, so NeoStation cannot pre-create those pieces. The user
+  /// creates the `NeoStation+RPCS3+Start` helper once, then NeoStation invokes
+  /// that exact Shortcut directly from the RPCS3 launch path after the JIT
+  /// warm-up. A separate Personal Automation is therefore not required.
   static const String _rpcs3ShortcutInstallUrl = '';
 
   static bool get hasMeloNXShortcutInstaller =>
@@ -77,12 +77,12 @@ class IosShortcutJitLaunchService {
     }
   }
 
-  /// Opens the RPCS3 automation setup entry point.
+  /// Opens the RPCS3 Shortcut setup entry point.
   ///
   /// Until a portable, device-independent Switch Control binding exists,
   /// this opens a blank Shortcut editor. The user creates the small
-  /// `NeoStation+RPCS3+Start` helper and a personal automation triggered when
-  /// RPCS3 opens. NeoStation itself remains on the stable standard JIT path.
+  /// `NeoStation+RPCS3+Start` helper and the required device-local Switch
+  /// Control configuration. NeoStation calls the helper itself during launch.
   static Future<bool> openRpcs3ShortcutInstaller() async {
     if (!Platform.isIOS) return false;
 
@@ -98,23 +98,38 @@ class IosShortcutJitLaunchService {
     }
   }
 
-  /// Runs an installed Shortcut and passes an emulator game deeplink as text
-  /// input. The Shortcut owns the foreground sequence so StikDebug can finish
-  /// enabling JIT before it opens the game URL.
+  /// Builds the canonical Shortcuts URL used by NeoStation to invoke an
+  /// installed helper from outside the Shortcuts app.
+  ///
+  /// Keeping URL construction here guarantees the literal `+` characters in
+  /// names such as `NeoStation+RPCS3+Start` are encoded consistently everywhere.
+  static Uri buildRunUri({
+    required String shortcutName,
+    String? input,
+  }) {
+    final query = <String, String>{'name': shortcutName};
+    if (input != null) {
+      query['input'] = 'text';
+      query['text'] = input;
+    }
+
+    return Uri(
+      scheme: 'shortcuts',
+      host: 'run-shortcut',
+      queryParameters: query,
+    );
+  }
+
+  /// Runs an installed Shortcut and optionally passes text input to it.
   static Future<bool> run({
     required String shortcutName,
-    required String input,
+    String? input,
   }) async {
     if (!Platform.isIOS) return false;
 
-    final shortcutUri = Uri(
-      scheme: 'shortcuts',
-      host: 'run-shortcut',
-      queryParameters: <String, String>{
-        'name': shortcutName,
-        'input': 'text',
-        'text': input,
-      },
+    final shortcutUri = buildRunUri(
+      shortcutName: shortcutName,
+      input: input,
     );
 
     try {

--- a/lib/services/rpcs3_launch_service.dart
+++ b/lib/services/rpcs3_launch_service.dart
@@ -1,22 +1,23 @@
 import 'dart:io';
 
 import 'package:external_folder_access/external_folder_access.dart';
+import 'package:neostation/services/ios_shortcut_jit_launch_service.dart';
 import 'package:neostation/services/logger_service.dart';
 
 /// Stable RPCS3 iOS launcher.
 ///
-/// NeoStation only performs the proven first-stage JIT handoff through
-/// StikDebug. It no longer persists a pending title, observes app lifecycle
-/// transitions, injects a second script, fingerprints RPCS3Core, or calls an
-/// internal RPCS3 boot function.
+/// NeoStation starts RPCS3's normal StikDebug Universal JIT flow, then the
+/// native iOS helper keeps a short background task alive and invokes the
+/// user-configured `NeoStation+RPCS3+Start` Shortcut after the JIT warm-up.
+/// The Shortcut owns the device-local Switch Control gesture that presses
+/// RPCS3's native Start/Commencer control.
 ///
-/// Optional automatic tapping of RPCS3's native "Start"/"Commencer" control
-/// is deliberately kept outside this service and is intended to be handled by
-/// an iOS Shortcuts personal automation triggered when RPCS3 opens. If that
-/// automation is absent, the user simply presses Start and chooses the game in
-/// RPCS3 normally.
+/// This keeps the RPCS3Core memory-injection / second-pass protocol retired
+/// while directly linking NeoStation to the Shortcut. A separate Personal
+/// Automation triggered by RPCS3 opening is no longer required.
 abstract final class Rpcs3LaunchService {
   static const String targetBundleId = 'com.xitrix.RPCS3';
+  static const Duration _shortcutWarmupDelay = Duration(seconds: 8);
 
   static final LoggerService _log = LoggerService.instance;
   static final RegExp _titleIdPattern = RegExp(r'^[A-Z0-9._-]{3,32}$');
@@ -28,15 +29,16 @@ abstract final class Rpcs3LaunchService {
 
   /// Kept as a no-op compatibility hook because older application startup
   /// code calls [initialize]. There is intentionally no lifecycle observer
-  /// anymore: the old second-pass direct-boot protocol has been removed.
+  /// and no second-pass RPCS3Core injection anymore.
   static Future<void> initialize() async {}
 
-  /// Opens StikDebug with its normal Universal JIT request for RPCS3.
+  /// Starts StikDebug with the normal Universal JIT request for RPCS3 and then
+  /// invokes `NeoStation+RPCS3+Start` through Apple's Shortcuts URL scheme.
   ///
-  /// [displayTitle], [sourcePath], and [sourceKind] remain accepted so existing
-  /// callers do not need special cases, but they are not injected into RPCS3.
-  /// The selected Title ID is validated only for diagnostics/session tracking;
-  /// RPCS3 itself remains responsible for game selection in the stable path.
+  /// The native preflight helper schedules the Shortcut handoff rather than a
+  /// Dart timer so the handoff still has a chance to run after NeoStation has
+  /// moved to the background. The selected Title ID is passed as text input for
+  /// diagnostics/future Shortcut revisions; the current helper may ignore it.
   static Future<bool> launchTitle(
     String? rawTitleId, {
     String? displayTitle,
@@ -49,22 +51,29 @@ abstract final class Rpcs3LaunchService {
     if (titleId == null) return false;
 
     _log.i(
-      'RPCS3 standard launch: titleId=$titleId '
+      'RPCS3 Shortcut launch: titleId=$titleId '
       'title=${displayTitle?.trim() ?? ''} '
       'sourceKind=${sourceKind?.trim() ?? ''} '
       'sourcePath=${sourcePath?.trim() ?? ''}',
     );
 
+    final shortcutUri = IosShortcutJitLaunchService.buildRunUri(
+      shortcutName: IosShortcutJitLaunchService.rpcs3ShortcutName,
+      input: titleId,
+    );
+
     try {
-      final opened = await ExternalFolderAccess.openJitRequest(
+      final opened = await ExternalFolderAccess.openUrlAfterJitPreflight(
+        shortcutUri.toString(),
         targetBaseBundleId: targetBundleId,
+        warmupDelay: _shortcutWarmupDelay,
         scriptName: 'universal.js',
-        debugFileName: 'rpcs3_launch_debug.txt',
+        debugFileName: 'rpcs3_shortcut_launch_debug.txt',
       );
       return opened == true;
     } catch (error, stack) {
       _log.e(
-        'Rpcs3LaunchService: standard JIT handoff failed for $titleId',
+        'Rpcs3LaunchService: JIT + Shortcut handoff failed for $titleId',
         error: error,
         stackTrace: stack,
       );

--- a/test/rpcs3_stage3_test.dart
+++ b/test/rpcs3_stage3_test.dart
@@ -105,12 +105,16 @@ void main() {
       );
     });
 
-    test('RPCS3 launcher uses stable Universal JIT only', () {
+    test('RPCS3 launcher uses Universal JIT plus direct Shortcut handoff', () {
       final service = File(
         'lib/services/rpcs3_launch_service.dart',
       ).readAsStringSync();
-      expect(service, contains('openJitRequest'));
+      expect(service, contains('openUrlAfterJitPreflight'));
       expect(service, contains("scriptName: 'universal.js'"));
+      expect(service, contains('rpcs3ShortcutName'));
+      expect(service, contains('buildRunUri'));
+      expect(service, contains('_shortcutWarmupDelay'));
+      expect(service, isNot(contains('openJitRequest')));
       expect(service, isNot(contains('supportedCoreFunctions')));
       expect(service, isNot(contains('SECOND_PASS')));
       expect(

--- a/test/rpcs3_stage6_test.dart
+++ b/test/rpcs3_stage6_test.dart
@@ -36,15 +36,17 @@ void main() {
       );
     });
 
-    test('launcher validates serials but has no direct-core protocol', () {
+    test('launcher validates serials without restoring direct-core protocol', () {
       expect(Rpcs3LaunchService.normalizeTitleId('bles00412'), 'BLES00412');
       expect(Rpcs3LaunchService.normalizeTitleId(''), isNull);
 
       final service = File(
         'lib/services/rpcs3_launch_service.dart',
       ).readAsStringSync();
-      expect(service, contains('openJitRequest'));
+      expect(service, contains('openUrlAfterJitPreflight'));
       expect(service, contains("scriptName: 'universal.js'"));
+      expect(service, contains('rpcs3ShortcutName'));
+      expect(service, isNot(contains('openJitRequest')));
       expect(service, isNot(contains('supportedCoreFunctions')));
       expect(service, isNot(contains('SECOND_PASS')));
       expect(service, isNot(contains('buildScriptForTesting')));

--- a/test/rpcs3_stage7_test.dart
+++ b/test/rpcs3_stage7_test.dart
@@ -22,19 +22,23 @@ void main() {
     expect(resolved.hasMeaningfulScrapedName, isFalse);
   });
 
-  test('RPCS3 launch uses only the stable Universal JIT handoff', () {
+  test('RPCS3 launch schedules the Start Shortcut after Universal JIT', () {
     final service = File(
       'lib/services/rpcs3_launch_service.dart',
     ).readAsStringSync();
-    expect(service, contains('openJitRequest'));
+    expect(service, contains('openUrlAfterJitPreflight'));
     expect(service, contains("scriptName: 'universal.js'"));
+    expect(service, contains('rpcs3ShortcutName'));
+    expect(service, contains('buildRunUri'));
+    expect(service, contains('_shortcutWarmupDelay'));
+    expect(service, isNot(contains('openJitRequest')));
     expect(service, isNot(contains('rpcs3_stikdebug_launch.js')));
     expect(service, isNot(contains('bootGameOffset')));
     expect(service, isNot(contains('expectedCoreUuid')));
     expect(service, isNot(contains('SECOND_PASS')));
   });
 
-  test('RPCS3 Shortcut setup has a stable helper name', () {
+  test('RPCS3 Shortcut setup has a stable helper name and run URL builder', () {
     expect(
       IosShortcutJitLaunchService.rpcs3ShortcutName,
       'NeoStation+RPCS3+Start',
@@ -44,6 +48,20 @@ void main() {
     ).readAsStringSync();
     expect(shortcutService, contains('shortcuts://create-shortcut'));
     expect(shortcutService, contains('openRpcs3ShortcutInstaller'));
+    expect(shortcutService, contains('buildRunUri'));
+    expect(shortcutService, contains("scheme: 'shortcuts'"));
+    expect(shortcutService, contains("host: 'run-shortcut'"));
+  });
+
+  test('RPCS3 Switch Control documentation describes direct handoff', () {
+    final doc = File(
+      'docs/RPCS3_SHORTCUT_SWITCH_CONTROL.md',
+    ).readAsStringSync();
+    expect(doc, contains('NeoStation+RPCS3+Start'));
+    expect(doc, contains('NeoStation RPCS3'));
+    expect(doc, contains('Full Screen'));
+    expect(doc, contains('Personal Automation'));
+    expect(doc, contains('not required'));
   });
 
   test('obsolete RPCS3 direct injection asset is removed', () {

--- a/test/rpcs3_stage7_test.dart
+++ b/test/rpcs3_stage7_test.dart
@@ -38,19 +38,27 @@ void main() {
     expect(service, isNot(contains('SECOND_PASS')));
   });
 
-  test('RPCS3 Shortcut setup has a stable helper name and run URL builder', () {
+  test('RPCS3 Shortcut setup has a stable helper name and run URL', () {
     expect(
       IosShortcutJitLaunchService.rpcs3ShortcutName,
       'NeoStation+RPCS3+Start',
     );
+
+    final uri = IosShortcutJitLaunchService.buildRunUri(
+      shortcutName: IosShortcutJitLaunchService.rpcs3ShortcutName,
+      input: 'BLES00412',
+    );
+    expect(uri.scheme, 'shortcuts');
+    expect(uri.host, 'run-shortcut');
+    expect(uri.queryParameters['name'], 'NeoStation+RPCS3+Start');
+    expect(uri.queryParameters['input'], 'text');
+    expect(uri.queryParameters['text'], 'BLES00412');
+
     final shortcutService = File(
       'lib/services/ios_shortcut_jit_launch_service.dart',
     ).readAsStringSync();
     expect(shortcutService, contains('shortcuts://create-shortcut'));
     expect(shortcutService, contains('openRpcs3ShortcutInstaller'));
-    expect(shortcutService, contains('buildRunUri'));
-    expect(shortcutService, contains("scheme: 'shortcuts'"));
-    expect(shortcutService, contains("host: 'run-shortcut'"));
   });
 
   test('RPCS3 Switch Control documentation describes direct handoff', () {


### PR DESCRIPTION
## Summary

- Centralize the canonical Apple Shortcuts run URL for NeoStation helpers.
- Change the RPCS3 launch path from a bare `openJitRequest` to the native delayed `openUrlAfterJitPreflight` handoff.
- Invoke the exact `NeoStation+RPCS3+Start` Shortcut after an 8-second Universal JIT warm-up.
- Pass the selected RPCS3 Title ID as optional Shortcut text input for diagnostics/future revisions.
- Keep the old RPCS3Core direct injection / second-pass protocol retired.
- Update RPCS3 stage tests and iOS 27 Switch Control documentation.

## iOS 27 setup

The device-local Shortcut remains:

`NeoStation+RPCS3+Start`

with the `NeoStation RPCS3` switch set and `Full Screen` switch/gesture configured by the user. A separate Personal Automation triggered by RPCS3 opening is no longer required with this build and should be disabled during testing to avoid a double launch.

## Validation note

The code path is wired through the existing native iOS background-task preflight helper, rather than a Dart timer, so the delayed Shortcut URL has a chance to fire after NeoStation backgrounds. Final Shortcuts foreground behavior still requires on-device validation on iOS 27.