### PR TITLE
Restore Build 167 behavior and keep visual game-detail fixes

### DIFF
--- a/lib/screens/game_screen/game_details_card/tabs/game_details_achievements_tab.dart
+++ b/lib/screens/game_screen/game_details_card/tabs/game_details_achievements_tab.dart
@@ -27,7 +27,7 @@ class GameDetailsAchievementsTab extends StatefulWidget {
     required this.isLoading,
     required this.onRefresh,
     this.topOffset = 55.0,
-    this.bottomOffset = 110.0,
+    this.bottomOffset = 78.0,
     this.leftOffset = 12.0,
     this.rightOffset = 12.0,
     this.headerAction,
@@ -43,6 +43,30 @@ class GameDetailsAchievementsTabState
   int _selectedAchievementIndex = 0;
   final Map<int, GlobalKey> _achievementKeys = {};
   final ScrollController _scrollController = ScrollController();
+
+  @override
+  void didUpdateWidget(covariant GameDetailsAchievementsTab oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    // The same achievements tab State is reused while the user moves through a
+    // playlist. Keeping the previous game's selected badge/scroll position can
+    // leave the new game with a stale selection or an apparently shifted grid.
+    // Reset the visual state whenever the hydrated achievement payload changes.
+    if (!identical(oldWidget.gameInfo, widget.gameInfo)) {
+      _selectedAchievementIndex = 0;
+      _achievementKeys.clear();
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !_scrollController.hasClients) return;
+        _scrollController.jumpTo(0);
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   /// Lazily retrieves or creates a GlobalKey for an achievement item to enable 'ensureVisible' logic.
   GlobalKey _getAchievementKey(int index) {
@@ -161,6 +185,7 @@ class GameDetailsAchievementsTabState
                 ),
               ],
             ),
+            clipBehavior: Clip.antiAlias,
             child: Center(
               child: Column(
                 mainAxisSize: MainAxisSize.min,
@@ -199,6 +224,7 @@ class GameDetailsAchievementsTabState
               ),
             ],
           ),
+          clipBehavior: Clip.antiAlias,
           child: Center(
             child: Column(
               mainAxisSize: MainAxisSize.min,
@@ -252,6 +278,7 @@ class GameDetailsAchievementsTabState
             ),
           ],
         ),
+        clipBehavior: Clip.antiAlias,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -531,6 +558,7 @@ class _AchievementsGrid extends StatelessWidget {
     final radii = Theme.of(context).extension<CornerRadii>() ?? CornerRadii.m();
     return GridView.builder(
       controller: scrollController,
+      padding: EdgeInsets.zero,
       gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: 6,
         crossAxisSpacing: 4.r,
@@ -569,6 +597,14 @@ class _AchievementsGrid extends StatelessWidget {
                     : 'https://media.retroachievements.org/Badge/${achievement.badgeName}_lock.png',
                 cacheWidth: 64,
                 fit: BoxFit.cover,
+                errorBuilder: (context, error, stackTrace) => ColoredBox(
+                  color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                  child: Icon(
+                    Symbols.emoji_events_rounded,
+                    size: 18.r,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                ),
               ),
             ),
           ),

--- a/lib/screens/game_screen/game_details_card/tabs/game_details_screenshot_video_tab.dart
+++ b/lib/screens/game_screen/game_details_card/tabs/game_details_screenshot_video_tab.dart
@@ -111,125 +111,152 @@ class _GameDetailsScreenshotVideoTabState
       mediaAspectRatio = _imageAspectRatios[screenshotPath]!;
     }
 
-    if (mediaAspectRatio <= 0 || mediaAspectRatio.isNaN) {
+    if (mediaAspectRatio <= 0 ||
+        mediaAspectRatio.isNaN ||
+        mediaAspectRatio.isInfinite) {
       mediaAspectRatio = 16 / 9;
     }
 
-    return Padding(
-      padding: EdgeInsets.fromLTRB(8.r, 40.r, 8.r, 80.r),
-      child: Center(
-        child: Container(
-          decoration: BoxDecoration(
-            borderRadius:
-                Theme.of(context).extension<CornerRadii>()?.radiusInternal ??
-                BorderRadius.circular(14.r),
-            boxShadow: [
-              BoxShadow(
-                color: Theme.of(
-                  context,
-                ).colorScheme.shadow.withValues(alpha: 0.3),
-                blurRadius: 3.r,
-                offset: Offset(3.0.r, 3.0.r),
-              ),
-            ],
-            color: Colors.transparent,
-          ),
-          child: ClipRRect(
-            borderRadius:
-                Theme.of(context).extension<CornerRadii>()?.radiusInternal ??
-                BorderRadius.circular(14.r),
-            clipBehavior: Clip.antiAlias,
-            child: AspectRatio(
-              aspectRatio: mediaAspectRatio,
-              child: Stack(
-                fit: StackFit.expand,
-                children: [
-                  if (!widget.isVideoDelayActive &&
-                      hasVideo &&
-                      widget.videoController!.value.isInitialized &&
-                      widget.videoController!.value.size.width > 0 &&
-                      widget.videoController!.value.size.height > 0) ...[
-                    Consumer<SqliteConfigProvider>(
-                      builder: (context, config, child) {
-                        return VideoPlayer(widget.videoController!);
-                      },
-                    ),
-                  ] else if (File(screenshotPath).existsSync()) ...[
-                    Image.file(
-                      File(screenshotPath),
-                      height: double.infinity,
-                      cacheHeight: 640,
-                      key: ValueKey(
-                        '${screenshotPath}_fg_${widget.imageVersion}',
-                      ),
-                      fit: BoxFit.cover,
-                      errorBuilder: (_, _, _) => const SizedBox.shrink(),
-                    ),
-                  ] else
-                    Center(
-                      child: Icon(
-                        Symbols.videogame_asset_rounded,
-                        size: 48.r,
-                        color: Colors.white24,
-                      ),
-                    ),
+    final radii = Theme.of(context).extension<CornerRadii>() ?? CornerRadii.m();
 
-                  if (!widget.isVideoDelayActive && hasVideo)
-                    Positioned(
-                      bottom: 8.r,
-                      right: 8.r,
-                      child: ExcludeFocus(
-                        child: Material(
-                          color: Colors.black54,
-                          borderRadius:
-                              Theme.of(
-                                context,
-                              ).extension<CornerRadii>()?.radiusExternal ??
-                              BorderRadius.circular(14.r),
-                          child: InkWell(
-                            onTap: () {
-                              SfxService().playNavSound();
-                              widget.onToggleVideoMute();
-                            },
-                            canRequestFocus: false,
-                            focusColor: Colors.transparent,
-                            hoverColor: Colors.transparent,
-                            highlightColor: Colors.transparent,
-                            splashColor: Colors.transparent,
-                            borderRadius:
-                                Theme.of(
-                                  context,
-                                ).extension<CornerRadii>()?.radiusInternal ??
-                                BorderRadius.circular(14.r),
-                            child: Padding(
-                              padding: EdgeInsets.symmetric(
-                                horizontal: 8.r,
-                                vertical: 4.r,
-                              ),
-                              child: Consumer<SqliteConfigProvider>(
-                                builder: (context, configProvider, child) {
-                                  final isMuted =
-                                      !configProvider.config.videoSound;
-                                  return Icon(
-                                    isMuted
-                                        ? Symbols.volume_off_rounded
-                                        : Symbols.volume_up_rounded,
-                                    size: 16.r,
-                                    color: Colors.white,
-                                  );
+    // Reserve the real top and bottom chrome before fitting media. The header
+    // is 46.r and the footer is 61.r, so tall 4:3/vertical previews can never
+    // touch the tabs while wide Switch previews still get a little more room.
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final horizontalClearance = 8.r;
+        final headerClearance = 58.r;
+        final footerClearance = 72.r;
+
+        final availableWidth =
+            constraints.maxWidth - (horizontalClearance * 2);
+        final availableHeight =
+            constraints.maxHeight - headerClearance - footerClearance;
+
+        if (availableWidth <= 0 || availableHeight <= 0) {
+          return const SizedBox.shrink();
+        }
+
+        final maxMediaWidth = availableWidth < 230.r
+            ? availableWidth
+            : 230.r;
+        final maxMediaHeight = availableHeight < 175.r
+            ? availableHeight
+            : 175.r;
+
+        return Padding(
+          padding: EdgeInsets.fromLTRB(
+            horizontalClearance,
+            headerClearance,
+            horizontalClearance,
+            footerClearance,
+          ),
+          child: Center(
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: maxMediaWidth,
+                maxHeight: maxMediaHeight,
+              ),
+              child: AspectRatio(
+                aspectRatio: mediaAspectRatio,
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: radii.radiusInternal,
+                    boxShadow: [
+                      BoxShadow(
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.shadow.withValues(alpha: 0.3),
+                        blurRadius: 3.r,
+                        offset: Offset(3.0.r, 3.0.r),
+                      ),
+                    ],
+                    color: Colors.black,
+                  ),
+                  clipBehavior: Clip.antiAlias,
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      if (!widget.isVideoDelayActive &&
+                          hasVideo &&
+                          widget.videoController!.value.isInitialized &&
+                          widget.videoController!.value.size.width > 0 &&
+                          widget.videoController!.value.size.height > 0) ...[
+                        Consumer<SqliteConfigProvider>(
+                          builder: (context, config, child) {
+                            return VideoPlayer(widget.videoController!);
+                          },
+                        ),
+                      ] else if (File(screenshotPath).existsSync()) ...[
+                        Image.file(
+                          File(screenshotPath),
+                          height: double.infinity,
+                          cacheHeight: 640,
+                          key: ValueKey(
+                            '${screenshotPath}_fg_${widget.imageVersion}',
+                          ),
+                          fit: BoxFit.contain,
+                          errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                        ),
+                      ] else
+                        Center(
+                          child: Icon(
+                            Symbols.videogame_asset_rounded,
+                            size: 48.r,
+                            color: Colors.white24,
+                          ),
+                        ),
+
+                      if (!widget.isVideoDelayActive && hasVideo)
+                        Positioned(
+                          bottom: 8.r,
+                          right: 8.r,
+                          child: ExcludeFocus(
+                            child: Material(
+                              color: Colors.black54,
+                              borderRadius: radii.radiusExternal,
+                              child: InkWell(
+                                onTap: () {
+                                  SfxService().playNavSound();
+                                  widget.onToggleVideoMute();
                                 },
+                                canRequestFocus: false,
+                                focusColor: Colors.transparent,
+                                hoverColor: Colors.transparent,
+                                highlightColor: Colors.transparent,
+                                splashColor: Colors.transparent,
+                                borderRadius: radii.radiusInternal,
+                                child: Padding(
+                                  padding: EdgeInsets.symmetric(
+                                    horizontal: 8.r,
+                                    vertical: 4.r,
+                                  ),
+                                  child: Consumer<SqliteConfigProvider>(
+                                    builder: (context, configProvider, child) {
+                                      final isMuted =
+                                          !configProvider.config.videoSound;
+                                      return Icon(
+                                        isMuted
+                                            ? Symbols.volume_off_rounded
+                                            : Symbols.volume_up_rounded,
+                                        size: 16.r,
+                                        color: Colors.white,
+                                      );
+                                    },
+                                  ),
+                                ),
                               ),
                             ),
                           ),
                         ),
-                      ),
-                    ),
-                ],
+                    ],
+                  ),
+                ),
               ),
             ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
+++ b/lib/screens/game_screen/game_details_card/widgets/game_details_footer.dart
@@ -3,7 +3,6 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_localization/flutter_localization.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:neostation/l10n/app_locale.dart';
-import 'package:neostation/services/game_legend_visibility.dart';
 import 'package:neostation/services/sfx_service.dart';
 import 'package:neostation/themes/app_themes.dart';
 import '../../../../models/system_model.dart';
@@ -12,15 +11,13 @@ import '../../../../models/retro_achievements_game_info.dart';
 import '../../../../sync/i_sync_provider.dart';
 import 'package:neostation/themes/chrome_surface.dart';
 import '../../../../themes/corner_radii.dart';
-import '../../../../utils/game_utils.dart';
-import '../../../../widgets/marquee_text.dart';
 import '../../music/music_player.dart';
 
-/// A sticky footer component for the game details card that provides actionable controls and status summaries.
+/// Sticky action/status footer used by the game details list view.
 ///
-/// Manages high-level game interactions (Play), summarizes cloud synchronization
-/// health, and provides quick access to trophy progress. Dynamically adjusts for specialized
-/// systems like the Music Player.
+/// The selected game title is intentionally not repeated here because the list
+/// panel already owns that identity. Rating and game stats are grouped directly
+/// beside PLAY so the footer reads as one compact action cluster.
 class GameDetailsFooter extends StatelessWidget {
   final SystemModel system;
   final GameModel game;
@@ -55,7 +52,6 @@ class GameDetailsFooter extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Scenario 1: Specialized Music Player UI.
     if (isMusicSystem) {
       return Positioned(
         bottom: -0.5.r,
@@ -65,133 +61,41 @@ class GameDetailsFooter extends StatelessWidget {
       );
     }
 
-    // Scenario 2: Standard Game Metadata UI.
+    final hasPlayTime = (game.playTime ?? 0) > 0;
+    final hasCombinedStats = hasRetroAchievements || hasPlayTime;
+
     return Positioned(
       bottom: -0.5.r,
       left: -0.5.r,
       right: -0.5.r,
-      height: 105.r,
+      height: 61.r,
       child: ClipRRect(
         child: RepaintBoundary(
-          child: Container(
-            padding: EdgeInsets.symmetric(horizontal: 12.r),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // Identity Section: Title and ROM Filename.
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Expanded(
-                      child: RepaintBoundary(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            MarqueeText(
-                              text: GameUtils.formatGameName(game.name),
-                              isActive: true,
-                              style: TextStyle(
-                                color: Colors.white,
-                                fontSize: 20.r,
-                                fontWeight: FontWeight.bold,
-                                shadows: [
-                                  Shadow(
-                                    blurRadius: 1.r,
-                                    color: Colors.black,
-                                    offset: const Offset(2, 2),
-                                  ),
-                                ],
-                              ),
-                            ),
-                            // Always reserve the ROM-filename subtitle's line
-                            // height so the action row below keeps a constant
-                            // baseline. Unscraped games have no subtitle; without
-                            // this reservation the rating/RA pill + PLAY button
-                            // float up one line. The empty string still lays out
-                            // a full line box via the shared strut/style.
-                            Text(
-                              game.showRomFileNameSubtitle ? game.romname : '',
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              strutStyle: StrutStyle(
-                                fontSize: 12.r,
-                                height: 1.15,
-                                forceStrutHeight: true,
-                              ),
-                              style: TextStyle(
-                                color: Colors.white.withValues(alpha: 0.72),
-                                fontSize: 12.r,
-                                fontWeight: FontWeight.w400,
-                                height: 1.15,
-                                shadows: [
-                                  Shadow(
-                                    blurRadius: 1.r,
-                                    color: Colors.black,
-                                    offset: const Offset(2, 2),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 12.r, vertical: 8.r),
+            child: ExcludeFocus(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  const Spacer(),
+                  if (game.rating > 0) ...[
+                    _SteamStyleRating(game: game),
+                    if (hasCombinedStats) SizedBox(width: 5.r),
                   ],
-                ),
-                SizedBox(height: 8.r),
-
-                // Actionable Section: Compact status indicators and primary Play button.
-                ExcludeFocus(
-                  child: Row(
-                    children: [
-                      // Game rating.
-                      if (game.rating > 0) ...[
-                        _SteamStyleRating(game: game),
-                        SizedBox(width: 8.r),
-                      ],
-
-                      // RetroAchievements Progress. When the legend is hidden
-                      // the row gains width on the left; the indicator eases out
-                      // to fill the gap to PLAY (LayoutBuilder gives it a
-                      // concrete target width so the change animates instead of
-                      // snapping). When shown it rests at its natural width,
-                      // left-aligned, and the rest of the slot stays empty.
-                      Expanded(
-                        child: LayoutBuilder(
-                          builder: (context, constraints) => Align(
-                            alignment: Alignment.centerLeft,
-                            child: _buildCompactAchievementsIndicator(
-                              context,
-                              availableWidth: constraints.maxWidth,
-                              hasPlayTime:
-                                  GameUtils.formatPlayTime(
-                                    game.playTime ?? 0,
-                                  ) !=
-                                  '0s',
-                            ),
-                          ),
-                        ),
-                      ),
-                      // Accumulated play time, shown as its own pill to the
-                      // left of PLAY (only once the game has been played).
-                      if (GameUtils.formatPlayTime(game.playTime ?? 0) !=
-                          '0s') ...[
-                        SizedBox(width: 8.r),
-                        _PlayTimePill(game: game),
-                      ],
-
-                      // Consistent 8.r gap before PLAY, matching the spacing
-                      // between the rating, RA and play-time pills.
-                      SizedBox(width: 8.r),
-
-                      // Primary Launch Control.
-                      _buildPlayButtonCompact(context),
-                    ],
-                  ),
-                ),
-              ],
+                  if (hasCombinedStats) ...[
+                    _CombinedGameStatsPill(
+                      game: game,
+                      hasRetroAchievements: hasRetroAchievements,
+                      isLoadingAchievements: isLoadingAchievements,
+                      currentGameInfo: currentGameInfo,
+                      onShowAchievements: onShowAchievements,
+                    ),
+                    SizedBox(width: 8.r),
+                  ] else if (game.rating > 0)
+                    SizedBox(width: 8.r),
+                  _buildPlayButtonCompact(context),
+                ],
+              ),
             ),
           ),
         ),
@@ -199,13 +103,12 @@ class GameDetailsFooter extends StatelessWidget {
     );
   }
 
-  /// High-contrast primary button for launching the emulator.
-  ///
-  /// Includes visual feedback for gamepad focus and displays accumulated play-time statistics.
   Widget _buildPlayButtonCompact(BuildContext context) {
     return Builder(
       builder: (context) {
         final isFocused = Focus.of(context).hasFocus;
+        final radii = Theme.of(context).extension<CornerRadii>() ?? CornerRadii.m();
+
         return AnimatedContainer(
           duration: const Duration(milliseconds: 200),
           width: 104.r,
@@ -214,15 +117,11 @@ class GameDetailsFooter extends StatelessWidget {
             color: isFocused
                 ? const Color(0xFF36F184)
                 : const Color(0xFF2ECC71),
-            borderRadius:
-                Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
-                BorderRadius.circular(14.r),
-            border: Border.all(color: Color(0xFF36F184), width: 1.r),
+            borderRadius: radii.radiusExternal,
+            border: Border.all(color: const Color(0xFF36F184), width: 1.r),
             boxShadow: [
               BoxShadow(
-                color: Theme.of(
-                  context,
-                ).colorScheme.shadow.withValues(alpha: 0.1),
+                color: Theme.of(context).colorScheme.shadow.withValues(alpha: 0.1),
                 blurRadius: 4.r,
                 offset: Offset(2.0.r, 2.0.r),
               ),
@@ -236,15 +135,13 @@ class GameDetailsFooter extends StatelessWidget {
               hoverColor: Colors.transparent,
               highlightColor: Colors.transparent,
               splashColor: Colors.white.withValues(alpha: 0.1),
-              borderRadius:
-                  Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
-                  BorderRadius.circular(14.r),
+              borderRadius: radii.radiusExternal,
               onTap: () {
                 SfxService().playEnterSound();
                 onPlayGame();
               },
               child: Padding(
-                padding: EdgeInsets.only(left: 0.r, right: 10.r),
+                padding: EdgeInsets.only(right: 10.r),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
@@ -274,46 +171,138 @@ class GameDetailsFooter extends StatelessWidget {
       },
     );
   }
+}
 
-  /// Resolves the current RetroAchievements progress into a compact visual badge.
-  Widget _buildCompactAchievementsIndicator(
-    BuildContext context, {
-    required double availableWidth,
-    required bool hasPlayTime,
-  }) {
-    if (!hasRetroAchievements) return const SizedBox.shrink();
+/// One compact surface for the RetroAchievements game avatar and accumulated
+/// play time. This replaces the previous separate RA and play-time pills so the
+/// avatar can never spill visually between containers.
+class _CombinedGameStatsPill extends StatelessWidget {
+  final GameModel game;
+  final bool hasRetroAchievements;
+  final bool isLoadingAchievements;
+  final GameInfoAndUserProgress? currentGameInfo;
+  final VoidCallback onShowAchievements;
 
-    // The badge fills its (Expanded) slot when the legend is hidden, or when
-    // there is no play-time pill claiming the space to its right (otherwise it
-    // would leave dead space between itself and PLAY). When neither applies it
-    // rests at 120.r. The width is animated so toggling eases in/out.
-    final bool legendHidden = GameLegendVisibility.hidden.value;
-    final bool expand = legendHidden || !hasPlayTime;
-    final bool noAchievements =
-        !isLoadingAchievements &&
-        (currentGameInfo == null || currentGameInfo!.numAchievements == 0);
+  const _CombinedGameStatsPill({
+    required this.game,
+    required this.hasRetroAchievements,
+    required this.isLoadingAchievements,
+    required this.currentGameInfo,
+    required this.onShowAchievements,
+  });
 
-    final int awarded = currentGameInfo?.numAwardedToUser ?? 0;
-    final int total = currentGameInfo?.numAchievements ?? 0;
-    final double progress = total > 0 ? awarded / total : 0.0;
+  String _formatClock(int seconds) {
+    final h = seconds ~/ 3600;
+    final m = (seconds % 3600) ~/ 60;
+    final s = seconds % 60;
+    String pad(int value) => value.toString().padLeft(2, '0');
+    return '${pad(h)}:${pad(m)}:${pad(s)}';
+  }
 
-    final String progressText = isLoadingAchievements
-        ? AppLocale.loading.getString(context)
-        : (noAchievements
-              ? AppLocale.noAchievements.getString(context)
-              : '$awarded/$total');
-
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final Color statusColor = noAchievements
-        ? theme.colorScheme.onSurface
-        : Colors.orange;
+    final radii = theme.extension<CornerRadii>() ?? CornerRadii.m();
+    final playTime = game.playTime ?? 0;
+    final hasPlayTime = playTime > 0;
 
-    final String? gameIconUrl = currentGameInfo?.imageIcon.isNotEmpty == true
+    final gameIconUrl = currentGameInfo?.imageIcon.isNotEmpty == true
         ? 'https://media.retroachievements.org${currentGameInfo!.imageIcon}'
         : null;
 
+    final content = Container(
+      height: 45.r,
+      padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 4.r),
+      decoration: BoxDecoration(
+        color: ChromeSurface.fill(context),
+        borderRadius: radii.radiusExternal,
+        border: Border.all(color: theme.colorScheme.outline, width: 1.r),
+        boxShadow: [
+          BoxShadow(
+            color: theme.colorScheme.shadow.withValues(alpha: 0.1),
+            blurRadius: 4.r,
+            offset: Offset(2.r, 2.r),
+          ),
+        ],
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          if (hasRetroAchievements)
+            ClipRRect(
+              borderRadius: radii.radiusInternal,
+              child: Container(
+                width: 32.r,
+                height: 32.r,
+                color: theme.colorScheme.surface,
+                alignment: Alignment.center,
+                child: gameIconUrl != null
+                    ? Image.network(
+                        gameIconUrl,
+                        fit: BoxFit.cover,
+                        width: 32.r,
+                        height: 32.r,
+                        errorBuilder: (_, _, _) => Icon(
+                          Symbols.emoji_events_rounded,
+                          color: Colors.orange,
+                          size: 17.r,
+                        ),
+                      )
+                    : isLoadingAchievements
+                    ? SizedBox(
+                        width: 16.r,
+                        height: 16.r,
+                        child: const CircularProgressIndicator(strokeWidth: 1.5),
+                      )
+                    : Icon(
+                        Symbols.emoji_events_rounded,
+                        color: Colors.orange,
+                        size: 17.r,
+                      ),
+              ),
+            ),
+          if (hasRetroAchievements && hasPlayTime) ...[
+            SizedBox(width: 8.r),
+            Container(
+              width: 1.r,
+              height: 28.r,
+              color: theme.colorScheme.outline.withValues(alpha: 0.45),
+            ),
+            SizedBox(width: 8.r),
+          ],
+          if (hasPlayTime)
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Symbols.schedule_rounded,
+                  color: theme.colorScheme.onSurface,
+                  size: 14.r,
+                ),
+                SizedBox(height: 1.r),
+                Text(
+                  _formatClock(playTime),
+                  style: TextStyle(
+                    color: theme.colorScheme.onSurface,
+                    fontSize: 10.r,
+                    fontWeight: FontWeight.w800,
+                    height: 1.0,
+                    fontFeatures: const [FontFeature.tabularFigures()],
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+
+    if (!hasRetroAchievements) return content;
+
     return Material(
       color: Colors.transparent,
+      borderRadius: radii.radiusExternal,
       child: InkWell(
         onTap: () {
           SfxService().playNavSound();
@@ -324,130 +313,14 @@ class GameDetailsFooter extends StatelessWidget {
         hoverColor: Colors.transparent,
         highlightColor: Colors.transparent,
         splashColor: theme.colorScheme.onSurface.withValues(alpha: 0.1),
-        borderRadius: BorderRadius.circular(8.r),
-        // Drive the width from a single 0..1 factor on the same 250ms /
-        // easeOutCubic timing as the sidebar margin, so the pill expands in
-        // lockstep with the legend slide (one motion) rather than shifting
-        // into place first and then easing its width (two steps).
-        child: TweenAnimationBuilder<double>(
-          tween: Tween<double>(end: expand ? 1.0 : 0.0),
-          duration: const Duration(milliseconds: 250),
-          curve: Curves.easeOutCubic,
-          builder: (context, t, child) => Container(
-            width: 120.r + (availableWidth - 120.r) * t,
-            height: 45.r,
-            decoration: BoxDecoration(
-              color: ChromeSurface.fill(context),
-              borderRadius:
-                  Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
-                  BorderRadius.circular(14.r),
-              border: Border.all(
-                color: Theme.of(context).colorScheme.outline,
-                width: 1.r,
-              ),
-              boxShadow: [
-                BoxShadow(
-                  color: Theme.of(
-                    context,
-                  ).colorScheme.shadow.withValues(alpha: 0.1),
-                  blurRadius: 4.r,
-                  offset: Offset(2.0.r, 2.0.r),
-                ),
-              ],
-            ),
-            child: child,
-          ),
-          child: Padding(
-            // Symmetric 8.r horizontal inset so neither the trophy icon nor the
-            // progress bar hugs the pill border. The progress column is always
-            // Expanded, so it simply absorbs the padding at any pill width (the
-            // shown/hidden width animation never overflows).
-            padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 4.r),
-            child: Row(
-              children: [
-                // RetroAchievements game icon.
-                ClipRRect(
-                  borderRadius:
-                      Theme.of(
-                        context,
-                      ).extension<CornerRadii>()?.radiusInternal ??
-                      BorderRadius.circular(14.r),
-                  child: Container(
-                    width: 32.r,
-                    height: 32.r,
-                    color: theme.colorScheme.surface,
-                    child: gameIconUrl != null
-                        ? Image.network(
-                            gameIconUrl,
-                            fit: BoxFit.cover,
-                            errorBuilder: (_, _, _) => Icon(
-                              Symbols.emoji_events_rounded,
-                              color: statusColor,
-                              size: 16.r,
-                            ),
-                          )
-                        : Icon(
-                            Symbols.emoji_events_rounded,
-                            color: statusColor,
-                            size: 16.r,
-                          ),
-                  ),
-                ),
-                SizedBox(width: 8.r),
-                // Progress bar and achievement count. When the legend is hidden
-                // the pill stretches, so let this column (and its bar) fill the
-                // extra width via Expanded; otherwise keep the fixed 70.r width.
-                Expanded(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      SizedBox(
-                        width: double.infinity,
-                        child: Text(
-                          progressText.toUpperCase(),
-                          style: TextStyle(
-                            color: theme.colorScheme.onSurface,
-                            fontSize: 10.r,
-                            fontWeight: FontWeight.bold,
-                            letterSpacing: 0.5,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                      SizedBox(height: 4.r),
-                      // Hold the bar short of the pill's right edge so it
-                      // doesn't run all the way across — mirrors the grid/
-                      // carousel pill's right margin under the progress count.
-                      Padding(
-                        padding: EdgeInsets.only(right: 10.r),
-                        child: ClipRRect(
-                          borderRadius: BorderRadius.circular(4.r),
-                          child: LinearProgressIndicator(
-                            value: isLoadingAchievements ? null : progress,
-                            minHeight: 5.r,
-                            backgroundColor: theme.colorScheme.onSurface
-                                .withValues(alpha: 0.1),
-                            valueColor: AlwaysStoppedAnimation<Color>(
-                              statusColor,
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
+        borderRadius: radii.radiusExternal,
+        child: content,
       ),
     );
   }
 }
 
-/// A Steam-inspired rating badge that interpolates color based on the score intensity.
+/// Steam-inspired rating badge, kept as a separate score surface.
 class _SteamStyleRating extends StatelessWidget {
   final GameModel game;
 
@@ -455,7 +328,6 @@ class _SteamStyleRating extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Normalizes a 0-20 score to a 0.0-10.0 scale for color interpolation.
     final ratingValue = (game.rating / 2).clamp(0.0, 10.0);
     final colorRatio = (ratingValue - 1) / 9;
     final customColors = AppThemes.getCustomColors(context);
@@ -464,24 +336,23 @@ class _SteamStyleRating extends StatelessWidget {
       customColors.successColor,
       colorRatio,
     )!;
+    final radii = Theme.of(context).extension<CornerRadii>() ?? CornerRadii.m();
 
     return Container(
       height: 45.r,
       padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 6.r),
       decoration: BoxDecoration(
         color: ChromeSurface.fill(context),
-        borderRadius:
-            Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
-            BorderRadius.circular(14.r),
+        borderRadius: radii.radiusExternal,
         border: Border.all(
           color: Theme.of(context).colorScheme.outline,
           width: 1.r,
         ),
         boxShadow: [
           BoxShadow(
-            color: Theme.of(context).colorScheme.shadow.withValues(alpha: 0.5),
-            blurRadius: 3.r,
-            offset: Offset(2.0.r, 2.0.r),
+            color: Theme.of(context).colorScheme.shadow.withValues(alpha: 0.1),
+            blurRadius: 4.r,
+            offset: Offset(2.r, 2.r),
           ),
         ],
       ),
@@ -491,9 +362,6 @@ class _SteamStyleRating extends StatelessWidget {
         children: [
           Icon(Symbols.star_rounded, color: ratingColor, size: 24.r),
           SizedBox(width: 4.r),
-          // Reserve width for the widest possible value ("10") so the pill
-          // stays a static size regardless of the current score (e.g. "1"
-          // no longer renders narrower than "10"). Scale/font-independent.
           Stack(
             alignment: Alignment.centerLeft,
             children: [
@@ -513,71 +381,6 @@ class _SteamStyleRating extends StatelessWidget {
                 ),
               ),
             ],
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Compact pill showing the accumulated play time for a game, styled to match
-/// the rating pill. Sits to the left of the PLAY button.
-class _PlayTimePill extends StatelessWidget {
-  final GameModel game;
-
-  const _PlayTimePill({required this.game});
-
-  /// Formats accumulated seconds as a zero-padded HH:MM:SS clock.
-  String _formatClock(int seconds) {
-    final h = seconds ~/ 3600;
-    final m = (seconds % 3600) ~/ 60;
-    final s = seconds % 60;
-    String pad(int v) => v.toString().padLeft(2, '0');
-    return '${pad(h)}:${pad(m)}:${pad(s)}';
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      height: 45.r,
-      padding: EdgeInsets.symmetric(horizontal: 8.r, vertical: 4.r),
-      decoration: BoxDecoration(
-        color: ChromeSurface.fill(context),
-        borderRadius:
-            Theme.of(context).extension<CornerRadii>()?.radiusExternal ??
-            BorderRadius.circular(14.r),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outline,
-          width: 1.r,
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: Theme.of(context).colorScheme.shadow.withValues(alpha: 0.5),
-            blurRadius: 3.r,
-            offset: Offset(2.0.r, 2.0.r),
-          ),
-        ],
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Icon(
-            Symbols.schedule_rounded,
-            color: Theme.of(context).colorScheme.onSurface,
-            size: 14.r,
-          ),
-          SizedBox(height: 1.r),
-          Text(
-            _formatClock(game.playTime ?? 0),
-            style: TextStyle(
-              color: Theme.of(context).colorScheme.onSurface,
-              fontSize: 10.r,
-              fontWeight: FontWeight.w800,
-              height: 1.0,
-              fontFeatures: const [FontFeature.tabularFigures()],
-            ),
           ),
         ],
       ),


### PR DESCRIPTION
This is the clean recovery point requested from the known-good Build 167 state.

What is preserved:
- Build 167 application behavior, including the StikJIT/RPCS3 path already present in that build.
- The recent screenshot/video layout improvements.
- The recent achievements layout/clipping/state-reset improvements.
- The redesigned lower game-details footer/stat blocks.

What is intentionally excluded:
- The later ARMSX2/RMSX2 functional/autoload changes from `fix/armsx2-autoload-achievements`.
- Any unrelated emulator-launch changes made after the known-good Build 167 state.

Verification: the application source on `main` already matches Build 167; commits after `0ce1e501bf5faf4295510b49c64b04d777132d38` on main only changed CI/README. This PR therefore changes exactly the three visual files and leaves the cleaned current build workflow intact.