### PR TITLE
Trigger audited repository cleanup

### DIFF
--- a/.cleanup-trigger
+++ b/.cleanup-trigger
@@ -1,0 +1,1 @@
+temporary cleanup trigger


### PR DESCRIPTION
Temporary marker commit used to trigger the cleanup executor on the final cleanup branch. The marker itself is removed by the cleanup script before the branch is merged to main.