### PR TITLE
Route iOS games by actual library membership

### DIFF
--- a/lib/services/game/game_launch_service.dart
+++ b/lib/services/game/game_launch_service.dart
@@ -249,13 +249,12 @@ class GameLaunchService {
           }
         }
 
-        // Multi-system iOS libraries: RetroArch and Manic EMU can coexist.
-        // A per-game choice wins; otherwise the user's primary app is used.
-        // When both apps can handle a newly-seen game, ask once and remember.
-        var libraryEmulator =
-            await IosEmulatorPreferenceService.choiceForGame(game.romPath!);
-        final retroArchHasGame =
-            RetroArchLibraryService.hasGameForRomPath(game.romPath!);
+        // Multi-system iOS libraries: route by actual membership first.
+        // The user's primary emulator is only a preference when BOTH libraries
+        // contain this game. It is never a global override for every title.
+        final retroArchHasGame = RetroArchLibraryService.hasGameForRomPath(
+          game.romPath!,
+        );
         final manicInstalled = await ManicEmuLaunchService.isInstalled();
         final manicFolder = ConfigService.linkedManicEmuFolderPath;
         final manicHasGame =
@@ -263,53 +262,16 @@ class GameLaunchService {
             manicFolder != null &&
             (path.equals(manicFolder, game.romPath!) ||
                 path.isWithin(manicFolder, game.romPath!));
-
-        if (libraryEmulator == null && retroArchHasGame && manicHasGame) {
-          if (!context.mounted) return GameLaunchResult.failure('', '');
-          libraryEmulator = await showDialog<IosLibraryEmulator>(
-            context: context,
-            builder: (dialogContext) => AlertDialog(
-              title: Text(ManicEmuLocale.text(context, 'launchTitle')),
-              content: Text(ManicEmuLocale.launchBody(context, game.name)),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.pop(
-                    dialogContext,
-                    IosLibraryEmulator.retroArch,
-                  ),
-                  child: const Text('RetroArch'),
-                ),
-                FilledButton(
-                  onPressed: () => Navigator.pop(
-                    dialogContext,
-                    IosLibraryEmulator.manicEmu,
-                  ),
-                  child: const Text('Manic EMU'),
-                ),
-              ],
-            ),
-          );
-          if (libraryEmulator == null) {
-            return GameLaunchResult.success();
-          }
-          await IosEmulatorPreferenceService.setChoiceForGame(
-            game.romPath!,
-            libraryEmulator,
-          );
-        }
-        libraryEmulator ??= await IosEmulatorPreferenceService.primary();
+        final primaryLibraryEmulator =
+            await IosEmulatorPreferenceService.primary();
+        final libraryEmulator =
+            IosEmulatorPreferenceService.resolveLaunchEmulator(
+              primary: primaryLibraryEmulator,
+              retroArchHasGame: retroArchHasGame,
+              manicEmuHasGame: manicHasGame,
+            );
 
         if (libraryEmulator == IosLibraryEmulator.manicEmu) {
-          if (!shouldAttemptManicDirectLaunch(
-            libraryEmulator,
-            installed: manicInstalled,
-          )) {
-            return GameLaunchResult.failure(
-              '${ManicEmuLocale.text(context, 'useManic')}: '
-              '${AppLocale.notInstalled.getString(context)}',
-              game.romPath,
-            );
-          }
           final launched = await ManicEmuLaunchService.launchGame(
             game.romPath!,
           );

--- a/lib/services/ios_emulator_preference_service.dart
+++ b/lib/services/ios_emulator_preference_service.dart
@@ -54,6 +54,21 @@ class IosEmulatorPreferenceService {
     await prefs.setString('$_gameChoicePrefix$romPath', _encode(emulator));
   }
 
+  /// Chooses the iOS library app for one game from actual library availability.
+  ///
+  /// The primary emulator is a preference only when both libraries contain the
+  /// game. It must never route a RetroArch-only game to Manic EMU, or vice versa.
+  static IosLibraryEmulator? resolveLaunchEmulator({
+    required IosLibraryEmulator primary,
+    required bool retroArchHasGame,
+    required bool manicEmuHasGame,
+  }) {
+    if (retroArchHasGame && manicEmuHasGame) return primary;
+    if (retroArchHasGame) return IosLibraryEmulator.retroArch;
+    if (manicEmuHasGame) return IosLibraryEmulator.manicEmu;
+    return null;
+  }
+
   /// Resolves the iOS library applications associated with a system's games.
   ///
   /// A per-game choice is authoritative. Otherwise the ROM's persisted path

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ workspace:
   - packages/gamepads_darwin
   - packages/gamepads_platform_interface
 
-version: 1.0.0+159
+version: 1.0.0+160
 environment:
   sdk: '>=3.9.2'
 

--- a/test/ios_system_emulator_association_test.dart
+++ b/test/ios_system_emulator_association_test.dart
@@ -31,18 +31,19 @@ void main() {
     );
   });
 
-  test('an explicit per-game choice takes precedence over folder ownership', () {
-    const romPath = '$manicRoot/Datas/Bravely Default.3ds';
-    expect(
-      resolve(
-        romPaths: const [romPath],
-        gameChoices: const {
-          romPath: IosLibraryEmulator.retroArch,
-        },
-      ),
-      const {IosLibraryEmulator.retroArch},
-    );
-  });
+  test(
+    'an explicit per-game choice takes precedence over folder ownership',
+    () {
+      const romPath = '$manicRoot/Datas/Bravely Default.3ds';
+      expect(
+        resolve(
+          romPaths: const [romPath],
+          gameChoices: const {romPath: IosLibraryEmulator.retroArch},
+        ),
+        const {IosLibraryEmulator.retroArch},
+      );
+    },
+  );
 
   test('a mixed system library exposes both iOS emulator applications', () {
     expect(
@@ -52,10 +53,7 @@ void main() {
           '$retroArchRoot/roms/3ds/Mario Kart 7.3ds',
         ],
       ),
-      const {
-        IosLibraryEmulator.manicEmu,
-        IosLibraryEmulator.retroArch,
-      },
+      const {IosLibraryEmulator.manicEmu, IosLibraryEmulator.retroArch},
     );
   });
 
@@ -94,30 +92,92 @@ void main() {
       const {IosLibraryEmulator.manicEmu},
     );
     expect(
-      resolve(
-        romPaths: const [],
-        primary: IosLibraryEmulator.manicEmu,
-      ),
+      resolve(romPaths: const [], primary: IosLibraryEmulator.manicEmu),
       const {IosLibraryEmulator.manicEmu},
     );
   });
 
-  test('the informational iOS emulator row cannot mutate database defaults', () {
-    final source = File(
-      'lib/widgets/system_emulator_settings_dialog.dart',
-    ).readAsStringSync();
-    final methodStart = source.indexOf('void _setSelectedAsDefault() {');
-    expect(methodStart, greaterThanOrEqualTo(0));
+  test(
+    'the informational iOS emulator row cannot mutate database defaults',
+    () {
+      final source = File('lib/widgets/system_emulator_settings_dialog.dart')
+          .readAsStringSync();
+      final methodStart = source.indexOf('void _setSelectedAsDefault() {');
+      expect(methodStart, greaterThanOrEqualTo(0));
 
-    final firstSelectionCheck = source.indexOf(
-      'if (_totalEmulators == 0',
-      methodStart,
+      final firstSelectionCheck = source.indexOf(
+        'if (_totalEmulators == 0',
+        methodStart,
+      );
+
+      expect(firstSelectionCheck, greaterThan(methodStart));
+      expect(
+        source.substring(methodStart, firstSelectionCheck),
+        contains('if (Platform.isIOS) return;'),
+      );
+    },
+  );
+  group('per-game iOS launch routing', () {
+    IosLibraryEmulator? route({
+      required IosLibraryEmulator primary,
+      required bool retroArch,
+      required bool manic,
+    }) => IosEmulatorPreferenceService.resolveLaunchEmulator(
+      primary: primary,
+      retroArchHasGame: retroArch,
+      manicEmuHasGame: manic,
     );
 
-    expect(firstSelectionCheck, greaterThan(methodStart));
-    expect(
-      source.substring(methodStart, firstSelectionCheck),
-      contains('if (Platform.isIOS) return;'),
-    );
+    test('RetroArch-only game ignores Manic primary preference', () {
+      expect(
+        route(
+          primary: IosLibraryEmulator.manicEmu,
+          retroArch: true,
+          manic: false,
+        ),
+        IosLibraryEmulator.retroArch,
+      );
+    });
+
+    test('Manic-only game ignores RetroArch primary preference', () {
+      expect(
+        route(
+          primary: IosLibraryEmulator.retroArch,
+          retroArch: false,
+          manic: true,
+        ),
+        IosLibraryEmulator.manicEmu,
+      );
+    });
+
+    test('game in both libraries uses the primary preference', () {
+      expect(
+        route(
+          primary: IosLibraryEmulator.manicEmu,
+          retroArch: true,
+          manic: true,
+        ),
+        IosLibraryEmulator.manicEmu,
+      );
+      expect(
+        route(
+          primary: IosLibraryEmulator.retroArch,
+          retroArch: true,
+          manic: true,
+        ),
+        IosLibraryEmulator.retroArch,
+      );
+    });
+
+    test('game in neither library does not force a library emulator', () {
+      expect(
+        route(
+          primary: IosLibraryEmulator.manicEmu,
+          retroArch: false,
+          manic: false,
+        ),
+        isNull,
+      );
+    });
   });
 }


### PR DESCRIPTION
Fixes iOS launch routing so the primary emulator is only a preference when both RetroArch TestFlight and Manic EMU IPA actually contain the game. A RetroArch-only game can no longer be sent to Manic EMU just because Manic is selected as primary, and vice versa. Adds regression tests for RetroArch-only, Manic-only, both, and neither cases. Bumps the build to 160.