### PR TITLE
Fix RPCS3 foreground automation handoff

### DIFF
--- a/docs/RPCS3_SHORTCUT_SWITCH_CONTROL.md
+++ b/docs/RPCS3_SHORTCUT_SWITCH_CONTROL.md
@@ -1,14 +1,18 @@
 # RPCS3 iOS — Switch Control auto-Start
 
-NeoStation keeps the experimental RPCS3Core memory-injection / second-pass StikDebug launcher retired. The current PS3 launch path is intentionally simpler:
+NeoStation keeps the experimental RPCS3Core memory-injection / second-pass StikDebug launcher retired. The stable PS3 launch path is:
 
-1. NeoStation starts the normal StikDebug Universal JIT flow for RPCS3 with `universal.js`.
-2. The native iOS preflight helper keeps a short background task alive and waits about 8 seconds for the JIT/RPCS3 foreground transition.
-3. NeoStation then opens Apple's `shortcuts://run-shortcut` URL for the exact helper named `NeoStation+RPCS3+Start`.
-4. The Shortcut selects the `NeoStation RPCS3` Switch Control set and activates the configured `Full Screen` switch.
-5. The Switch Control recipe/macro runs its custom gesture and taps RPCS3's **Start / Commencer** button.
+1. NeoStation starts StikDebug Universal JIT for RPCS3 with `universal.js`.
+2. The native iOS preflight helper waits about 8 seconds for the JIT warm-up.
+3. NeoStation asks StikDebug to foreground RPCS3 with its `launch-app` URL.
+4. iOS sees RPCS3 open and triggers the device-local Personal Automation.
+5. The automation runs the exact Shortcut `NeoStation+RPCS3+Start`.
+6. The Shortcut selects the `NeoStation RPCS3` Switch Control set and activates the configured `Full Screen` switch.
+7. The Switch Control recipe/macro runs its custom gesture and taps RPCS3's **Start / Commencer** button.
 
-The Accessibility configuration is still device-local. iOS does not give NeoStation a public API to create the user's Switch Control switch, switch set, recipe/macro, or custom tap gesture, so those pieces must be configured once on the iPhone.
+This intentionally does **not** try to launch the Shortcut from NeoStation after NeoStation has entered the background. The previous direct handoff could be rejected by iOS even though the Shortcuts URL itself was valid.
+
+The Accessibility configuration and Personal Automation are device-local. iOS does not give NeoStation a public API to create the user's Switch Control switch, switch set, recipe/macro, custom tap gesture, or Personal Automation, so those pieces must be configured once on the iPhone.
 
 ## 1. Configure Switch Control
 
@@ -21,7 +25,7 @@ On the iPhone:
 5. Record a single tap at the exact position of RPCS3's **Start / Commencer** button, using the same device orientation in which RPCS3 opens.
 6. Create a Switch Control set named **NeoStation RPCS3** and keep the configured Full Screen switch/recipe in that set.
 
-The exact labels can vary slightly by iOS language/version. On iOS 27, the configuration observed during NeoStation testing exposes the switch set, `Full Screen` switch state, and recipe/macro directly.
+The exact labels can vary slightly by iOS language/version. On the iOS 27 setup used for NeoStation testing, the switch set, `Full Screen` switch state, and recipe/macro are exposed directly.
 
 ## 2. Create the Shortcut
 
@@ -29,29 +33,34 @@ Create a Shortcut named exactly:
 
 `NeoStation+RPCS3+Start`
 
-For the current iOS 27 setup, use these actions in this order:
+Use these actions in this order:
 
 1. **Set Switch Control Switch Set** -> `NeoStation RPCS3`.
 2. **Set Switch Control Switch State** -> activate `Full Screen`.
 3. **Wait** -> 1 second.
 4. **Set Switch Control Switch State** -> deactivate `Full Screen`.
 
-The 1-second wait is only there to keep the switch active briefly enough for the configured recipe/gesture to run. Adjust it only if on-device testing proves that a different delay is required.
+Do **not** add **Open App -> RPCS3** at the top of this Shortcut when using the Personal Automation described below. RPCS3 is already foregrounded before the automation runs. Re-opening it from the Shortcut can retrigger the same app-open automation and cause a loop or duplicate execution.
 
-## 3. Personal Automation is not required
+The 1-second wait keeps the switch active briefly enough for the configured recipe/gesture to run. Adjust it only if on-device testing shows that a different delay is required.
 
-Older NeoStation builds relied on a **Personal Automation** triggered when RPCS3 opened. Builds containing the direct Shortcut handoff now invoke `NeoStation+RPCS3+Start` themselves after the JIT warm-up, so that Personal Automation is **not required**.
+## 3. Create and enable the Personal Automation
 
-If an old Personal Automation such as **When RPCS3 is opened -> Run NeoStation+RPCS3+Start** is still enabled, disable it before testing the direct NeoStation path. Otherwise the Shortcut can run twice.
+In **Shortcuts > Automation**:
+
+1. Create a Personal Automation for **App**.
+2. Select **RPCS3**.
+3. Choose **Is Opened / Est ouverte**.
+4. Set it to **Run Immediately / Exécuter immédiatement** when that option is available.
+5. Add **Run Shortcut / Exécuter le raccourci** -> `NeoStation+RPCS3+Start`.
+6. Make sure the automation itself is enabled.
+
+The automation may be named something like `RPCS3 Auto Start`; its display name is not used by NeoStation. The exact Shortcut name `NeoStation+RPCS3+Start` is the important part.
 
 ## Expected path
 
-`NeoStation -> StikDebug / universal.js -> RPCS3 -> NeoStation+RPCS3+Start -> Switch Control -> Start / Commencer`
+`NeoStation -> StikDebug / universal.js -> RPCS3 opens -> Personal Automation -> NeoStation+RPCS3+Start -> Switch Control -> Start / Commencer`
 
-The selected RPCS3 Title ID is also passed to the Shortcut as optional text input for diagnostics/future revisions. The current Switch Control helper does not need to consume that input.
-
-## On-device fallback
-
-The final foreground behavior of Apple's Shortcuts URL scheme can vary by iOS release. If on-device testing shows that running the Shortcut leaves the Shortcuts app in the foreground when the custom gesture fires, add an **Open App -> RPCS3** action immediately before activating `Full Screen`, then test again. If that still does not behave reliably, the previous Personal Automation remains a valid fallback while NeoStation keeps the stable Universal JIT launch path.
+If the automation does not fire, first verify that the Personal Automation is enabled and configured to run immediately. If it fires but the gesture misses the button, adjust only the Switch Control gesture or its short wait; do not add a second RPCS3 app-open action to the Shortcut.
 
 No RPCS3Core UUID, boot offset, internal boot call, or second-pass injection is used by this flow.

--- a/docs/RPCS3_SHORTCUT_SWITCH_CONTROL.md
+++ b/docs/RPCS3_SHORTCUT_SWITCH_CONTROL.md
@@ -53,7 +53,7 @@ In **Shortcuts > Automation**:
 3. Choose **Is Opened / Est ouverte**.
 4. Set it to **Run Immediately / Exécuter immédiatement** when that option is available.
 5. Add **Run Shortcut / Exécuter le raccourci** -> `NeoStation+RPCS3+Start`.
-6. Make sure the automation itself is enabled.
+6. Make sure the automation itself is enabled, and keep it enabled for this launch mode.
 
 The automation may be named something like `RPCS3 Auto Start`; its display name is not used by NeoStation. The exact Shortcut name `NeoStation+RPCS3+Start` is the important part.
 

--- a/lib/services/ios_shortcut_jit_launch_service.dart
+++ b/lib/services/ios_shortcut_jit_launch_service.dart
@@ -29,9 +29,10 @@ class IosShortcutJitLaunchService {
   ///
   /// The Switch Control set, switch and gesture are device-local accessibility
   /// configuration, so NeoStation cannot pre-create those pieces. The user
-  /// creates the `NeoStation+RPCS3+Start` helper once, then NeoStation invokes
-  /// that exact Shortcut directly from the RPCS3 launch path after the JIT
-  /// warm-up. A separate Personal Automation is therefore not required.
+  /// creates the `NeoStation+RPCS3+Start` helper once and binds it to a Personal
+  /// Automation triggered when RPCS3 opens. NeoStation's RPCS3 launch path
+  /// foregrounds RPCS3 after JIT; the automation then runs the helper while
+  /// RPCS3 is already the active app.
   static const String _rpcs3ShortcutInstallUrl = '';
 
   static bool get hasMeloNXShortcutInstaller =>
@@ -81,8 +82,8 @@ class IosShortcutJitLaunchService {
   ///
   /// Until a portable, device-independent Switch Control binding exists,
   /// this opens a blank Shortcut editor. The user creates the small
-  /// `NeoStation+RPCS3+Start` helper and the required device-local Switch
-  /// Control configuration. NeoStation calls the helper itself during launch.
+  /// `NeoStation+RPCS3+Start` helper, the required device-local Switch Control
+  /// configuration, and a Personal Automation for the RPCS3 app-open event.
   static Future<bool> openRpcs3ShortcutInstaller() async {
     if (!Platform.isIOS) return false;
 

--- a/lib/services/rpcs3_launch_service.dart
+++ b/lib/services/rpcs3_launch_service.dart
@@ -1,23 +1,21 @@
 import 'dart:io';
 
 import 'package:external_folder_access/external_folder_access.dart';
-import 'package:neostation/services/ios_shortcut_jit_launch_service.dart';
 import 'package:neostation/services/logger_service.dart';
 
 /// Stable RPCS3 iOS launcher.
 ///
 /// NeoStation starts RPCS3's normal StikDebug Universal JIT flow, then the
-/// native iOS helper keeps a short background task alive and invokes the
-/// user-configured `NeoStation+RPCS3+Start` Shortcut after the JIT warm-up.
-/// The Shortcut owns the device-local Switch Control gesture that presses
-/// RPCS3's native Start/Commencer control.
+/// native iOS helper foregrounds RPCS3 itself after the JIT warm-up. Opening
+/// RPCS3 is the event used by the user's device-local Personal Automation,
+/// which runs `NeoStation+RPCS3+Start` while RPCS3 is already foregrounded.
 ///
-/// This keeps the RPCS3Core memory-injection / second-pass protocol retired
-/// while directly linking NeoStation to the Shortcut. A separate Personal
-/// Automation triggered by RPCS3 opening is no longer required.
+/// This avoids trying to open Apple's Shortcuts URL scheme from NeoStation's
+/// background execution window. It also keeps the retired RPCS3Core memory
+/// injection / second-pass protocol out of the stable launch path.
 abstract final class Rpcs3LaunchService {
   static const String targetBundleId = 'com.xitrix.RPCS3';
-  static const Duration _shortcutWarmupDelay = Duration(seconds: 8);
+  static const Duration _rpcs3WarmupDelay = Duration(seconds: 8);
 
   static final LoggerService _log = LoggerService.instance;
   static final RegExp _titleIdPattern = RegExp(r'^[A-Z0-9._-]{3,32}$');
@@ -32,13 +30,13 @@ abstract final class Rpcs3LaunchService {
   /// and no second-pass RPCS3Core injection anymore.
   static Future<void> initialize() async {}
 
-  /// Starts StikDebug with the normal Universal JIT request for RPCS3 and then
-  /// invokes `NeoStation+RPCS3+Start` through Apple's Shortcuts URL scheme.
+  /// Starts StikDebug with the normal Universal JIT request for RPCS3, waits
+  /// for the bounded warm-up window, then asks StikDebug to foreground RPCS3.
   ///
-  /// The native preflight helper schedules the Shortcut handoff rather than a
-  /// Dart timer so the handoff still has a chance to run after NeoStation has
-  /// moved to the background. The selected Title ID is passed as text input for
-  /// diagnostics/future Shortcut revisions; the current helper may ignore it.
+  /// The app-open transition is deliberately the final native handoff. The
+  /// user's iOS Personal Automation observes "RPCS3 is opened" and runs the
+  /// `NeoStation+RPCS3+Start` Shortcut from that event, so the Switch Control
+  /// gesture executes against RPCS3 instead of against the Shortcuts app.
   static Future<bool> launchTitle(
     String? rawTitleId, {
     String? displayTitle,
@@ -51,29 +49,23 @@ abstract final class Rpcs3LaunchService {
     if (titleId == null) return false;
 
     _log.i(
-      'RPCS3 Shortcut launch: titleId=$titleId '
+      'RPCS3 automation launch: titleId=$titleId '
       'title=${displayTitle?.trim() ?? ''} '
       'sourceKind=${sourceKind?.trim() ?? ''} '
       'sourcePath=${sourcePath?.trim() ?? ''}',
     );
 
-    final shortcutUri = IosShortcutJitLaunchService.buildRunUri(
-      shortcutName: IosShortcutJitLaunchService.rpcs3ShortcutName,
-      input: titleId,
-    );
-
     try {
-      final opened = await ExternalFolderAccess.openUrlAfterJitPreflight(
-        shortcutUri.toString(),
+      final opened = await ExternalFolderAccess.openAppAfterJitPreflight(
         targetBaseBundleId: targetBundleId,
-        warmupDelay: _shortcutWarmupDelay,
+        warmupDelay: _rpcs3WarmupDelay,
         scriptName: 'universal.js',
-        debugFileName: 'rpcs3_shortcut_launch_debug.txt',
+        debugFileName: 'rpcs3_automation_launch_debug.txt',
       );
       return opened == true;
     } catch (error, stack) {
       _log.e(
-        'Rpcs3LaunchService: JIT + Shortcut handoff failed for $titleId',
+        'Rpcs3LaunchService: JIT + RPCS3 foreground handoff failed for $titleId',
         error: error,
         stackTrace: stack,
       );

--- a/test/rpcs3_stage3_test.dart
+++ b/test/rpcs3_stage3_test.dart
@@ -105,15 +105,16 @@ void main() {
       );
     });
 
-    test('RPCS3 launcher uses Universal JIT plus direct Shortcut handoff', () {
+    test('RPCS3 launcher foregrounds RPCS3 after Universal JIT', () {
       final service = File(
         'lib/services/rpcs3_launch_service.dart',
       ).readAsStringSync();
-      expect(service, contains('openUrlAfterJitPreflight'));
+      expect(service, contains('openAppAfterJitPreflight'));
       expect(service, contains("scriptName: 'universal.js'"));
-      expect(service, contains('rpcs3ShortcutName'));
-      expect(service, contains('buildRunUri'));
-      expect(service, contains('_shortcutWarmupDelay'));
+      expect(service, contains('_rpcs3WarmupDelay'));
+      expect(service, contains('rpcs3_automation_launch_debug.txt'));
+      expect(service, isNot(contains('buildRunUri')));
+      expect(service, isNot(contains('rpcs3ShortcutName')));
       expect(service, isNot(contains('openJitRequest')));
       expect(service, isNot(contains('supportedCoreFunctions')));
       expect(service, isNot(contains('SECOND_PASS')));

--- a/test/rpcs3_stage6_test.dart
+++ b/test/rpcs3_stage6_test.dart
@@ -43,9 +43,11 @@ void main() {
       final service = File(
         'lib/services/rpcs3_launch_service.dart',
       ).readAsStringSync();
-      expect(service, contains('openUrlAfterJitPreflight'));
+      expect(service, contains('openAppAfterJitPreflight'));
       expect(service, contains("scriptName: 'universal.js'"));
-      expect(service, contains('rpcs3ShortcutName'));
+      expect(service, contains('_rpcs3WarmupDelay'));
+      expect(service, isNot(contains('buildRunUri')));
+      expect(service, isNot(contains('rpcs3ShortcutName')));
       expect(service, isNot(contains('openJitRequest')));
       expect(service, isNot(contains('supportedCoreFunctions')));
       expect(service, isNot(contains('SECOND_PASS')));

--- a/test/rpcs3_stage7_test.dart
+++ b/test/rpcs3_stage7_test.dart
@@ -22,15 +22,17 @@ void main() {
     expect(resolved.hasMeaningfulScrapedName, isFalse);
   });
 
-  test('RPCS3 launch schedules the Start Shortcut after Universal JIT', () {
+  test('RPCS3 launch foregrounds the app after Universal JIT', () {
     final service = File(
       'lib/services/rpcs3_launch_service.dart',
     ).readAsStringSync();
-    expect(service, contains('openUrlAfterJitPreflight'));
+    expect(service, contains('openAppAfterJitPreflight'));
     expect(service, contains("scriptName: 'universal.js'"));
-    expect(service, contains('rpcs3ShortcutName'));
-    expect(service, contains('buildRunUri'));
-    expect(service, contains('_shortcutWarmupDelay'));
+    expect(service, contains('_rpcs3WarmupDelay'));
+    expect(service, contains('rpcs3_automation_launch_debug.txt'));
+    expect(service, isNot(contains('buildRunUri')));
+    expect(service, isNot(contains('rpcs3ShortcutName')));
+    expect(service, isNot(contains('openUrlAfterJitPreflight('));
     expect(service, isNot(contains('openJitRequest')));
     expect(service, isNot(contains('rpcs3_stikdebug_launch.js')));
     expect(service, isNot(contains('bootGameOffset')));
@@ -38,30 +40,21 @@ void main() {
     expect(service, isNot(contains('SECOND_PASS')));
   });
 
-  test('RPCS3 Shortcut setup has a stable helper name and run URL', () {
+  test('RPCS3 Shortcut setup keeps the exact helper name', () {
     expect(
       IosShortcutJitLaunchService.rpcs3ShortcutName,
       'NeoStation+RPCS3+Start',
     );
-
-    final uri = IosShortcutJitLaunchService.buildRunUri(
-      shortcutName: IosShortcutJitLaunchService.rpcs3ShortcutName,
-      input: 'BLES00412',
-    );
-    expect(uri.scheme, 'shortcuts');
-    expect(uri.host, 'run-shortcut');
-    expect(uri.queryParameters['name'], 'NeoStation+RPCS3+Start');
-    expect(uri.queryParameters['input'], 'text');
-    expect(uri.queryParameters['text'], 'BLES00412');
 
     final shortcutService = File(
       'lib/services/ios_shortcut_jit_launch_service.dart',
     ).readAsStringSync();
     expect(shortcutService, contains('shortcuts://create-shortcut'));
     expect(shortcutService, contains('openRpcs3ShortcutInstaller'));
+    expect(shortcutService, contains('Personal Automation'));
   });
 
-  test('RPCS3 Switch Control documentation describes direct handoff', () {
+  test('RPCS3 Switch Control documentation requires app-open automation', () {
     final doc = File(
       'docs/RPCS3_SHORTCUT_SWITCH_CONTROL.md',
     ).readAsStringSync();
@@ -69,7 +62,8 @@ void main() {
     expect(doc, contains('NeoStation RPCS3'));
     expect(doc, contains('Full Screen'));
     expect(doc, contains('Personal Automation'));
-    expect(doc, contains('not required'));
+    expect(doc, contains('Run Immediately'));
+    expect(doc, contains('Do **not** add **Open App -> RPCS3**'));
   });
 
   test('obsolete RPCS3 direct injection asset is removed', () {


### PR DESCRIPTION
## Summary

- Stop trying to open `NeoStation+RPCS3+Start` from NeoStation's background execution window after StikDebug.
- Use the existing native `openAppAfterJitPreflight` path so StikDebug enables Universal JIT, waits 8 seconds, then foregrounds RPCS3.
- Let the device-local Personal Automation (`When RPCS3 is opened`) run `NeoStation+RPCS3+Start` while RPCS3 is already foregrounded.
- Keep the exact Shortcut name unchanged.
- Explicitly document that `Open App -> RPCS3` must **not** be added to the Shortcut when using the app-open automation, because it can retrigger the automation and loop/double-run.
- Update RPCS3 regression tests and iOS 27 setup documentation.

Expected path:

`NeoStation -> StikDebug / universal.js -> RPCS3 foreground -> Personal Automation -> NeoStation+RPCS3+Start -> Switch Control -> Start`
