### PR TITLE
Trigger Gallica import-only Library cleanup

### DIFF
--- a/tools/.library_cleanup_pr_trigger
+++ b/tools/.library_cleanup_pr_trigger
@@ -1,0 +1,1 @@
+Trigger the import-only Gallica cleanup workflow from a same-repository pull request.

--- a/tools/.library_cleanup_pr_trigger
+++ b/tools/.library_cleanup_pr_trigger
@@ -1,1 +1,2 @@
 Trigger the import-only Gallica cleanup workflow from a same-repository pull request.
+Second synchronization after source-only workflow update.


### PR DESCRIPTION
Temporary workflow trigger completed successfully. Gallica is now import-only on feature/library-native, imported Gallica OPDS compatibility is retained, obsolete one-shot patch tooling was removed, and the stable read-only IPA build workflow was restored.