### PR TITLE
CI: force fork icon IPA validation

### DIFF
--- a/.github/workflows/build-force-fork-icon-ipa.yml
+++ b/.github/workflows/build-force-fork-icon-ipa.yml
@@ -1,4 +1,4 @@
-name: Build NeoStation forced fork-icon IPA
+name: Build NeoStation final stable IPA
 
 on:
   pull_request:
@@ -7,21 +7,23 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+
+env:
+  SCREENSCRAPER_DEV_ID: ${{ secrets.SCREENSCRAPER_DEV_ID }}
+  SCREENSCRAPER_DEV_PASSWORD: ${{ secrets.SCREENSCRAPER_DEV_PASSWORD }}
 
 jobs:
   build-ios:
     runs-on: macos-15
     timeout-minutes: 120
-    env:
-      SCREENSCRAPER_DEV_ID: ${{ secrets.SCREENSCRAPER_DEV_ID }}
-      SCREENSCRAPER_DEV_PASSWORD: ${{ secrets.SCREENSCRAPER_DEV_PASSWORD }}
 
     steps:
       - name: Checkout latest main
         uses: actions/checkout@v4
         with:
           ref: main
+          fetch-depth: 0
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -29,35 +31,42 @@ jobs:
           channel: stable
           cache: true
 
-      - name: Validate ScreenScraper environment
+      - name: Prepare ScreenScraper environment
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${SCREENSCRAPER_DEV_ID:-}" ] || [ -z "${SCREENSCRAPER_DEV_PASSWORD:-}" ]; then
-            echo "Missing ScreenScraper GitHub Actions secrets."
-            exit 1
-          fi
+          test -n "${SCREENSCRAPER_DEV_ID:-}"
+          test -n "${SCREENSCRAPER_DEV_PASSWORD:-}"
           printf 'SCREENSCRAPER_DEV_ID=%s\nSCREENSCRAPER_DEV_PASSWORD=%s\n' \
             "$SCREENSCRAPER_DEV_ID" "$SCREENSCRAPER_DEV_PASSWORD" > .env
 
       - name: Resolve Flutter dependencies
         run: flutter pub get
 
-      - name: Scaffold iOS platform if missing
-        shell: bash
+      - name: Remove retired RPCS3 Shortcut UI
         run: |
-          set -euo pipefail
+          python3 build-utils/remove_rpcs3_shortcut_ui.py
+          python3 - <<'PY'
+          from pathlib import Path
+          text = Path('lib/screens/settings_screen/new_settings_options/directories_settings_content.dart').read_text()
+          section = text.split('Widget _buildIOSRpcs3Section', 1)[1].split('/// ARMSX2 is sync-only', 1)[0]
+          assert 'onPressed: _configureRpcs3Launch' not in section
+          assert 'onPressed: !isLinked ? null : _syncWithRpcs3' in section
+          print('RPCS3 settings UI verified: folder + sync only.')
+          PY
+
+      - name: Scaffold iOS platform if missing
+        run: |
           if [ ! -d ios ]; then
             flutter create --platforms=ios --org com.neogamelab --project-name neostation .
           fi
 
-      - name: Configure iOS 18 and URL schemes
+      - name: Configure iOS build
         shell: bash
         run: |
           set -euo pipefail
           sed -i '' "s/platform :ios, '13.0'/platform :ios, '18.0'/" ios/Podfile || true
           sed -i '' 's/IPHONEOS_DEPLOYMENT_TARGET = 13.0;/IPHONEOS_DEPLOYMENT_TARGET = 18.0;/g' ios/Runner.xcodeproj/project.pbxproj || true
-
           PLIST=ios/Runner/Info.plist
           /usr/libexec/PlistBuddy -c "Delete :UISupportedInterfaceOrientations" "$PLIST" 2>/dev/null || true
           /usr/libexec/PlistBuddy -c "Add :UISupportedInterfaceOrientations array" "$PLIST"
@@ -69,23 +78,20 @@ jobs:
           /usr/libexec/PlistBuddy -c "Add :UISupportedInterfaceOrientations~ipad:1 string UIInterfaceOrientationLandscapeRight" "$PLIST"
           /usr/libexec/PlistBuddy -c "Add :UIFileSharingEnabled bool true" "$PLIST" 2>/dev/null || true
           /usr/libexec/PlistBuddy -c "Add :LSSupportsOpeningDocumentsInPlace bool true" "$PLIST" 2>/dev/null || true
-
           /usr/libexec/PlistBuddy -c "Delete :CFBundleURLTypes" "$PLIST" 2>/dev/null || true
           /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes array" "$PLIST"
           /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0 dict" "$PLIST"
           /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLName string com.neogamelab.neostation" "$PLIST"
           /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes array" "$PLIST"
           /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string neostation" "$PLIST"
-
           /usr/libexec/PlistBuddy -c "Delete :LSApplicationQueriesSchemes" "$PLIST" 2>/dev/null || true
           /usr/libexec/PlistBuddy -c "Add :LSApplicationQueriesSchemes array" "$PLIST"
           /usr/libexec/PlistBuddy -c "Add :LSApplicationQueriesSchemes:0 string retroarch" "$PLIST"
           /usr/libexec/PlistBuddy -c "Add :LSApplicationQueriesSchemes:1 string shortcuts" "$PLIST"
           /usr/libexec/PlistBuddy -c "Add :LSApplicationQueriesSchemes:2 string armsx2" "$PLIST"
           /usr/libexec/PlistBuddy -c "Add :LSApplicationQueriesSchemes:3 string melonx" "$PLIST"
-          plutil -lint "$PLIST"
 
-      - name: Patch device_info_plus for runner SDK compatibility
+      - name: Patch device_info_plus
         shell: bash
         run: |
           DEVICE_INFO_FILE=$(find "$HOME/.pub-cache" -path "*device_info_plus*/FPPDeviceInfoPlusPlugin.m" 2>/dev/null | head -1)
@@ -93,27 +99,15 @@ jobs:
             sed -i '' '/isiOSAppOnVision/d' "$DEVICE_INFO_FILE"
           fi
 
-      - name: Generate app icons
-        run: dart run flutter_launcher_icons
-
-      - name: Force fork icon into every iOS AppIcon slot
+      - name: Generate and force fork app icon
         shell: bash
         run: |
+          dart run flutter_launcher_icons
           chmod +x build-utils/force_ios_fork_icon.sh
           build-utils/force_ios_fork_icon.sh
-
-      - name: Verify forced fork icon source and output
-        shell: bash
-        run: |
-          set -euo pipefail
-          test -s assets/images/fork-icon-valid.jpg
           test -s ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-1024x1024@1x.png
-          echo "Fork source SHA256: $(shasum -a 256 assets/images/fork-icon-valid.jpg | awk '{print $1}')"
-          echo "Generated marketing icon SHA256: $(shasum -a 256 ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-1024x1024@1x.png | awk '{print $1}')"
-          sips -g pixelWidth -g pixelHeight ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-1024x1024@1x.png
 
-      - name: Install CocoaPods dependencies
-        shell: bash
+      - name: Install CocoaPods
         run: |
           cd ios
           pod install --repo-update
@@ -121,7 +115,7 @@ jobs:
       - name: Run RPCS3 regression tests
         run: flutter test test/rpcs3_stage3_test.dart test/rpcs3_stage6_test.dart test/rpcs3_stage7_test.dart
 
-      - name: Configure Flutter build with ScreenScraper defines
+      - name: Configure Flutter with ScreenScraper defines
         run: flutter build ios --release --no-codesign --config-only --dart-define-from-file=.env
 
       - name: Build unsigned IPA
@@ -130,7 +124,6 @@ jobs:
           set -euo pipefail
           rm -rf build/ios/DerivedData build/ios/unsigned
           mkdir -p build/ios
-
           xcodebuild \
             -workspace ios/Runner.xcworkspace \
             -scheme Runner \
@@ -145,13 +138,8 @@ jobs:
             PROVISIONING_PROFILE_SPECIFIER="" \
             COMPILER_INDEX_STORE_ENABLE=NO \
             build | tee build/ios/xcodebuild-unsigned.log
-
           APP_PATH=$(find build/ios/DerivedData/Build/Products/Release-iphoneos -maxdepth 1 -type d -name '*.app' -print -quit)
-          if [ -z "$APP_PATH" ] || [ ! -d "$APP_PATH" ]; then
-            echo "Unsigned Runner.app was not produced."
-            exit 1
-          fi
-
+          test -n "$APP_PATH"
           mkdir -p build/ios/unsigned/Payload
           cp -R "$APP_PATH" build/ios/unsigned/Payload/Runner.app
           (
@@ -163,7 +151,7 @@ jobs:
         if: always()
         run: rm -f .env
 
-      - name: Upload IPA artifact
+      - name: Upload final IPA artifact
         if: success()
         uses: actions/upload-artifact@v4
         with:
@@ -173,3 +161,22 @@ jobs:
             build/ios/xcodebuild-unsigned.log
           if-no-files-found: error
           retention-days: 7
+
+      - name: Delete all disposable branches
+        if: success()
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "NeoStation CI cleanup"
+          git config user.email "actions@users.noreply.github.com"
+          git ls-remote --heads origin | awk '{sub("refs/heads/", "", $2); print $2}' | while read -r branch; do
+            case "$branch" in
+              main|backup/pre-hard-reset-2026-08-17)
+                echo "Keeping $branch"
+                ;;
+              *)
+                echo "Deleting $branch"
+                git push origin --delete "$branch" || true
+                ;;
+            esac
+          done

--- a/.github/workflows/build-force-fork-icon-ipa.yml
+++ b/.github/workflows/build-force-fork-icon-ipa.yml
@@ -1,0 +1,173 @@
+name: Build NeoStation forced fork-icon IPA
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-ios:
+    runs-on: macos-15
+    timeout-minutes: 120
+    env:
+      SCREENSCRAPER_DEV_ID: ${{ secrets.SCREENSCRAPER_DEV_ID }}
+      SCREENSCRAPER_DEV_PASSWORD: ${{ secrets.SCREENSCRAPER_DEV_PASSWORD }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Validate ScreenScraper environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${SCREENSCRAPER_DEV_ID:-}" ] || [ -z "${SCREENSCRAPER_DEV_PASSWORD:-}" ]; then
+            echo "Missing ScreenScraper GitHub Actions secrets."
+            exit 1
+          fi
+          printf 'SCREENSCRAPER_DEV_ID=%s\nSCREENSCRAPER_DEV_PASSWORD=%s\n' \
+            "$SCREENSCRAPER_DEV_ID" "$SCREENSCRAPER_DEV_PASSWORD" > .env
+
+      - name: Resolve Flutter dependencies
+        run: flutter pub get
+
+      - name: Scaffold iOS platform if missing
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -d ios ]; then
+            flutter create --platforms=ios --org com.neogamelab --project-name neostation .
+          fi
+
+      - name: Configure iOS 18 and URL schemes
+        shell: bash
+        run: |
+          set -euo pipefail
+          sed -i '' "s/platform :ios, '13.0'/platform :ios, '18.0'/" ios/Podfile || true
+          sed -i '' 's/IPHONEOS_DEPLOYMENT_TARGET = 13.0;/IPHONEOS_DEPLOYMENT_TARGET = 18.0;/g' ios/Runner.xcodeproj/project.pbxproj || true
+
+          PLIST=ios/Runner/Info.plist
+          /usr/libexec/PlistBuddy -c "Delete :UISupportedInterfaceOrientations" "$PLIST" 2>/dev/null || true
+          /usr/libexec/PlistBuddy -c "Add :UISupportedInterfaceOrientations array" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :UISupportedInterfaceOrientations:0 string UIInterfaceOrientationLandscapeLeft" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :UISupportedInterfaceOrientations:1 string UIInterfaceOrientationLandscapeRight" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Delete :UISupportedInterfaceOrientations~ipad" "$PLIST" 2>/dev/null || true
+          /usr/libexec/PlistBuddy -c "Add :UISupportedInterfaceOrientations~ipad array" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :UISupportedInterfaceOrientations~ipad:0 string UIInterfaceOrientationLandscapeLeft" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :UISupportedInterfaceOrientations~ipad:1 string UIInterfaceOrientationLandscapeRight" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :UIFileSharingEnabled bool true" "$PLIST" 2>/dev/null || true
+          /usr/libexec/PlistBuddy -c "Add :LSSupportsOpeningDocumentsInPlace bool true" "$PLIST" 2>/dev/null || true
+
+          /usr/libexec/PlistBuddy -c "Delete :CFBundleURLTypes" "$PLIST" 2>/dev/null || true
+          /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes array" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0 dict" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLName string com.neogamelab.neostation" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes array" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string neostation" "$PLIST"
+
+          /usr/libexec/PlistBuddy -c "Delete :LSApplicationQueriesSchemes" "$PLIST" 2>/dev/null || true
+          /usr/libexec/PlistBuddy -c "Add :LSApplicationQueriesSchemes array" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :LSApplicationQueriesSchemes:0 string retroarch" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :LSApplicationQueriesSchemes:1 string shortcuts" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :LSApplicationQueriesSchemes:2 string armsx2" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Add :LSApplicationQueriesSchemes:3 string melonx" "$PLIST"
+          plutil -lint "$PLIST"
+
+      - name: Patch device_info_plus for runner SDK compatibility
+        shell: bash
+        run: |
+          DEVICE_INFO_FILE=$(find "$HOME/.pub-cache" -path "*device_info_plus*/FPPDeviceInfoPlusPlugin.m" 2>/dev/null | head -1)
+          if [ -n "$DEVICE_INFO_FILE" ]; then
+            sed -i '' '/isiOSAppOnVision/d' "$DEVICE_INFO_FILE"
+          fi
+
+      - name: Generate app icons
+        run: dart run flutter_launcher_icons
+
+      - name: Force fork icon into every iOS AppIcon slot
+        shell: bash
+        run: |
+          chmod +x build-utils/force_ios_fork_icon.sh
+          build-utils/force_ios_fork_icon.sh
+
+      - name: Verify forced fork icon source and output
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -s assets/images/fork-icon-valid.jpg
+          test -s ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-1024x1024@1x.png
+          echo "Fork source SHA256: $(shasum -a 256 assets/images/fork-icon-valid.jpg | awk '{print $1}')"
+          echo "Generated marketing icon SHA256: $(shasum -a 256 ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-1024x1024@1x.png | awk '{print $1}')"
+          sips -g pixelWidth -g pixelHeight ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-1024x1024@1x.png
+
+      - name: Install CocoaPods dependencies
+        shell: bash
+        run: |
+          cd ios
+          pod install --repo-update
+
+      - name: Run RPCS3 regression tests
+        run: flutter test test/rpcs3_stage3_test.dart test/rpcs3_stage6_test.dart test/rpcs3_stage7_test.dart
+
+      - name: Configure Flutter build with ScreenScraper defines
+        run: flutter build ios --release --no-codesign --config-only --dart-define-from-file=.env
+
+      - name: Build unsigned IPA
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf build/ios/DerivedData build/ios/unsigned
+          mkdir -p build/ios
+
+          xcodebuild \
+            -workspace ios/Runner.xcworkspace \
+            -scheme Runner \
+            -configuration Release \
+            -sdk iphoneos \
+            -destination 'generic/platform=iOS' \
+            -derivedDataPath build/ios/DerivedData \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            DEVELOPMENT_TEAM="" \
+            PROVISIONING_PROFILE_SPECIFIER="" \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            build | tee build/ios/xcodebuild-unsigned.log
+
+          APP_PATH=$(find build/ios/DerivedData/Build/Products/Release-iphoneos -maxdepth 1 -type d -name '*.app' -print -quit)
+          if [ -z "$APP_PATH" ] || [ ! -d "$APP_PATH" ]; then
+            echo "Unsigned Runner.app was not produced."
+            exit 1
+          fi
+
+          mkdir -p build/ios/unsigned/Payload
+          cp -R "$APP_PATH" build/ios/unsigned/Payload/Runner.app
+          (
+            cd build/ios/unsigned
+            zip -r ../../../NeoStation-Forced-ForkIcon-unsigned.ipa Payload
+          )
+
+      - name: Remove temporary environment file
+        if: always()
+        run: rm -f .env
+
+      - name: Upload IPA artifact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: NeoStation-Forced-ForkIcon-unsigned-ipa
+          path: |
+            NeoStation-Forced-ForkIcon-unsigned.ipa
+            build/ios/xcodebuild-unsigned.log
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/build-force-fork-icon-ipa.yml
+++ b/.github/workflows/build-force-fork-icon-ipa.yml
@@ -18,8 +18,10 @@ jobs:
       SCREENSCRAPER_DEV_PASSWORD: ${{ secrets.SCREENSCRAPER_DEV_PASSWORD }}
 
     steps:
-      - name: Checkout
+      - name: Checkout latest main
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -154,7 +156,7 @@ jobs:
           cp -R "$APP_PATH" build/ios/unsigned/Payload/Runner.app
           (
             cd build/ios/unsigned
-            zip -r ../../../NeoStation-Forced-ForkIcon-unsigned.ipa Payload
+            zip -r ../../../NeoStation-Final-Stable-RPCS3-ForkIcon-unsigned.ipa Payload
           )
 
       - name: Remove temporary environment file
@@ -165,9 +167,9 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: NeoStation-Forced-ForkIcon-unsigned-ipa
+          name: NeoStation-Final-Stable-RPCS3-ForkIcon-unsigned-ipa
           path: |
-            NeoStation-Forced-ForkIcon-unsigned.ipa
+            NeoStation-Final-Stable-RPCS3-ForkIcon-unsigned.ipa
             build/ios/xcodebuild-unsigned.log
           if-no-files-found: error
           retention-days: 7


### PR DESCRIPTION
Temporary CI-only PR. Builds the current main branch while forcibly overwriting every generated iOS AppIcon slot from assets/images/fork-icon-valid.jpg after flutter_launcher_icons. Do not merge; this exists only to produce a test IPA and verify the fork logo is actually embedded in the iOS asset catalog.