### PR TITLE
fix: lazy-load RPCS3 and neutralize Build 216 entitlements

### DIFF
--- a/.github/workflows/build-ipa-once.yml
+++ b/.github/workflows/build-ipa-once.yml
@@ -1,5 +1,5 @@
-name: NeoStation iOS Build 215
-run-name: NeoStation iOS Build 215 • ${{ github.sha }}
+name: NeoStation iOS Build 216
+run-name: NeoStation iOS Build 216 • ${{ github.sha }}
 
 on:
   push:
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: neostation-ios-build-215
+  group: neostation-ios-build-216
   cancel-in-progress: true
 
 jobs:
@@ -21,9 +21,9 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 180
     env:
-      BUILD_NUMBER: '215'
-      IPA_NAME: 'NeoStation-iOS-Build-215'
-      ARTIFACT_NAME: 'NeoStation-iOS-Build-215'
+      BUILD_NUMBER: '216'
+      IPA_NAME: 'NeoStation-iOS-Build-216'
+      ARTIFACT_NAME: 'NeoStation-iOS-Build-216'
       DOLPHIN_SHA: 7cac54161659421ed95c2cd1c0b0746539a4cd38
       HOMEBREW_NO_AUTO_UPDATE: '1'
       BUNDLE_GEMFILE: ${{ github.workspace }}/build-utils/Gemfile.dolphin
@@ -212,7 +212,7 @@ jobs:
           flutter build ios --release --no-codesign --config-only --no-pub \
             --build-number="$BUILD_NUMBER" --dart-define-from-file=.dart-defines.json
           python3 packages/dolphin_internal_bridge/ci/build_support.py configure
-          python3 build-utils/configure_rpcs3_ios_v1.py
+          python3 build-utils/configure_rpcs3_ios_v2.py
           dart run flutter_launcher_icons
           bash build-utils/force_ios_fork_icon.sh
           env -u BUNDLE_GEMFILE -u BUNDLE_PATH pod install --project-directory=ios
@@ -228,6 +228,11 @@ jobs:
             CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' \
             DEVELOPMENT_TEAM='' PROVISIONING_PROFILE_SPECIFIER='' \
             COMPILER_INDEX_STORE_ENABLE=NO build
+
+      - name: Embed dormant RPCS3 Core
+        run: |
+          set -euo pipefail
+          python3 build-utils/embed_rpcs3_core_lazy.py
 
       - name: Package IPA
         run: |
@@ -254,17 +259,21 @@ jobs:
                   raise SystemExit('Embedded RPCS3 Core is unexpectedly small')
               if not helpers:
                   raise SystemExit('Embedded RPCS3 JIT helper extension is missing')
+
           entitlements = Path('dist/NeoStation-signing.entitlements')
           payload = plistlib.loads(entitlements.read_bytes())
-          for key in (
+          forbidden = (
               'get-task-allow',
               'com.apple.developer.kernel.extended-virtual-addressing',
               'com.apple.developer.kernel.increased-memory-limit',
               'com.apple.developer.kernel.increased-debugging-memory-limit',
-          ):
-              if payload.get(key) is not True:
-                  raise SystemExit(f'Missing RPCS3 entitlement: {key}')
-          print(f'RPCS3 IPA validation passed: {cores[0]} + RPCS3JITHelper')
+          )
+          present = [key for key in forbidden if key in payload]
+          if present:
+              raise SystemExit(
+                  'Build 216 must not force user-specific entitlements: ' + ', '.join(present)
+              )
+          print(f'RPCS3 lazy IPA validation passed: {cores[0]} + RPCS3JITHelper; neutral entitlements')
           PY
           ls -lah dist
 

--- a/build-utils/configure_rpcs3_ios_v2.py
+++ b/build-utils/configure_rpcs3_ios_v2.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Configure the RPCS3 helper without forcing host entitlements.
+
+Build 216 intentionally ships a neutral NeoStation entitlement file. Users may
+apply get-task-allow / memory capabilities when they sign the IPA themselves
+(e.g. developer account or a compatible sideloading workflow). RPCS3 remains a
+lazy-loaded optional engine and must never prevent NeoStation from reaching its
+menus when those capabilities are absent.
+"""
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+
+from configure_rpcs3_ios_v1 import (
+    IOS,
+    ROOT,
+    RUNNER,
+    configure_helper_files,
+    configure_podfile,
+    configure_xcode_project,
+)
+
+FORCED_RUNTIME_ENTITLEMENTS = (
+    'get-task-allow',
+    'com.apple.developer.kernel.extended-virtual-addressing',
+    'com.apple.developer.kernel.increased-memory-limit',
+    'com.apple.developer.kernel.increased-debugging-memory-limit',
+)
+
+
+def neutralize_runner_entitlements() -> None:
+    path = RUNNER / 'Runner.entitlements'
+    payload = plistlib.loads(path.read_bytes()) if path.is_file() else {}
+    if not isinstance(payload, dict):
+        raise SystemExit('Existing Runner entitlements are not a dictionary')
+    for key in FORCED_RUNTIME_ENTITLEMENTS:
+        payload.pop(key, None)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(plistlib.dumps(payload, fmt=plistlib.FMT_XML, sort_keys=False))
+
+
+def main() -> None:
+    if not (IOS / 'Runner.xcodeproj').is_dir():
+        raise SystemExit('Generate the Flutter iOS host before configuring RPCS3')
+    core = ROOT / 'packages/rpcs3_internal_bridge/ios/Frameworks/libRPCS3Core.dylib'
+    if not core.is_file():
+        raise SystemExit(f'RPCS3 Core has not been materialized: {core}')
+    stik = ROOT / 'packages/stikjit_bridge/ios/Frameworks/StikJIT.xcframework/ios-arm64/StikJIT.framework/StikJIT'
+    if not stik.is_file():
+        raise SystemExit(f'StikJIT device framework missing: {stik}')
+
+    configure_helper_files()
+    configure_podfile()
+    configure_xcode_project()
+    # Run this last because the Dolphin configurator legitimately prepares its
+    # own host files first. We do not modify Dolphin code; we only ensure the
+    # distributed NeoStation IPA does not force user-specific capabilities.
+    neutralize_runner_entitlements()
+    print('Configured RPCS3 lazy runtime with neutral NeoStation entitlements.')
+
+
+if __name__ == '__main__':
+    main()

--- a/build-utils/embed_rpcs3_core_lazy.py
+++ b/build-utils/embed_rpcs3_core_lazy.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Embed RPCS3 Core after Xcode builds NeoStation and prove lazy loading.
+
+The dylib is copied into the built .app only after the host and plugin have
+linked. We then inspect every Mach-O in the application and reject the build if
+anything except libRPCS3Core.dylib itself declares a dependency on it.
+"""
+from __future__ import annotations
+
+import os
+import plistlib
+import shutil
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PRODUCTS = ROOT / 'build/ios/DolphinDerivedData/Build/Products/Release-iphoneos'
+CORE = ROOT / 'packages/rpcs3_internal_bridge/ios/Frameworks/libRPCS3Core.dylib'
+
+
+def is_macho(path: Path) -> bool:
+    try:
+        output = subprocess.check_output(['file', str(path)], text=True, stderr=subprocess.DEVNULL)
+    except subprocess.CalledProcessError:
+        return False
+    return 'Mach-O' in output
+
+
+def dependencies(path: Path) -> str:
+    try:
+        return subprocess.check_output(['otool', '-L', str(path)], text=True, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(f'Could not inspect Mach-O dependencies for {path}: {exc.output}')
+
+
+def main() -> None:
+    apps = [path for path in PRODUCTS.glob('*.app') if path.is_dir()]
+    if len(apps) != 1:
+        raise SystemExit(f'Expected exactly one built app, found {apps}')
+    app = apps[0]
+    if not CORE.is_file() or CORE.stat().st_size < 60_000_000:
+        raise SystemExit(f'RPCS3 Core is missing or unexpectedly small: {CORE}')
+
+    frameworks = app / 'Frameworks'
+    frameworks.mkdir(parents=True, exist_ok=True)
+    destination = frameworks / 'libRPCS3Core.dylib'
+    shutil.copy2(CORE, destination)
+    destination.chmod(0o755)
+
+    linked = []
+    inspected = 0
+    for path in app.rglob('*'):
+        if not path.is_file() or path == destination:
+            continue
+        if not is_macho(path):
+            continue
+        inspected += 1
+        output = dependencies(path)
+        if 'libRPCS3Core.dylib' in output:
+            linked.append(str(path.relative_to(app)))
+
+    if linked:
+        raise SystemExit(
+            'RPCS3 Core is still linked at application startup: ' + ', '.join(linked)
+        )
+
+    # Ensure the app executable itself exists and is part of the verified scan.
+    info = plistlib.loads((app / 'Info.plist').read_bytes())
+    executable = app / str(info.get('CFBundleExecutable', ''))
+    if not executable.is_file() or not is_macho(executable):
+        raise SystemExit('Built NeoStation executable is missing or not Mach-O')
+
+    print(f'Embedded dormant RPCS3 Core at {destination}')
+    print(f'RPCS3 lazy-link validation passed across {inspected} NeoStation Mach-O binaries.')
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/widgets/rpcs3_internal_playlist_actions.dart
+++ b/lib/widgets/rpcs3_internal_playlist_actions.dart
@@ -38,14 +38,11 @@ class _Rpcs3InternalPlaylistActionsState
 
   void _interaction(bool active) => widget.onInteractionChanged?.call(active);
 
+  // Opening the menu must never initialize or dlopen RPCS3. The Core stays
+  // dormant until the user explicitly chooses a PS3 action (game/firmware) or
+  // launches a PS3 title.
   Future<void> _opened() async {
     _interaction(true);
-    try {
-      if (await Rpcs3InternalService.hasFirmware() && mounted) {
-        final version = await Rpcs3InternalService.firmwareVersion();
-        if (mounted) setState(() => _firmwareVersion = version);
-      }
-    } catch (_) {}
   }
 
   void _notice(String message) {

--- a/packages/rpcs3_internal_bridge/ios/rpcs3_internal_bridge.podspec
+++ b/packages/rpcs3_internal_bridge/ios/rpcs3_internal_bridge.podspec
@@ -1,17 +1,23 @@
 Pod::Spec.new do |s|
   s.name             = 'rpcs3_internal_bridge'
   s.version          = '0.1.0'
-  s.summary          = 'In-process RPCS3 Core bridge for NeoStation iOS.'
+  s.summary          = 'Lazy-loaded in-process RPCS3 Core bridge for NeoStation iOS.'
   s.description      = <<-DESC
-Loads the RPCS3 iOS 0.8.1 Core as an isolated PlayStation 3 engine inside
-NeoStation. The standalone RPCS3 SwiftUI application is not embedded.
+Exposes NeoStation's PlayStation 3 runtime bridge without linking RPCS3 Core
+into the application at process startup. The verified RPCS3 dylib is embedded
+as a dormant runtime resource and opened only when a PS3 session is requested.
+The standalone RPCS3 SwiftUI application is not embedded.
                        DESC
   s.homepage         = 'https://github.com/TarbleFR/neostation-ios'
   s.license          = { :type => 'GPL-3.0' }
   s.author           = { 'NeoStation iOS' => 'TarbleFR' }
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'
-  s.vendored_libraries = 'Frameworks/libRPCS3Core.dylib'
+  # Deliberately do NOT use vendored_libraries here. CocoaPods would link the
+  # dylib into Runner/rpcs3_internal_bridge and dyld would load RPCS3 before
+  # NeoStation reaches its menus. Build 216 copies this file after Xcode builds
+  # the host, and Rpcs3InternalBridgePlugin opens it later with dlopen().
+  s.preserve_paths   = 'Frameworks/libRPCS3Core.dylib'
   s.dependency 'Flutter'
   s.platform = :ios, '17.4'
   s.ios.deployment_target = '17.4'

--- a/test/rpcs3_lazy_load_contract_test.dart
+++ b/test/rpcs3_lazy_load_contract_test.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('RPCS3 lazy runtime contract', () {
+    test('RPCS3 Core is not a CocoaPods vendored library', () {
+      final podspec = File(
+        'packages/rpcs3_internal_bridge/ios/rpcs3_internal_bridge.podspec',
+      ).readAsStringSync();
+      expect(podspec, isNot(contains('vendored_libraries')));
+      expect(podspec, contains("s.preserve_paths   = 'Frameworks/libRPCS3Core.dylib'"));
+    });
+
+    test('RPCS3 Core is opened only by the native bridge', () {
+      final plugin = File(
+        'packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm',
+      ).readAsStringSync();
+      expect(plugin, contains('dlopen('));
+      expect(plugin, contains('libRPCS3Core.dylib'));
+      expect(plugin, contains('RTLD_NOW | RTLD_LOCAL'));
+    });
+
+    test('opening the PS3 import menu does not initialize RPCS3', () {
+      final widget = File(
+        'lib/widgets/rpcs3_internal_playlist_actions.dart',
+      ).readAsStringSync();
+      final start = widget.indexOf('Future<void> _opened() async');
+      final end = widget.indexOf('void _notice', start);
+      expect(start, greaterThanOrEqualTo(0));
+      expect(end, greaterThan(start));
+      final opened = widget.substring(start, end);
+      expect(opened, isNot(contains('Rpcs3InternalService')));
+      expect(opened, isNot(contains('hasFirmware')));
+    });
+
+    test('distributed IPA does not force user-specific entitlements', () {
+      final configurator = File(
+        'build-utils/configure_rpcs3_ios_v2.py',
+      ).readAsStringSync();
+      for (final key in <String>[
+        'get-task-allow',
+        'com.apple.developer.kernel.extended-virtual-addressing',
+        'com.apple.developer.kernel.increased-memory-limit',
+        'com.apple.developer.kernel.increased-debugging-memory-limit',
+      ]) {
+        expect(configurator, contains(key));
+      }
+      expect(configurator, contains('payload.pop(key, None)'));
+      expect(configurator, isNot(contains("payload['get-task-allow'] = True")));
+    });
+  });
+}

--- a/test/rpcs3_lazy_load_contract_test.dart
+++ b/test/rpcs3_lazy_load_contract_test.dart
@@ -8,8 +8,11 @@ void main() {
       final podspec = File(
         'packages/rpcs3_internal_bridge/ios/rpcs3_internal_bridge.podspec',
       ).readAsStringSync();
-      expect(podspec, isNot(contains('vendored_libraries')));
-      expect(podspec, contains("s.preserve_paths   = 'Frameworks/libRPCS3Core.dylib'"));
+      expect(podspec, isNot(contains('s.vendored_libraries')));
+      expect(
+        podspec,
+        contains("s.preserve_paths   = 'Frameworks/libRPCS3Core.dylib'"),
+      );
     });
 
     test('RPCS3 Core is opened only by the native bridge', () {


### PR DESCRIPTION
## RPCS3 startup fix
- Keep libRPCS3Core.dylib out of CocoaPods vendored linkage so dyld does not load RPCS3 before NeoStation reaches its menus.
- Embed the verified RPCS3 Core only after Xcode has linked the host.
- Verify every Mach-O in the built app and fail the build if any binary except the Core itself declares a direct libRPCS3Core dependency.
- Keep RPCS3 dormant until an explicit PS3 action or game launch triggers dlopen().
- Opening the PS3 import menu no longer initializes RPCS3.

## Entitlements
- Build 216 no longer forces get-task-allow, extended virtual addressing, increased memory limit or increased debugging memory limit into the distributed NeoStation IPA.
- These capabilities can be supplied later by the user's own signing setup/account.
- RPCS3 continues to fail gracefully at PS3 launch if required JIT capabilities are unavailable.

## Isolation
- No Dolphin source, target or runtime file is modified.

## Build
- Prepare NeoStation iOS Build 216 with structural checks for dormant RPCS3 Core, RPCS3JITHelper presence and neutral entitlements.