### PR TITLE
Detect Manic membership across linked libraries

### DIFF
--- a/lib/services/game/game_launch_service.dart
+++ b/lib/services/game/game_launch_service.dart
@@ -17,6 +17,7 @@ import 'package:neostation/services/melonx_library_service.dart';
 import 'package:neostation/services/rpcs3_library_service.dart';
 import 'package:neostation/services/rpcs3_launch_service.dart';
 import 'package:neostation/services/manic_emu_launch_service.dart';
+import 'package:neostation/services/manic_emu_library_service.dart';
 import 'package:neostation/services/ios_emulator_preference_service.dart';
 import 'package:neostation/services/logger_service.dart';
 
@@ -256,12 +257,12 @@ class GameLaunchService {
           game.romPath!,
         );
         final manicInstalled = await ManicEmuLaunchService.isInstalled();
-        final manicFolder = ConfigService.linkedManicEmuFolderPath;
         final manicHasGame =
             manicInstalled &&
-            manicFolder != null &&
-            (path.equals(manicFolder, game.romPath!) ||
-                path.isWithin(manicFolder, game.romPath!));
+            await ManicEmuLibraryService.hasGameForRomPath(
+              ConfigService.linkedManicEmuFolderPath,
+              game.romPath!,
+            );
         final primaryLibraryEmulator =
             await IosEmulatorPreferenceService.primary();
         final libraryEmulator =

--- a/lib/services/manic_emu_library_service.dart
+++ b/lib/services/manic_emu_library_service.dart
@@ -41,6 +41,82 @@ class ManicEmuLibraryService {
     return await child.exists() ? child.path : null;
   }
 
+  /// Returns whether a ROM represented by [romPath] is actually present in the
+  /// linked Manic EMU library.
+  ///
+  /// A row originating from Manic itself is identified by folder ownership.
+  /// For a row originating from RetroArch, compare the filename stem against
+  /// Manic's public Documents/Datas folder. This also handles RetroArch ZIP
+  /// containers because Manic imports/extracts the contained ROM using the same
+  /// title stem before computing its launch identifier.
+  static Future<bool> hasGameForRomPath(
+    String? linkedPath,
+    String romPath,
+  ) async {
+    final root = linkedPath?.trim();
+    final rom = romPath.trim();
+    if (root == null || root.isEmpty || rom.isEmpty) return false;
+
+    final normalizedRoot = path.normalize(root);
+    final normalizedRom = path.normalize(rom);
+    if (path.equals(normalizedRoot, normalizedRom) ||
+        path.isWithin(normalizedRoot, normalizedRom)) {
+      return true;
+    }
+
+    final targetStem = path
+        .basenameWithoutExtension(normalizedRom)
+        .toLowerCase();
+    if (targetStem.isEmpty) return false;
+
+    final dataFolder = await resolveDataFolder(normalizedRoot);
+    if (dataFolder != null) {
+      try {
+        await for (final entity in Directory(
+          dataFolder,
+        ).list(recursive: false, followLinks: false)) {
+          if (entity is! File) continue;
+          if (path.basenameWithoutExtension(entity.path).toLowerCase() ==
+              targetStem) {
+            return true;
+          }
+        }
+      } catch (_) {
+        // An unavailable security-scoped bookmark means the game cannot be
+        // considered launchable from Manic for this session.
+      }
+    }
+
+    // 3DS installs live outside Datas. Only inspect that tree for 3DS-family
+    // extensions so ordinary ROM launches never pay for a recursive walk.
+    final extension = path
+        .extension(normalizedRom)
+        .toLowerCase()
+        .replaceFirst('.', '');
+    if (!nintendo3dsExtensions.contains(extension)) return false;
+
+    final documentsRoot = path.basename(normalizedRoot).toLowerCase() == 'datas'
+        ? path.dirname(normalizedRoot)
+        : normalizedRoot;
+    final threeDsRoot = Directory(path.join(documentsRoot, '3DS'));
+    if (!await threeDsRoot.exists()) return false;
+    try {
+      await for (final entity in threeDsRoot.list(
+        recursive: true,
+        followLinks: false,
+      )) {
+        if (entity is! File) continue;
+        if (path.basenameWithoutExtension(entity.path).toLowerCase() ==
+            targetStem) {
+          return true;
+        }
+      }
+    } catch (_) {
+      return false;
+    }
+    return false;
+  }
+
   static Future<bool> containsNintendo3dsGames(String dataFolder) async {
     final extensions = await extensionsInDataFolder(dataFolder);
     return extensions.any(nintendo3dsExtensions.contains);
@@ -52,10 +128,9 @@ class ManicEmuLibraryService {
   static Future<Set<String>> extensionsInDataFolder(String dataFolder) async {
     final extensions = <String>{};
     try {
-      await for (final entity in Directory(dataFolder).list(
-        recursive: false,
-        followLinks: false,
-      )) {
+      await for (final entity in Directory(
+        dataFolder,
+      ).list(recursive: false, followLinks: false)) {
         if (entity is! File) continue;
         final extension = path
             .extension(entity.path)

--- a/test/manic_emu_library_service_test.dart
+++ b/test/manic_emu_library_service_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:neostation/data/datasources/sqlite_database_service.dart';
 import 'package:neostation/models/system_model.dart';
 import 'package:neostation/services/manic_emu_library_service.dart';
+import 'package:path/path.dart' as path;
 
 import 'database_test_helper.dart';
 
@@ -42,23 +43,26 @@ void main() {
     );
   });
 
-  test('reads a large mixed Datas library without opening ROM contents', () async {
-    final data = await Directory.systemTemp.createTemp('manic_mixed_datas_');
-    addTearDown(() async {
-      if (await data.exists()) await data.delete(recursive: true);
-    });
+  test(
+    'reads a large mixed Datas library without opening ROM contents',
+    () async {
+      final data = await Directory.systemTemp.createTemp('manic_mixed_datas_');
+      addTearDown(() async {
+        if (await data.exists()) await data.delete(recursive: true);
+      });
 
-    const extensions = ['nes', 'sfc', 'gba', 'gbc', 'nds', '3ds'];
-    for (var index = 0; index < 60; index++) {
-      final extension = extensions[index % extensions.length];
-      File('${data.path}/Game $index.$extension').writeAsStringSync('rom');
-    }
+      const extensions = ['nes', 'sfc', 'gba', 'gbc', 'nds', '3ds'];
+      for (var index = 0; index < 60; index++) {
+        final extension = extensions[index % extensions.length];
+        File('${data.path}/Game $index.$extension').writeAsStringSync('rom');
+      }
 
-    expect(
-      await ManicEmuLibraryService.extensionsInDataFolder(data.path),
-      containsAll(extensions),
-    );
-  });
+      expect(
+        await ManicEmuLibraryService.extensionsInDataFolder(data.path),
+        containsAll(extensions),
+      );
+    },
+  );
 
   test('imports a 3DS ROM from Manic Datas as an extra scan path', () async {
     final helper = DatabaseTestHelper();
@@ -101,4 +105,33 @@ void main() {
     );
     expect(games.single['filename'], 'Mario Kart 7.3ds');
   });
+
+  test(
+    'RetroArch path is recognized when same game exists in Manic Datas',
+    () async {
+      final temp = await Directory.systemTemp.createTemp(
+        'manic_membership_test_',
+      );
+      addTearDown(() => temp.delete(recursive: true));
+      final datas = Directory(path.join(temp.path, 'Datas'));
+      await datas.create(recursive: true);
+      await File(path.join(datas.path, 'Virtua Racing Deluxe.32x'))
+          .writeAsBytes([1]);
+
+      expect(
+        await ManicEmuLibraryService.hasGameForRomPath(
+          temp.path,
+          '/RetroArch/32x/Virtua Racing Deluxe.zip',
+        ),
+        isTrue,
+      );
+      expect(
+        await ManicEmuLibraryService.hasGameForRomPath(
+          temp.path,
+          '/RetroArch/32x/WWF Raw.zip',
+        ),
+        isFalse,
+      );
+    },
+  );
 }


### PR DESCRIPTION
Completes the per-game routing fix by making Manic EMU membership detection symmetric with RetroArch. A game row originating from RetroArch is now recognized as also present in Manic when a matching title exists in Manic Documents/Datas, including RetroArch ZIP containers matched to Manic's extracted ROM stem. Adds regression coverage for positive and negative cross-library matches.