### PR TITLE
Fix RPCS3 firmware/game imports and add internal manager

### DIFF
--- a/.github/workflows/build-ipa-once.yml
+++ b/.github/workflows/build-ipa-once.yml
@@ -1,5 +1,5 @@
-name: NeoStation iOS Build 217
-run-name: NeoStation iOS Build 217 • ${{ github.sha }}
+name: NeoStation iOS Build 218
+run-name: NeoStation iOS Build 218 • ${{ github.sha }}
 
 on:
   push:
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: neostation-ios-build-217
+  group: neostation-ios-build-218
   cancel-in-progress: true
 
 jobs:
@@ -21,9 +21,9 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 180
     env:
-      BUILD_NUMBER: '217'
-      IPA_NAME: 'NeoStation-iOS-Build-217'
-      ARTIFACT_NAME: 'NeoStation-iOS-Build-217'
+      BUILD_NUMBER: '218'
+      IPA_NAME: 'NeoStation-iOS-Build-218'
+      ARTIFACT_NAME: 'NeoStation-iOS-Build-218'
       DOLPHIN_SHA: 7cac54161659421ed95c2cd1c0b0746539a4cd38
       HOMEBREW_NO_AUTO_UPDATE: '1'
       BUNDLE_GEMFILE: ${{ github.workspace }}/build-utils/Gemfile.dolphin
@@ -271,7 +271,7 @@ jobs:
           present = [key for key in forbidden if key in payload]
           if present:
               raise SystemExit(
-                  'Build 217 must not force user-specific entitlements: ' + ', '.join(present)
+                  'Build 218 must not force user-specific entitlements: ' + ', '.join(present)
               )
           print(f'RPCS3 lazy IPA validation passed: {cores[0]} + RPCS3JITHelper; neutral entitlements')
           PY

--- a/lib/screens/rpcs3_manager_screen.dart
+++ b/lib/screens/rpcs3_manager_screen.dart
@@ -1,0 +1,289 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../services/rpcs3_internal_service.dart';
+
+/// User-facing management surface for the embedded RPCS3 engine.
+///
+/// Opening this screen loads RPCS3 in maintenance mode only. JIT is not
+/// requested until a game is launched from the normal NeoStation library.
+class Rpcs3ManagerScreen extends StatefulWidget {
+  const Rpcs3ManagerScreen({
+    super.key,
+    required this.onLibraryChanged,
+  });
+
+  final Future<void> Function() onLibraryChanged;
+
+  @override
+  State<Rpcs3ManagerScreen> createState() => _Rpcs3ManagerScreenState();
+}
+
+class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
+  bool _loading = true;
+  bool _busy = false;
+  String _firmwareVersion = '';
+  String _build = '';
+  int _abi = 0;
+  String? _error;
+
+  bool get _fr => Localizations.localeOf(context).languageCode == 'fr';
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _refresh());
+  }
+
+  @override
+  void dispose() {
+    // Returning to NeoStation should leave the PS3 engine dormant again.
+    unawaited(Rpcs3InternalService.closeManagementRuntime());
+    super.dispose();
+  }
+
+  void _notice(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  Future<void> _refresh() async {
+    if (!mounted) return;
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      await Rpcs3InternalService.ensureManagementInitialized();
+      final version = await Rpcs3InternalService.firmwareVersion();
+      final diagnostics = await Rpcs3InternalService.diagnostics();
+      if (!mounted) return;
+      setState(() {
+        _firmwareVersion = version;
+        _build = diagnostics['build']?.toString() ?? '';
+        _abi = (diagnostics['abi'] as num?)?.toInt() ?? 0;
+      });
+    } on Rpcs3InternalException catch (error) {
+      if (mounted) setState(() => _error = error.message);
+    } catch (error) {
+      if (mounted) setState(() => _error = error.toString());
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _installFirmware() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      if (await Rpcs3InternalService.importFirmware()) {
+        _firmwareVersion = await Rpcs3InternalService.firmwareVersion();
+        _notice(
+          _fr
+              ? 'Firmware PS3 installé : $_firmwareVersion'
+              : 'PS3 firmware installed: $_firmwareVersion',
+        );
+        if (mounted) setState(() {});
+      }
+    } on Rpcs3InternalException catch (error) {
+      _notice(error.message);
+    } catch (error) {
+      _notice(error.toString());
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _importGames() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      final result = await Rpcs3InternalService.importGames();
+      if (result.imported > 0) {
+        await widget.onLibraryChanged();
+        _notice(
+          _fr
+              ? '${result.imported} jeu(x) PS3 importé(s).'
+              : '${result.imported} PS3 game(s) imported.',
+        );
+      }
+      if (result.rejected > 0) {
+        _notice(
+          result.errors.isNotEmpty
+              ? result.errors.first
+              : (_fr ? 'Import RPCS3 refusé.' : 'RPCS3 import rejected.'),
+        );
+      }
+    } on Rpcs3InternalException catch (error) {
+      _notice(error.message);
+    } catch (error) {
+      _notice(error.toString());
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _importFolder() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      if (await Rpcs3InternalService.importExtractedGameFolder()) {
+        await widget.onLibraryChanged();
+        _notice(
+          _fr ? 'Dossier de jeu PS3 importé.' : 'PS3 game folder imported.',
+        );
+      }
+    } on Rpcs3InternalException catch (error) {
+      _notice(error.message);
+    } catch (error) {
+      _notice(error.toString());
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final firmwareInstalled = _firmwareVersion.isNotEmpty;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('RPCS3'),
+        actions: [
+          IconButton(
+            tooltip: _fr ? 'Actualiser' : 'Refresh',
+            onPressed: _busy ? null : _refresh,
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 760),
+            child: ListView(
+              padding: const EdgeInsets.all(24),
+              children: [
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.memory,
+                              color: scheme.primary,
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Text(
+                                _fr
+                                    ? 'Émulateur RPCS3 intégré'
+                                    : 'Embedded RPCS3 emulator',
+                                style: Theme.of(context).textTheme.titleLarge,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          _fr
+                              ? 'Mode maintenance : installation du firmware et des jeux sans JIT. Le JIT est activé uniquement lorsque vous lancez un jeu PS3.'
+                              : 'Maintenance mode: install firmware and games without JIT. JIT is enabled only when you launch a PS3 game.',
+                        ),
+                        if (_build.isNotEmpty || _abi != 0) ...[
+                          const SizedBox(height: 8),
+                          Text(
+                            'Core ${_build.isEmpty ? '' : _build}${_abi == 0 ? '' : ' • ABI $_abi'}',
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Card(
+                  child: ListTile(
+                    leading: Icon(
+                      firmwareInstalled
+                          ? Icons.check_circle
+                          : Icons.warning_amber_rounded,
+                      color: firmwareInstalled
+                          ? scheme.primary
+                          : scheme.error,
+                    ),
+                    title: Text(
+                      firmwareInstalled
+                          ? (_fr
+                                ? 'Firmware PS3 installé'
+                                : 'PS3 firmware installed')
+                          : (_fr ? 'Firmware PS3 requis' : 'PS3 firmware required'),
+                    ),
+                    subtitle: Text(
+                      firmwareInstalled
+                          ? _firmwareVersion
+                          : (_fr
+                                ? 'Installez le fichier officiel PS3UPDAT.PUP.'
+                                : 'Install the official PS3UPDAT.PUP file.'),
+                    ),
+                  ),
+                ),
+                if (_error != null) ...[
+                  const SizedBox(height: 12),
+                  Card(
+                    color: scheme.errorContainer,
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Text(
+                        _error!,
+                        style: TextStyle(color: scheme.onErrorContainer),
+                      ),
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 20),
+                FilledButton.icon(
+                  key: const ValueKey('rpcs3-manager-firmware'),
+                  onPressed: _loading || _busy ? null : _installFirmware,
+                  icon: const Icon(Icons.system_update_alt),
+                  label: Text(
+                    _fr ? 'Installer le firmware PS3' : 'Install PS3 firmware',
+                  ),
+                ),
+                const SizedBox(height: 12),
+                FilledButton.tonalIcon(
+                  key: const ValueKey('rpcs3-manager-games'),
+                  onPressed: _loading || _busy ? null : _importGames,
+                  icon: const Icon(Icons.file_upload_outlined),
+                  label: Text(_fr ? 'Importer des jeux' : 'Import games'),
+                ),
+                const SizedBox(height: 12),
+                FilledButton.tonalIcon(
+                  key: const ValueKey('rpcs3-manager-folder'),
+                  onPressed: _loading || _busy ? null : _importFolder,
+                  icon: const Icon(Icons.folder_open),
+                  label: Text(
+                    _fr
+                        ? 'Importer un dossier de jeu'
+                        : 'Import a game folder',
+                  ),
+                ),
+                if (_loading || _busy) ...[
+                  const SizedBox(height: 24),
+                  const Center(child: CircularProgressIndicator()),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/rpcs3_internal_service.dart
+++ b/lib/services/rpcs3_internal_service.dart
@@ -33,17 +33,24 @@ class Rpcs3InternalException implements Exception {
 
 /// Owns the in-process PlayStation 3 engine embedded in NeoStation iOS.
 ///
-/// The standalone RPCS3 application is never launched. NeoStation embeds only
-/// the verified RPCS3 iOS Core dylib and drives its exported iOS ABI directly.
+/// RPCS3 has two deliberately separate runtime modes:
+/// - maintenance: no JIT, used to install firmware/games and inspect the library;
+/// - gameplay: JIT prepared, used only when a PS3 title is actually launched.
+///
+/// The standalone RPCS3 application is never launched. NeoStation embeds the
+/// verified RPCS3 iOS Core dylib and drives its exported iOS ABI directly.
 class Rpcs3InternalService {
   Rpcs3InternalService._();
 
   static final _log = LoggerService.instance;
   static bool _initializing = false;
   static bool _initialized = false;
+  static bool _initializedForGameplay = false;
   static bool _jitPrepared = false;
 
   static bool get supported => Platform.isIOS;
+  static bool get initialized => _initialized;
+  static bool get gameplayMode => _initialized && _initializedForGameplay;
 
   static Future<Directory> rootDirectory() async {
     final support = await getApplicationSupportDirectory();
@@ -69,7 +76,16 @@ class Rpcs3InternalService {
   static Future<Map<String, dynamic>> diagnostics() async {
     final core = await Rpcs3InternalBridge.diagnostics();
     final jit = await Rpcs3InternalBridge.jitStatus();
-    return <String, dynamic>{...core, 'jit': jit, 'jitPrepared': _jitPrepared};
+    return <String, dynamic>{
+      ...core,
+      'jit': jit,
+      'jitPrepared': _jitPrepared,
+      'runtimeMode': !_initialized
+          ? 'stopped'
+          : _initializedForGameplay
+          ? 'gameplay'
+          : 'maintenance',
+    };
   }
 
   static Future<void> _ensureJit() async {
@@ -77,7 +93,7 @@ class Rpcs3InternalService {
     if (!await PairingFileService.hasStoredPairingFile()) {
       throw const Rpcs3InternalException(
         'pairingRequired',
-        'Import the NeoStation Pairing File before starting RPCS3.',
+        'Import the NeoStation Pairing File before starting a PS3 game.',
       );
     }
 
@@ -99,35 +115,54 @@ class Rpcs3InternalService {
     );
   }
 
-  static Future<void> ensureInitialized() async {
+  static Future<void> _shutdownRuntime() async {
+    if (!_initialized) return;
+    final report = await Rpcs3InternalBridge.shutdown();
+    if (report['success'] != true) {
+      throw Rpcs3InternalException(
+        'coreShutdownFailed',
+        report['message']?.toString() ?? 'RPCS3 Core could not shut down.',
+      );
+    }
+    _initialized = false;
+    _initializedForGameplay = false;
+    _log.i('RPCS3 internal Core shut down for runtime mode transition.');
+  }
+
+  static Future<void> _ensureRuntime({required bool gameplay}) async {
     if (!supported) {
       throw const Rpcs3InternalException(
         'unsupported',
         'RPCS3 internal is available on iOS only.',
       );
     }
-    if (_initialized) return;
+
+    if (_initialized && _initializedForGameplay == gameplay) return;
+
     if (_initializing) {
       while (_initializing) {
         await Future<void>.delayed(const Duration(milliseconds: 50));
       }
-      if (_initialized) return;
-      throw const Rpcs3InternalException(
-        'initializeFailed',
-        'RPCS3 initialization failed.',
-      );
+      if (_initialized && _initializedForGameplay == gameplay) return;
+      return _ensureRuntime(gameplay: gameplay);
     }
 
     _initializing = true;
     try {
-      await _ensureJit();
+      if (_initialized && _initializedForGameplay != gameplay) {
+        await _shutdownRuntime();
+      }
+
+      // Firmware and content installation do not need JIT. JIT is requested
+      // only when the user actually launches a game.
+      if (gameplay) await _ensureJit();
 
       final data = await dataDirectory();
       final cache = await cacheDirectory();
       final report = await Rpcs3InternalBridge.initialize(
         supportPath: data.path,
         cachePath: cache.path,
-        expandedJitRegion: true,
+        expandedJitRegion: gameplay,
       );
       if (report['success'] != true) {
         throw Rpcs3InternalException(
@@ -137,14 +172,33 @@ class Rpcs3InternalService {
       }
 
       _initialized = true;
-      _log.i('RPCS3 internal Core initialized inside NeoStation.');
+      _initializedForGameplay = gameplay;
+      _log.i(
+        'RPCS3 internal Core initialized in ${gameplay ? 'gameplay/JIT' : 'maintenance'} mode.',
+      );
     } finally {
       _initializing = false;
     }
   }
 
+  /// Opens RPCS3 for firmware/content management without requiring JIT.
+  static Future<void> ensureManagementInitialized() =>
+      _ensureRuntime(gameplay: false);
+
+  /// Keeps the historical API name for callers that mean "ready to play".
+  static Future<void> ensureInitialized() => _ensureRuntime(gameplay: true);
+
+  static Future<void> ensureGameplayInitialized() =>
+      _ensureRuntime(gameplay: true);
+
+  static Future<void> closeManagementRuntime() async {
+    if (_initialized && !_initializedForGameplay) {
+      await _shutdownRuntime();
+    }
+  }
+
   static Future<String> firmwareVersion() async {
-    await ensureInitialized();
+    await ensureManagementInitialized();
     return (await Rpcs3InternalBridge.firmwareVersion()).trim();
   }
 
@@ -154,6 +208,20 @@ class Rpcs3InternalService {
     } catch (_) {
       return false;
     }
+  }
+
+  static Future<String> _stageFirmware(String sourcePath) async {
+    final root = await rootDirectory();
+    final imports = Directory(path.join(root.path, 'Imports'));
+    await imports.create(recursive: true);
+    final staged = File(
+      path.join(
+        imports.path,
+        'PS3UPDAT-${DateTime.now().microsecondsSinceEpoch}.PUP',
+      ),
+    );
+    await File(sourcePath).copy(staged.path);
+    return staged.path;
   }
 
   static Future<bool> importFirmware() async {
@@ -174,23 +242,36 @@ class Rpcs3InternalService {
       );
     }
 
-    await ensureInitialized();
-    final report = await Rpcs3InternalBridge.installFirmware(sourcePath);
-    if (report['success'] != true) {
-      throw Rpcs3InternalException(
-        'firmwareInstallFailed',
-        report['message']?.toString() ?? 'RPCS3 rejected the PS3 firmware.',
-      );
-    }
+    await ensureManagementInitialized();
+    String? stagedPath;
+    try {
+      // Keep a private copy while the native installer runs. This avoids the
+      // iOS document-picker security scope disappearing mid-install.
+      stagedPath = await _stageFirmware(sourcePath);
+      final report = await Rpcs3InternalBridge.installFirmware(stagedPath);
+      if (report['success'] != true) {
+        throw Rpcs3InternalException(
+          'firmwareInstallFailed',
+          report['message']?.toString() ?? 'RPCS3 rejected the PS3 firmware.',
+        );
+      }
 
-    final version = (await Rpcs3InternalBridge.firmwareVersion()).trim();
-    if (version.isEmpty) {
-      throw const Rpcs3InternalException(
-        'firmwareVerificationFailed',
-        'RPCS3 did not report an installed firmware after import.',
-      );
+      final version = (await Rpcs3InternalBridge.firmwareVersion()).trim();
+      if (version.isEmpty) {
+        throw const Rpcs3InternalException(
+          'firmwareVerificationFailed',
+          'RPCS3 did not report an installed firmware after import.',
+        );
+      }
+      _log.i('RPCS3 firmware installed successfully: $version');
+      return true;
+    } finally {
+      if (stagedPath != null) {
+        try {
+          await File(stagedPath).delete();
+        } catch (_) {}
+      }
     }
-    return true;
   }
 
   static Future<Rpcs3ImportResult> importGames() async {
@@ -205,7 +286,7 @@ class Rpcs3InternalService {
       return const Rpcs3ImportResult(imported: 0, rejected: 0);
     }
 
-    await ensureInitialized();
+    await ensureManagementInitialized();
 
     var imported = 0;
     var rejected = 0;
@@ -261,7 +342,7 @@ class Rpcs3InternalService {
     );
     if (folder == null) return false;
 
-    await ensureInitialized();
+    await ensureManagementInitialized();
     final report = await Rpcs3InternalBridge.installFolder(folder);
     if (report['success'] != true) {
       throw Rpcs3InternalException(
@@ -277,7 +358,9 @@ class Rpcs3InternalService {
     final normalized = titleId.trim().toUpperCase();
     if (normalized.isEmpty) return false;
 
-    await ensureInitialized();
+    // Read firmware in maintenance mode first. Only after this check succeeds
+    // do we transition to the JIT-enabled gameplay runtime.
+    await ensureManagementInitialized();
     final firmware = (await Rpcs3InternalBridge.firmwareVersion()).trim();
     if (firmware.isEmpty) {
       throw const Rpcs3InternalException(
@@ -286,8 +369,9 @@ class Rpcs3InternalService {
       );
     }
 
-    // Direct Core boot: the standalone RPCS3 SwiftUI Start screen is not part
-    // of NeoStation and is never presented.
+    await ensureGameplayInitialized();
+
+    // Direct Core boot: no standalone RPCS3 launch screen is presented.
     final report = await Rpcs3InternalBridge.launchGame(
       titleId: normalized,
       savestateId: savestateId,

--- a/lib/widgets/rpcs3_internal_playlist_actions.dart
+++ b/lib/widgets/rpcs3_internal_playlist_actions.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
+import '../screens/rpcs3_manager_screen.dart';
 import '../services/rpcs3_internal_service.dart';
 
 class Rpcs3InternalPlaylistActions extends StatefulWidget {
@@ -26,7 +27,8 @@ class _Rpcs3InternalPlaylistActionsState
   String _firmwareVersion = '';
 
   bool get _fr => Localizations.localeOf(context).languageCode == 'fr';
-  String get _import => _fr ? 'Importer' : 'Import';
+  String get _import => _fr ? 'RPCS3 / Importer' : 'RPCS3 / Import';
+  String get _open => _fr ? 'Ouvrir RPCS3' : 'Open RPCS3';
   String get _games => _fr ? 'Importer des jeux' : 'Import games';
   String get _folder =>
       _fr ? 'Importer un dossier de jeu' : 'Import game folder';
@@ -34,13 +36,13 @@ class _Rpcs3InternalPlaylistActionsState
       _fr ? 'Importer le firmware PS3' : 'Import PS3 firmware';
   String get _firmwareMissing => _fr ? 'Firmware requis' : 'Firmware required';
   String get _failed =>
-      _fr ? 'Échec de l’importation RPCS3.' : 'RPCS3 import failed.';
+      _fr ? 'Échec de l’opération RPCS3.' : 'RPCS3 operation failed.';
 
   void _interaction(bool active) => widget.onInteractionChanged?.call(active);
 
-  // Opening the menu must never initialize or dlopen RPCS3. The Core stays
-  // dormant until the user explicitly chooses a PS3 action (game/firmware) or
-  // launches a PS3 title.
+  // Opening the popup alone must not initialize or dlopen RPCS3. The Core is
+  // loaded only after the user explicitly opens RPCS3, imports content, or
+  // launches a PS3 game.
   Future<void> _opened() async {
     _interaction(true);
   }
@@ -52,8 +54,36 @@ class _Rpcs3InternalPlaylistActionsState
     ).showSnackBar(SnackBar(content: Text(message)));
   }
 
+  Future<void> _openManager() async {
+    _interaction(false);
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => Rpcs3ManagerScreen(
+          onLibraryChanged: widget.onLibraryChanged,
+        ),
+      ),
+    );
+    if (!mounted) return;
+    try {
+      if (await Rpcs3InternalService.hasFirmware()) {
+        _firmwareVersion = await Rpcs3InternalService.firmwareVersion();
+      }
+    } catch (_) {
+      // Firmware state is shown again the next time the manager is opened.
+    } finally {
+      await Rpcs3InternalService.closeManagementRuntime();
+    }
+    if (mounted) setState(() {});
+  }
+
   Future<void> _selected(String action) async {
     if (_busy) return;
+
+    if (action == 'open') {
+      await _openManager();
+      return;
+    }
+
     setState(() => _busy = true);
     try {
       if (action == 'games') {
@@ -144,10 +174,20 @@ class _Rpcs3InternalPlaylistActionsState
             ),
           ),
           const PopupMenuDivider(),
-          PopupMenuItem(value: 'games', child: Text(_games)),
-          PopupMenuItem(value: 'folder', child: Text(_folder)),
+          PopupMenuItem(
+            value: 'open',
+            child: Row(
+              children: [
+                const Icon(Icons.memory),
+                SizedBox(width: 8.r),
+                Text(_open),
+              ],
+            ),
+          ),
           const PopupMenuDivider(),
           PopupMenuItem(value: 'firmware', child: Text(_firmware)),
+          PopupMenuItem(value: 'games', child: Text(_games)),
+          PopupMenuItem(value: 'folder', child: Text(_folder)),
         ],
       ),
     );

--- a/packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm
+++ b/packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm
@@ -82,6 +82,7 @@ static UIViewController* RPCS3RootViewController(void) {
 @property(nonatomic, strong) FlutterMethodChannel* channel;
 @property(nonatomic, strong) RPCS3GameViewController* gameController;
 @property(nonatomic, assign) BOOL initialized;
+@property(nonatomic, assign) BOOL initializedWithExpandedJit;
 @property(nonatomic, assign) BOOL operationBusy;
 @end
 
@@ -206,7 +207,9 @@ static void RPCS3Progress(void* context,
       if (value) build = [NSString stringWithUTF8String:value] ?: @"";
     }
     result(@{@"coreLoaded": @(loaded), @"abi": @(abi), @"build": build,
-             @"initialized": @(self.initialized), @"message": error ?: @""});
+             @"initialized": @(self.initialized),
+             @"expandedJitRegion": @(self.initializedWithExpandedJit),
+             @"message": error ?: @""});
     return;
   }
 
@@ -218,7 +221,14 @@ static void RPCS3Progress(void* context,
     dispatch_async(_runtimeQueue, ^{
       NSString* error = nil;
       if (![self loadCore:&error]) { dispatch_async(dispatch_get_main_queue(), ^{ result(@{@"success": @NO, @"message": error ?: @"Core unavailable"}); }); return; }
-      if (self.initialized) { dispatch_async(dispatch_get_main_queue(), ^{ result(@{@"success": @YES, @"alreadyInitialized": @YES}); }); return; }
+      if (self.initialized) {
+        if (self.initializedWithExpandedJit == expanded) {
+          dispatch_async(dispatch_get_main_queue(), ^{ result(@{@"success": @YES, @"alreadyInitialized": @YES, @"expandedJitRegion": @(expanded)}); });
+        } else {
+          dispatch_async(dispatch_get_main_queue(), ^{ result(@{@"success": @NO, @"modeMismatch": @YES, @"message": @"RPCS3 Core must be restarted to change runtime mode."}); });
+        }
+        return;
+      }
       rpcs3_ios_init_options options = {};
       options.abi_version = kExpectedAbi;
       options.size = sizeof(options);
@@ -230,9 +240,37 @@ static void RPCS3Progress(void* context,
       options.expanded_jit_region = expanded ? 1 : 0;
       options.reserved = 0;
       rpcs3_ios_status status = self->_api.initialize(&options);
-      if (status == 0) self.initialized = YES;
-      NSDictionary* payload = [self statusPayload:status];
+      if (status == 0) {
+        self.initialized = YES;
+        self.initializedWithExpandedJit = expanded;
+      }
+      NSMutableDictionary* payload = [[self statusPayload:status] mutableCopy];
+      payload[@"expandedJitRegion"] = @(expanded);
       dispatch_async(dispatch_get_main_queue(), ^{ result(payload); });
+    });
+    return;
+  }
+
+  if ([call.method isEqualToString:@"shutdown"]) {
+    dispatch_async(_runtimeQueue, ^{
+      if (!self.initialized) {
+        dispatch_async(dispatch_get_main_queue(), ^{ result(@{@"success": @YES, @"alreadyShutdown": @YES}); });
+        return;
+      }
+      if (self.gameController && self->_api.stop_emulation) self->_api.stop_emulation();
+      if (self->_api.set_display_surface) self->_api.set_display_surface(NULL);
+      rpcs3_ios_status status = self->_api.shutdown ? self->_api.shutdown() : 0;
+      if (status == 0) {
+        self.initialized = NO;
+        self.initializedWithExpandedJit = NO;
+      }
+      NSDictionary* payload = [self statusPayload:status];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        RPCS3GameViewController* controller = self.gameController;
+        self.gameController = nil;
+        [controller dismissViewControllerAnimated:NO completion:nil];
+        result(payload);
+      });
     });
     return;
   }
@@ -279,7 +317,10 @@ static void RPCS3Progress(void* context,
     NSDictionary* args = [call.arguments isKindOfClass:NSDictionary.class] ? call.arguments : @{};
     NSString* titleId = [args[@"titleId"] isKindOfClass:NSString.class] ? args[@"titleId"] : @"";
     NSString* savestateId = [args[@"savestateId"] isKindOfClass:NSString.class] ? args[@"savestateId"] : nil;
-    if (!self.initialized || !titleId.length || self.gameController) { result(@{@"success": @NO, @"message": @"RPCS3 is not ready to boot this title."}); return; }
+    if (!self.initialized || !self.initializedWithExpandedJit || !titleId.length || self.gameController) {
+      result(@{@"success": @NO, @"message": @"RPCS3 is not ready to boot this title with JIT."});
+      return;
+    }
     __block RPCS3GameViewController* controller = nil;
     dispatch_sync(dispatch_get_main_queue(), ^{
       UIViewController* root = RPCS3RootViewController();

--- a/packages/rpcs3_internal_bridge/lib/rpcs3_internal_bridge.dart
+++ b/packages/rpcs3_internal_bridge/lib/rpcs3_internal_bridge.dart
@@ -44,6 +44,12 @@ class Rpcs3InternalBridge {
         const <String, dynamic>{},
   );
 
+  static Future<Map<String, dynamic>> shutdown() async =>
+      Map<String, dynamic>.from(
+        await _channel.invokeMapMethod<String, dynamic>('shutdown') ??
+            const <String, dynamic>{},
+      );
+
   static Future<String> firmwareVersion() async =>
       (await _channel.invokeMethod<String>('firmwareVersion')) ?? '';
 

--- a/test/rpcs3_internal_integration_test.dart
+++ b/test/rpcs3_internal_integration_test.dart
@@ -26,6 +26,24 @@ void main() {
       expect(helper, isNot(contains('com.xitrix.RPCS3')));
     });
 
+    test('maintenance mode installs firmware/content without requiring JIT', () {
+      final service = File(
+        'lib/services/rpcs3_internal_service.dart',
+      ).readAsStringSync();
+      final bridge = File(
+        'packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm',
+      ).readAsStringSync();
+
+      expect(service, contains('ensureManagementInitialized'));
+      expect(service, contains('if (gameplay) await _ensureJit();'));
+      expect(service, contains('expandedJitRegion: gameplay'));
+      expect(service, contains('await ensureManagementInitialized();'));
+      expect(service, contains('Rpcs3InternalBridge.installFirmware'));
+      expect(service, contains('_stageFirmware'));
+      expect(bridge, contains('@"shutdown"'));
+      expect(bridge, contains('initializedWithExpandedJit'));
+    });
+
     test('launch boots the selected title directly through RPCS3 Core', () {
       final plugin = File(
         'packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm',
@@ -33,13 +51,24 @@ void main() {
       final launcher = File(
         'lib/services/rpcs3_launch_service.dart',
       ).readAsStringSync();
+      final service = File(
+        'lib/services/rpcs3_internal_service.dart',
+      ).readAsStringSync();
 
       expect(plugin, contains('rpcs3_ios_boot_game'));
       expect(plugin, contains('self->_api.boot_game'));
       expect(plugin, contains('@"launchGame"'));
+      expect(plugin, contains('!self.initializedWithExpandedJit'));
       expect(launcher, contains('Rpcs3InternalService.launchTitle'));
       expect(launcher, isNot(contains('openJitRequest')));
       expect(launcher, isNot(contains('com.xitrix.RPCS3')));
+      expect(service, contains('await ensureGameplayInitialized();'));
+
+      // The standalone SwiftUI gate is not embedded or recreated. Game launch
+      // goes directly to rpcs3_ios_boot_game after firmware + JIT readiness.
+      expect(plugin, isNot(contains('setTitle:@"Start"')));
+      expect(plugin, isNot(contains('setTitle:@"Commencer"')));
+      expect(service, isNot(contains('com.xitrix.RPCS3')));
     });
 
     test('firmware remains mandatory before direct boot', () {
@@ -47,23 +76,34 @@ void main() {
         'lib/services/rpcs3_internal_service.dart',
       ).readAsStringSync();
       final firmwareCheck = service.indexOf("'firmwareRequired'");
+      final gameplayInit = service.indexOf('await ensureGameplayInitialized();');
       final launchCall = service.indexOf('Rpcs3InternalBridge.launchGame');
 
       expect(firmwareCheck, greaterThanOrEqualTo(0));
-      expect(launchCall, greaterThan(firmwareCheck));
-      expect(service, contains('Rpcs3InternalBridge.installFirmware'));
+      expect(gameplayInit, greaterThan(firmwareCheck));
+      expect(launchCall, greaterThan(gameplayInit));
     });
 
-    test('PS3 library exposes game and firmware imports', () {
+    test('PS3 library exposes emulator manager and all import actions', () {
       final widget = File(
         'lib/widgets/rpcs3_internal_playlist_actions.dart',
       ).readAsStringSync();
+      final manager = File(
+        'lib/screens/rpcs3_manager_screen.dart',
+      ).readAsStringSync();
 
+      expect(widget, contains("value: 'open'"));
+      expect(widget, contains('Ouvrir RPCS3'));
+      expect(widget, contains('Rpcs3ManagerScreen'));
       expect(widget, contains("value: 'games'"));
       expect(widget, contains("value: 'folder'"));
       expect(widget, contains("value: 'firmware'"));
       expect(widget, contains('Importer le firmware PS3'));
-      expect(widget, contains('Firmware requis'));
+      expect(manager, contains('rpcs3-manager-firmware'));
+      expect(manager, contains('rpcs3-manager-games'));
+      expect(manager, contains('rpcs3-manager-folder'));
+      expect(manager, isNot(contains('Start')));
+      expect(manager, isNot(contains('Commencer')));
     });
   });
 }


### PR DESCRIPTION
Separates RPCS3 maintenance mode from gameplay JIT mode, adds an internal RPCS3 manager screen, stages firmware safely for iOS document access, keeps direct boot without the standalone Start screen, and prepares Build 218. DolphiniOS is untouched.