### PR TITLE
Add private web installer for NeoStation iOS

### DIFF
--- a/web-installer/.env.example
+++ b/web-installer/.env.example
@@ -1,0 +1,15 @@
+# HTTP Basic Auth protecting the installer page itself
+INSTALLER_USER=neostation
+INSTALLER_PASSWORD=change-me-with-a-long-random-password
+
+# Long random token used by iOS when fetching manifest/IPA outside the browser session
+INSTALL_TOKEN=change-me-with-at-least-32-random-characters
+
+# Direct HTTPS URL of the ALREADY SIGNED IPA.
+# The current GitHub Actions unsigned IPA cannot be used here as-is.
+IPA_SOURCE_URL=https://example.com/private-builds/NeoStation-signed.ipa
+
+APP_TITLE=NeoStation iOS
+APP_BUNDLE_ID=com.neogamelab.neostation
+APP_VERSION=1.0
+BUILD_LABEL=Private Beta

--- a/web-installer/README.md
+++ b/web-installer/README.md
@@ -1,0 +1,55 @@
+# NeoStation iOS — Private Web Installer
+
+This folder contains a small private OTA installation portal intended for iPhone/iPad browsers.
+
+## What it does
+
+- Protects the landing page with HTTP Basic Auth.
+- Marks every route `noindex` / `nofollow` / `noarchive`.
+- Generates the Apple OTA `manifest.plist` dynamically.
+- Uses a long install token because the iOS installation service fetches the manifest and IPA outside the browser page itself.
+- Redirects the token-protected `/app.ipa` endpoint to the configured signed IPA URL.
+
+## Important signing limitation
+
+The GitHub Actions IPA produced by NeoStation's current `feature/library-native` workflow is **unsigned**. An unsigned IPA cannot be installed by the web button.
+
+For OTA installation, configure `IPA_SOURCE_URL` with an **already signed** IPA that the target device is allowed to install. The IPA and manifest must be reachable over HTTPS. Apple documents website-based installation using a manifest and a trusted signed app; distribution/profile requirements depend on the signing/distribution method being used.
+
+## Deploy on Vercel
+
+1. Import `TarbleFR/neostation-ios` into Vercel.
+2. Select branch `feature/private-web-installer`.
+3. Set **Root Directory** to `web-installer`.
+4. Add the environment variables listed in `.env.example`.
+5. Deploy.
+6. Open the resulting HTTPS URL from Chrome or Safari on the iPhone.
+7. Enter the Basic Auth username/password.
+8. Tap **Installer NeoStation iOS**.
+
+## Environment variables
+
+- `INSTALLER_USER`: private page login.
+- `INSTALLER_PASSWORD`: private page password. Use a strong random value.
+- `INSTALL_TOKEN`: at least 32 random characters. This protects manifest/IPA endpoints used outside the browser auth session.
+- `IPA_SOURCE_URL`: direct HTTPS URL to a signed NeoStation IPA.
+- `APP_TITLE`: defaults to `NeoStation iOS`.
+- `APP_BUNDLE_ID`: defaults to `com.neogamelab.neostation`.
+- `APP_VERSION`: version string inserted in the manifest.
+- `BUILD_LABEL`: text shown on the private portal.
+
+## Security model
+
+The page itself is server-side password protected. The manifest and `/app.ipa` route use a separate opaque token because iOS may fetch installation resources independently of the browser's Basic Auth session.
+
+The final `IPA_SOURCE_URL` must remain reachable by the iOS installation service. For stronger control, use an HTTPS object-storage URL with a long unguessable path or another distribution backend designed to serve the signed IPA. Do not commit certificates, provisioning profiles, passwords, tokens, or signing keys to this repository.
+
+## Routes
+
+- `/` — authenticated private installer page.
+- `/manifest.plist?token=...` — token-gated Apple OTA manifest.
+- `/app.ipa?token=...` — token-gated redirect to `IPA_SOURCE_URL`.
+
+## Chrome on iOS
+
+The page itself is standard HTTPS and works in iOS browsers. The install button uses Apple's `itms-services://` handoff. If an iOS browser refuses to hand off that custom scheme, open the same private URL in Safari and retry.

--- a/web-installer/api/index.js
+++ b/web-installer/api/index.js
@@ -1,0 +1,143 @@
+const crypto = require('crypto');
+
+function safeEqual(a, b) {
+  const left = Buffer.from(String(a || ''), 'utf8');
+  const right = Buffer.from(String(b || ''), 'utf8');
+  if (left.length !== right.length) return false;
+  return crypto.timingSafeEqual(left, right);
+}
+
+function unauthorized(res) {
+  res.setHeader('WWW-Authenticate', 'Basic realm="NeoStation iOS Installer", charset="UTF-8"');
+  res.status(401).send('Authentication required.');
+}
+
+function requireBasicAuth(req, res) {
+  const expectedUser = process.env.INSTALLER_USER;
+  const expectedPassword = process.env.INSTALLER_PASSWORD;
+  if (!expectedUser || !expectedPassword) {
+    res.status(503).send('Installer authentication is not configured.');
+    return false;
+  }
+
+  const header = req.headers.authorization || '';
+  if (!header.startsWith('Basic ')) {
+    unauthorized(res);
+    return false;
+  }
+
+  let decoded = '';
+  try {
+    decoded = Buffer.from(header.slice(6), 'base64').toString('utf8');
+  } catch (_) {
+    unauthorized(res);
+    return false;
+  }
+
+  const separator = decoded.indexOf(':');
+  if (separator < 0) {
+    unauthorized(res);
+    return false;
+  }
+
+  const user = decoded.slice(0, separator);
+  const password = decoded.slice(separator + 1);
+  if (!safeEqual(user, expectedUser) || !safeEqual(password, expectedPassword)) {
+    unauthorized(res);
+    return false;
+  }
+  return true;
+}
+
+function htmlEscape(value) {
+  return String(value || '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+module.exports = (req, res) => {
+  res.setHeader('Cache-Control', 'no-store, max-age=0');
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive');
+  res.setHeader('Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'");
+
+  if (!requireBasicAuth(req, res)) return;
+
+  const token = process.env.INSTALL_TOKEN;
+  const ipaUrl = process.env.IPA_SOURCE_URL;
+  const appTitle = process.env.APP_TITLE || 'NeoStation iOS';
+  const version = process.env.APP_VERSION || 'Beta';
+  const buildLabel = process.env.BUILD_LABEL || 'Private build';
+
+  const host = req.headers['x-forwarded-host'] || req.headers.host;
+  const origin = `https://${host}`;
+  const ready = Boolean(token && ipaUrl && ipaUrl.startsWith('https://'));
+  const manifestUrl = ready
+    ? `${origin}/manifest.plist?token=${encodeURIComponent(token)}`
+    : '';
+  const installUrl = ready
+    ? `itms-services://?action=download-manifest&url=${encodeURIComponent(manifestUrl)}`
+    : '#';
+
+  const body = `<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="robots" content="noindex,nofollow,noarchive">
+  <meta name="theme-color" content="#111318">
+  <title>${htmlEscape(appTitle)} — Private Installer</title>
+  <style>
+    :root { color-scheme: dark; font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", Inter, system-ui, sans-serif; }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-height: 100vh; background: radial-gradient(circle at 30% 0%, #24273d 0, #111318 34%, #090a0d 100%); color: #f7f8fb; display: grid; place-items: center; padding: 24px; }
+    main { width: min(620px, 100%); }
+    .card { background: rgba(24,27,34,.82); border: 1px solid rgba(255,255,255,.1); border-radius: 28px; padding: 30px; box-shadow: 0 30px 90px rgba(0,0,0,.38); backdrop-filter: blur(18px); }
+    .brand { display: flex; gap: 14px; align-items: center; margin-bottom: 24px; }
+    .icon { width: 58px; height: 58px; border-radius: 17px; display: grid; place-items: center; font-size: 30px; background: linear-gradient(145deg,#7567ff,#5144e8); box-shadow: inset 0 1px rgba(255,255,255,.22); }
+    h1 { font-size: clamp(28px, 6vw, 42px); line-height: 1.02; margin: 0; letter-spacing: -.04em; }
+    .eyebrow { color: #9ba3b5; font-size: 13px; text-transform: uppercase; letter-spacing: .12em; margin-bottom: 5px; }
+    .meta { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin: 22px 0; }
+    .pill { background: rgba(255,255,255,.055); border: 1px solid rgba(255,255,255,.07); border-radius: 15px; padding: 13px 14px; }
+    .label { font-size: 12px; color: #8e97aa; margin-bottom: 3px; }
+    .value { font-weight: 650; }
+    .install { display: block; text-align: center; text-decoration: none; color: white; font-weight: 760; font-size: 18px; padding: 17px 20px; border-radius: 17px; background: linear-gradient(135deg,#6e61ff,#5144e8); box-shadow: 0 12px 30px rgba(81,68,232,.35); margin-top: 8px; }
+    .install.disabled { opacity: .42; pointer-events: none; box-shadow: none; }
+    .note { margin-top: 18px; font-size: 13px; line-height: 1.55; color: #a9b0bf; }
+    .warning { margin-top: 18px; padding: 14px 15px; border-radius: 15px; background: rgba(255,184,77,.09); border: 1px solid rgba(255,184,77,.18); color: #ffd397; font-size: 13px; line-height: 1.45; }
+    .ok { color: #7ce6bd; }
+    .bad { color: #ffb57e; }
+    footer { text-align: center; color: #6f7788; font-size: 12px; margin-top: 16px; }
+    @media (max-width: 540px) { .card { padding: 23px; border-radius: 23px; } .meta { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="card">
+      <div class="brand">
+        <div class="icon">◈</div>
+        <div>
+          <div class="eyebrow">Private iOS Installer</div>
+          <h1>${htmlEscape(appTitle)}</h1>
+        </div>
+      </div>
+      <div class="meta">
+        <div class="pill"><div class="label">Version</div><div class="value">${htmlEscape(version)}</div></div>
+        <div class="pill"><div class="label">Build</div><div class="value">${htmlEscape(buildLabel)}</div></div>
+        <div class="pill"><div class="label">Distribution</div><div class="value">Sideload / OTA</div></div>
+        <div class="pill"><div class="label">Status</div><div class="value ${ready ? 'ok' : 'bad'}">${ready ? 'Prêt à installer' : 'Configuration requise'}</div></div>
+      </div>
+      <a class="install ${ready ? '' : 'disabled'}" href="${htmlEscape(installUrl)}">Installer NeoStation iOS</a>
+      ${ready ? '' : '<div class="warning">Le portail est protégé, mais aucune IPA signée HTTPS n’est encore configurée. Renseigne INSTALL_TOKEN et IPA_SOURCE_URL dans Vercel.</div>'}
+      <p class="note">Ouvre cette page sur l’iPhone avec Chrome ou Safari, puis touche le bouton d’installation. iOS récupère ensuite le manifeste et l’IPA via HTTPS.</p>
+      <p class="note"><strong>Important :</strong> une IPA non signée ne peut pas être installée par ce bouton. L’IPA publiée doit être signée avec un profil/certificat accepté par l’appareil.</p>
+    </section>
+    <footer>NeoStation iOS · Private distribution portal · noindex</footer>
+  </main>
+</body>
+</html>`;
+
+  res.status(200).setHeader('Content-Type', 'text/html; charset=utf-8').send(body);
+};

--- a/web-installer/api/ipa.js
+++ b/web-installer/api/ipa.js
@@ -1,0 +1,28 @@
+const crypto = require('crypto');
+
+function safeEqual(a, b) {
+  const left = Buffer.from(String(a || ''), 'utf8');
+  const right = Buffer.from(String(b || ''), 'utf8');
+  if (left.length !== right.length) return false;
+  return crypto.timingSafeEqual(left, right);
+}
+
+module.exports = (req, res) => {
+  res.setHeader('Cache-Control', 'no-store, max-age=0');
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive');
+
+  const expectedToken = process.env.INSTALL_TOKEN;
+  const receivedToken = req.query?.token;
+  if (!expectedToken || !safeEqual(receivedToken, expectedToken)) {
+    res.status(403).send('Forbidden');
+    return;
+  }
+
+  const ipaSourceUrl = process.env.IPA_SOURCE_URL;
+  if (!ipaSourceUrl || !ipaSourceUrl.startsWith('https://')) {
+    res.status(503).send('IPA_SOURCE_URL is not configured.');
+    return;
+  }
+
+  res.status(302).setHeader('Location', ipaSourceUrl).end();
+};

--- a/web-installer/api/manifest.js
+++ b/web-installer/api/manifest.js
@@ -1,0 +1,77 @@
+const crypto = require('crypto');
+
+function safeEqual(a, b) {
+  const left = Buffer.from(String(a || ''), 'utf8');
+  const right = Buffer.from(String(b || ''), 'utf8');
+  if (left.length !== right.length) return false;
+  return crypto.timingSafeEqual(left, right);
+}
+
+function xmlEscape(value) {
+  return String(value || '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+module.exports = (req, res) => {
+  res.setHeader('Cache-Control', 'no-store, max-age=0');
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive');
+
+  const expectedToken = process.env.INSTALL_TOKEN;
+  const receivedToken = req.query?.token;
+  if (!expectedToken || !safeEqual(receivedToken, expectedToken)) {
+    res.status(403).send('Forbidden');
+    return;
+  }
+
+  const ipaSourceUrl = process.env.IPA_SOURCE_URL;
+  if (!ipaSourceUrl || !ipaSourceUrl.startsWith('https://')) {
+    res.status(503).send('IPA_SOURCE_URL is not configured.');
+    return;
+  }
+
+  const appTitle = process.env.APP_TITLE || 'NeoStation iOS';
+  const bundleId = process.env.APP_BUNDLE_ID || 'com.neogamelab.neostation';
+  const version = process.env.APP_VERSION || '1.0';
+  const host = req.headers['x-forwarded-host'] || req.headers.host;
+  const ipaUrl = `https://${host}/app.ipa?token=${encodeURIComponent(expectedToken)}`;
+
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>items</key>
+  <array>
+    <dict>
+      <key>assets</key>
+      <array>
+        <dict>
+          <key>kind</key>
+          <string>software-package</string>
+          <key>url</key>
+          <string>${xmlEscape(ipaUrl)}</string>
+        </dict>
+      </array>
+      <key>metadata</key>
+      <dict>
+        <key>bundle-identifier</key>
+        <string>${xmlEscape(bundleId)}</string>
+        <key>bundle-version</key>
+        <string>${xmlEscape(version)}</string>
+        <key>kind</key>
+        <string>software</string>
+        <key>title</key>
+        <string>${xmlEscape(appTitle)}</string>
+      </dict>
+    </dict>
+  </array>
+</dict>
+</plist>`;
+
+  res.status(200)
+    .setHeader('Content-Type', 'text/xml; charset=utf-8')
+    .send(plist);
+};

--- a/web-installer/vercel.json
+++ b/web-installer/vercel.json
@@ -1,18 +1,8 @@
 {
   "version": 2,
-  "routes": [
-    { "src": "/manifest\\.plist", "dest": "/api/manifest.js" },
-    { "src": "/app\\.ipa", "dest": "/api/ipa.js" },
-    { "src": "/", "dest": "/api/index.js" }
-  ],
-  "headers": [
-    {
-      "source": "/(.*)",
-      "headers": [
-        { "key": "X-Robots-Tag", "value": "noindex, nofollow, noarchive" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "Referrer-Policy", "value": "no-referrer" }
-      ]
-    }
+  "rewrites": [
+    { "source": "/manifest.plist", "destination": "/api/manifest" },
+    { "source": "/app.ipa", "destination": "/api/ipa" },
+    { "source": "/", "destination": "/api/index" }
   ]
 }

--- a/web-installer/vercel.json
+++ b/web-installer/vercel.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "routes": [
+    { "src": "/manifest\\.plist", "dest": "/api/manifest.js" },
+    { "src": "/app\\.ipa", "dest": "/api/ipa.js" },
+    { "src": "/", "dest": "/api/index.js" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Robots-Tag", "value": "noindex, nofollow, noarchive" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "no-referrer" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a Vercel-ready private OTA installer portal for NeoStation iOS.

- HTTP Basic Auth protects the landing page server-side.
- `manifest.plist` is generated dynamically for Apple OTA installation.
- Separate long install token protects manifest/IPA fetches made outside the browser session.
- IPA delivery is configured through `IPA_SOURCE_URL` so signing artifacts/secrets are never committed.
- `noindex`/`nofollow` headers and page metadata reduce accidental discovery.
- Includes deployment and signing requirements documentation.

Important: the existing GitHub Actions IPA is unsigned and cannot be installed through this OTA page until `IPA_SOURCE_URL` points to an already signed IPA that the target device can install.