### PR TITLE
Auto-sync iOS libraries and respect Dynamic Island

### DIFF
--- a/lib/screens/game_screen/my_games_carousel.dart
+++ b/lib/screens/game_screen/my_games_carousel.dart
@@ -1031,6 +1031,12 @@ class _GamesCarouselState extends State<GamesCarousel> {
     );
 
     _buildSettledChrome();
+    final safeLeftInset = Platform.isIOS
+        ? MediaQuery.viewPaddingOf(context).left
+        : 0.0;
+    final safeRightInset = Platform.isIOS
+        ? MediaQuery.viewPaddingOf(context).right
+        : 0.0;
 
     return Stack(
       children: [
@@ -1042,7 +1048,10 @@ class _GamesCarouselState extends State<GamesCarousel> {
             // the vertical legend on the left.
             Expanded(
               child: Padding(
-                padding: EdgeInsets.symmetric(horizontal: 60.r),
+                padding: EdgeInsets.only(
+                  left: 60.r + safeLeftInset,
+                  right: 60.r + safeRightInset,
+                ),
                 child: NativeCarousel(
                   key: _carouselKey,
                   itemCount: widget.games.length,
@@ -1163,7 +1172,9 @@ class _GamesCarouselState extends State<GamesCarousel> {
           curve: Curves.easeOutCubic,
           top: 12.r,
           bottom: 12.r,
-          left: GameLegendVisibility.hidden.value ? -72.r : 10.r,
+          left: GameLegendVisibility.hidden.value
+              ? -(72.r + safeLeftInset)
+              : safeLeftInset + 10.r,
           child: AnimatedOpacity(
             duration: const Duration(milliseconds: 250),
             opacity: GameLegendVisibility.hidden.value ? 0.0 : 1.0,

--- a/lib/screens/game_screen/my_games_grid.dart
+++ b/lib/screens/game_screen/my_games_grid.dart
@@ -1027,6 +1027,9 @@ class _GamesGridState extends State<GamesGrid> {
     }
 
     _buildSettledChrome();
+    final safeLeftInset = Platform.isIOS
+        ? MediaQuery.viewPaddingOf(context).left
+        : 0.0;
 
     return Stack(
       children: [
@@ -1041,7 +1044,9 @@ class _GamesGridState extends State<GamesGrid> {
               // smaller when the legend is shown.
               child: Padding(
                 padding: EdgeInsets.only(
-                  left: GameLegendVisibility.hidden.value ? 0 : 72.r,
+                  left:
+                      safeLeftInset +
+                      (GameLegendVisibility.hidden.value ? 0 : 72.r),
                 ),
                 child: LayoutBuilder(
                   builder: (context, constraints) {
@@ -1256,7 +1261,9 @@ class _GamesGridState extends State<GamesGrid> {
           curve: Curves.easeOutCubic,
           top: 12.r,
           bottom: 12.r,
-          left: GameLegendVisibility.hidden.value ? -72.r : 10.r,
+          left: GameLegendVisibility.hidden.value
+              ? -(72.r + safeLeftInset)
+              : safeLeftInset + 10.r,
           child: AnimatedOpacity(
             duration: const Duration(milliseconds: 250),
             opacity: GameLegendVisibility.hidden.value ? 0.0 : 1.0,

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -1087,6 +1087,9 @@ class _SystemGamesListState extends State<SystemGamesList> {
   /// info/preview panel (right). The selected game's fanart is rendered behind
   /// the entire viewport so it peeks through both panels.
   Widget _buildGamesList() {
+    final safeLeftInset = Platform.isIOS
+        ? MediaQuery.viewPaddingOf(context).left
+        : 0.0;
     final availableHeight =
         MediaQuery.of(context).size.height -
         MediaQuery.of(context).padding.top -
@@ -1128,7 +1131,9 @@ class _SystemGamesListState extends State<SystemGamesList> {
               width: 200.r,
               height: availableHeight,
               margin: EdgeInsets.only(
-                left: GameLegendVisibility.hidden.value ? 12.r : 72.r,
+                left:
+                    safeLeftInset +
+                    (GameLegendVisibility.hidden.value ? 12.r : 72.r),
                 top: 12.r,
                 bottom: 12.r,
               ),
@@ -1202,7 +1207,9 @@ class _SystemGamesListState extends State<SystemGamesList> {
             curve: Curves.easeOutCubic,
             top: 12.r,
             bottom: 12.r,
-            left: GameLegendVisibility.hidden.value ? -72.r : 10.r,
+            left: GameLegendVisibility.hidden.value
+                ? -(72.r + safeLeftInset)
+                : safeLeftInset + 10.r,
             child: AnimatedOpacity(
               duration: const Duration(milliseconds: 250),
               opacity: GameLegendVisibility.hidden.value ? 0.0 : 1.0,

--- a/lib/widgets/setup_wizard.dart
+++ b/lib/widgets/setup_wizard.dart
@@ -85,6 +85,11 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
   /// push stops re-asserting `setupWizardActive` and the dock can come in.
   bool _finishing = false;
 
+  // iOS first-run library linking is kicked off automatically once the app is
+  // active. This guard prevents duplicate document pickers across lifecycle
+  // transitions while RetroArch hands the user back to NeoStation.
+  bool _initialIosLibraryLinkStarted = false;
+
   static final _log = LoggerService.instance;
 
   GamepadNavigation? _gamepadNav;
@@ -123,6 +128,11 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
     WidgetsBinding.instance.addObserver(this);
     _initializeSteps();
     _initGamepad();
+    if (Platform.isIOS) {
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        await _startInitialIosLibraryLinkIfNeeded();
+      });
+    }
     if (Platform.isAndroid) {
       _secondaryDisplayState = SecondaryDisplayState.instance;
       _hasSecondaryDisplay =
@@ -159,11 +169,22 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed && Platform.isAndroid) {
+    if (state != AppLifecycleState.resumed) return;
+
+    if (Platform.isAndroid) {
       _refreshPermissionStates();
       // The gamepad was deactivated before we sent the user to Settings; bring
       // it back now that we have focus again on the Permissions step.
       if (_currentStep == _stepPermissions) _gamepadNav?.activate();
+      return;
+    }
+
+    // RetroArch's first-run sync temporarily backgrounds NeoStation. Wait for
+    // the return before presenting the security-scoped folder picker. Manic
+    // EMU never leaves the app here, so its picker is normally started by the
+    // initial post-frame callback above.
+    if (Platform.isIOS) {
+      _startInitialIosLibraryLinkIfNeeded();
     }
   }
 
@@ -2000,7 +2021,46 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
     }
   }
 
-  Future<void> _selectFolder() async {
+  Future<void> _startInitialIosLibraryLinkIfNeeded() async {
+    if (!Platform.isIOS ||
+        !mounted ||
+        _currentStep != _stepFolder ||
+        _isSelectingFolder ||
+        _initialIosLibraryLinkStarted) {
+      return;
+    }
+
+    // Do not attempt to present UIDocumentPicker while NeoStation is inactive
+    // (notably while RetroArch is still in the foreground for its callback).
+    if (WidgetsBinding.instance.lifecycleState != AppLifecycleState.resumed) {
+      return;
+    }
+
+    final primary = await IosEmulatorPreferenceService.primary();
+    if (!mounted || _currentStep != _stepFolder || _isSelectingFolder) return;
+
+    final existingLink = primary == IosLibraryEmulator.manicEmu
+        ? ConfigService.linkedManicEmuFolderPath
+        : ConfigService.linkedExternalFolderPath;
+    if (existingLink != null && existingLink.trim().isNotEmpty) return;
+
+    _initialIosLibraryLinkStarted = true;
+    try {
+      // The picker is the one iOS-required user confirmation. Once granted,
+      // _selectFolder persists the bookmark, registers the ROM source and runs
+      // the real scan immediately, so no trip to Settings > Directories is
+      // required on first use.
+      await _selectFolder(allowInternalFallback: false);
+    } finally {
+      // A cancellation leaves the user on the same wizard step, where the main
+      // action can retry normally. A successful link advances to Scanning.
+      if (mounted && _currentStep == _stepFolder) {
+        _initialIosLibraryLinkStarted = false;
+      }
+    }
+  }
+
+  Future<void> _selectFolder({bool allowInternalFallback = true}) async {
     if (_currentStep != _stepFolder) return;
 
     // Guard: prevent re-entry and stop gamepad from intercepting picker events
@@ -2076,9 +2136,11 @@ class _SetupWizardState extends State<SetupWizard> with WidgetsBindingObserver {
               type: NotificationType.info,
             );
           }
-        } else if (mounted) {
-          // Declined/cancelled the picker — fall back to the internal
-          // default so onboarding still has somewhere to go.
+        } else if (mounted && allowInternalFallback) {
+          // Manual folder selection retains the historical internal fallback.
+          // The automatic first-run attempt deliberately stays on this step if
+          // the picker is cancelled, so it never silently replaces the chosen
+          // RetroArch/Manic EMU library with NeoStation's private ROM folder.
           await configProvider.selectRomFolder(scan: false);
           result = configProvider.config.romFolder;
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ workspace:
   - packages/gamepads_darwin
   - packages/gamepads_platform_interface
 
-version: 1.0.0+158
+version: 1.0.0+159
 environment:
   sdk: '>=3.9.2'
 


### PR DESCRIPTION
Automates the first-use library link/scan for Manic EMU IPA (and completes the RetroArch TestFlight first-run flow) so users do not need to visit synchronized directories manually. Also applies the iOS landscape safe-area inset to list, grid and carousel game playlist views so the action rail and content stay clear of the Dynamic Island/cutout. Bumps the iOS build to 159.