### PR TITLE
Verify audited cleanup branch from main

### DIFF
--- a/.verify-cleanup-branch-trigger
+++ b/.verify-cleanup-branch-trigger
@@ -1,0 +1,1 @@
+temporary verification trigger


### PR DESCRIPTION
Temporary marker used to trigger the main-branch cleanup verifier against maintenance/final-repository-cleanup. It will be removed before the final repository cleanup is completed.