### PR TITLE
Fix RPCS3 crash before Core load

### DIFF
--- a/.github/workflows/build-ipa-once.yml
+++ b/.github/workflows/build-ipa-once.yml
@@ -1,5 +1,5 @@
-name: NeoStation iOS Build 218
-run-name: NeoStation iOS Build 218 • ${{ github.sha }}
+name: NeoStation iOS Build 219
+run-name: NeoStation iOS Build 219 • ${{ github.sha }}
 
 on:
   push:
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: neostation-ios-build-218
+  group: neostation-ios-build-219
   cancel-in-progress: true
 
 jobs:
@@ -21,9 +21,9 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 180
     env:
-      BUILD_NUMBER: '218'
-      IPA_NAME: 'NeoStation-iOS-Build-218'
-      ARTIFACT_NAME: 'NeoStation-iOS-Build-218'
+      BUILD_NUMBER: '219'
+      IPA_NAME: 'NeoStation-iOS-Build-219'
+      ARTIFACT_NAME: 'NeoStation-iOS-Build-219'
       DOLPHIN_SHA: 7cac54161659421ed95c2cd1c0b0746539a4cd38
       HOMEBREW_NO_AUTO_UPDATE: '1'
       BUNDLE_GEMFILE: ${{ github.workspace }}/build-utils/Gemfile.dolphin
@@ -262,18 +262,18 @@ jobs:
 
           entitlements = Path('dist/NeoStation-signing.entitlements')
           payload = plistlib.loads(entitlements.read_bytes())
-          forbidden = (
+          required = (
               'get-task-allow',
               'com.apple.developer.kernel.extended-virtual-addressing',
               'com.apple.developer.kernel.increased-memory-limit',
               'com.apple.developer.kernel.increased-debugging-memory-limit',
           )
-          present = [key for key in forbidden if key in payload]
-          if present:
+          missing = [key for key in required if payload.get(key) is not True]
+          if missing:
               raise SystemExit(
-                  'Build 218 must not force user-specific entitlements: ' + ', '.join(present)
+                  'Build 219 is missing required RPCS3 signing entitlements: ' + ', '.join(missing)
               )
-          print(f'RPCS3 lazy IPA validation passed: {cores[0]} + RPCS3JITHelper; neutral entitlements')
+          print(f'RPCS3 lazy IPA validation passed: {cores[0]} + RPCS3JITHelper; required JIT/memory entitlements emitted')
           PY
           ls -lah dist
 

--- a/build-utils/configure_rpcs3_ios_v2.py
+++ b/build-utils/configure_rpcs3_ios_v2.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Configure the RPCS3 helper without forcing host entitlements.
+"""Configure NeoStation for the lazy RPCS3 runtime and its required entitlements.
 
-Build 216 intentionally ships a neutral NeoStation entitlement file. Users may
-apply get-task-allow / memory capabilities when they sign the IPA themselves
-(e.g. developer account or a compatible sideloading workflow). RPCS3 remains a
-lazy-loaded optional engine and must never prevent NeoStation from reaching its
-menus when those capabilities are absent.
+RPCS3 iOS 0.8.1 is still lazy-loaded, so it cannot crash NeoStation before a
+PS3 action is requested. Once requested, however, the Core requires the same
+host capabilities as the standalone RPCS3 IPA: get-task-allow, extended virtual
+addressing and the increased memory limits. These are emitted into
+Runner.entitlements and copied to NeoStation-signing.entitlements by the IPA
+packager so the sideloading/signing step can preserve them.
 """
 from __future__ import annotations
 
@@ -21,21 +22,20 @@ from configure_rpcs3_ios_v1 import (
     configure_xcode_project,
 )
 
-FORCED_RUNTIME_ENTITLEMENTS = (
-    'get-task-allow',
-    'com.apple.developer.kernel.extended-virtual-addressing',
-    'com.apple.developer.kernel.increased-memory-limit',
-    'com.apple.developer.kernel.increased-debugging-memory-limit',
-)
+REQUIRED_RUNTIME_ENTITLEMENTS = {
+    'get-task-allow': True,
+    'com.apple.developer.kernel.extended-virtual-addressing': True,
+    'com.apple.developer.kernel.increased-memory-limit': True,
+    'com.apple.developer.kernel.increased-debugging-memory-limit': True,
+}
 
 
-def neutralize_runner_entitlements() -> None:
+def configure_runner_entitlements() -> None:
     path = RUNNER / 'Runner.entitlements'
     payload = plistlib.loads(path.read_bytes()) if path.is_file() else {}
     if not isinstance(payload, dict):
         raise SystemExit('Existing Runner entitlements are not a dictionary')
-    for key in FORCED_RUNTIME_ENTITLEMENTS:
-        payload.pop(key, None)
+    payload.update(REQUIRED_RUNTIME_ENTITLEMENTS)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(plistlib.dumps(payload, fmt=plistlib.FMT_XML, sort_keys=False))
 
@@ -53,11 +53,8 @@ def main() -> None:
     configure_helper_files()
     configure_podfile()
     configure_xcode_project()
-    # Run this last because the Dolphin configurator legitimately prepares its
-    # own host files first. We do not modify Dolphin code; we only ensure the
-    # distributed NeoStation IPA does not force user-specific capabilities.
-    neutralize_runner_entitlements()
-    print('Configured RPCS3 lazy runtime with neutral NeoStation entitlements.')
+    configure_runner_entitlements()
+    print('Configured RPCS3 lazy runtime with required NeoStation JIT/memory entitlements.')
 
 
 if __name__ == '__main__':

--- a/lib/screens/rpcs3_manager_screen.dart
+++ b/lib/screens/rpcs3_manager_screen.dart
@@ -6,8 +6,9 @@ import '../services/rpcs3_internal_service.dart';
 
 /// User-facing management surface for the embedded RPCS3 engine.
 ///
-/// Opening this screen loads RPCS3 in maintenance mode only. JIT is not
-/// requested until a game is launched from the normal NeoStation library.
+/// RPCS3 iOS 0.8.1 requires JIT before its Core can be loaded, even for
+/// firmware/content maintenance. Opening this screen prepares that runtime and
+/// then exposes the Core's native installation APIs through NeoStation.
 class Rpcs3ManagerScreen extends StatefulWidget {
   const Rpcs3ManagerScreen({
     super.key,
@@ -38,7 +39,8 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
 
   @override
   void dispose() {
-    // Returning to NeoStation should leave the PS3 engine dormant again.
+    // Closing the manager leaves the validated RPCS3 Core ready for a later
+    // direct game boot; it is not an external emulator process.
     unawaited(Rpcs3InternalService.closeManagementRuntime());
     super.dispose();
   }
@@ -194,8 +196,8 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
                         const SizedBox(height: 12),
                         Text(
                           _fr
-                              ? 'Mode maintenance : installation du firmware et des jeux sans JIT. Le JIT est activé uniquement lorsque vous lancez un jeu PS3.'
-                              : 'Maintenance mode: install firmware and games without JIT. JIT is enabled only when you launch a PS3 game.',
+                              ? 'RPCS3 active d’abord le JIT requis par son moteur, puis ce menu permet d’installer le firmware et les jeux. Le lancement d’un jeu reste direct depuis NeoStation.'
+                              : 'RPCS3 first enables the JIT required by its engine, then this menu can install firmware and games. Games still boot directly from NeoStation.',
                         ),
                         if (_build.isNotEmpty || _abi != 0) ...[
                           const SizedBox(height: 8),

--- a/lib/services/rpcs3_internal_service.dart
+++ b/lib/services/rpcs3_internal_service.dart
@@ -33,24 +33,22 @@ class Rpcs3InternalException implements Exception {
 
 /// Owns the in-process PlayStation 3 engine embedded in NeoStation iOS.
 ///
-/// RPCS3 has two deliberately separate runtime modes:
-/// - maintenance: no JIT, used to install firmware/games and inspect the library;
-/// - gameplay: JIT prepared, used only when a PS3 title is actually launched.
-///
-/// The standalone RPCS3 application is never launched. NeoStation embeds the
-/// verified RPCS3 iOS Core dylib and drives its exported iOS ABI directly.
+/// RPCS3 iOS 0.8.1 requires JIT to be active before libRPCS3Core.dylib is
+/// dlopened, including for firmware/content management. NeoStation therefore
+/// prepares and validates JIT first, loads one expanded RPCS3 runtime, and then
+/// uses that same runtime for firmware installation, game import and direct
+/// title boot. The standalone RPCS3 SwiftUI application is never launched.
 class Rpcs3InternalService {
   Rpcs3InternalService._();
 
   static final _log = LoggerService.instance;
   static bool _initializing = false;
   static bool _initialized = false;
-  static bool _initializedForGameplay = false;
   static bool _jitPrepared = false;
 
   static bool get supported => Platform.isIOS;
   static bool get initialized => _initialized;
-  static bool get gameplayMode => _initialized && _initializedForGameplay;
+  static bool get gameplayMode => _initialized;
 
   static Future<Directory> rootDirectory() async {
     final support = await getApplicationSupportDirectory();
@@ -80,20 +78,21 @@ class Rpcs3InternalService {
       ...core,
       'jit': jit,
       'jitPrepared': _jitPrepared,
-      'runtimeMode': !_initialized
-          ? 'stopped'
-          : _initializedForGameplay
-          ? 'gameplay'
-          : 'maintenance',
+      'runtimeMode': _initialized ? 'ready' : 'stopped',
     };
   }
 
   static Future<void> _ensureJit() async {
-    if (_jitPrepared) return;
+    if (_jitPrepared) {
+      final current = await Rpcs3InternalBridge.jitStatus();
+      if (current['debugged'] == true) return;
+      _jitPrepared = false;
+    }
+
     if (!await PairingFileService.hasStoredPairingFile()) {
       throw const Rpcs3InternalException(
         'pairingRequired',
-        'Import the NeoStation Pairing File before starting a PS3 game.',
+        'Import the NeoStation Pairing File before opening RPCS3 or installing PS3 firmware/games.',
       );
     }
 
@@ -109,60 +108,49 @@ class Rpcs3InternalService {
       );
     }
 
+    final status = await Rpcs3InternalBridge.jitStatus();
+    if (status['debugged'] != true) {
+      throw const Rpcs3InternalException(
+        'jitNotPersistent',
+        'RPCS3 JIT did not remain active after StikJIT detached.',
+      );
+    }
+
     _jitPrepared = true;
     _log.i(
       'RPCS3 internal JIT prepared for NeoStation pid=${jit['pid'] ?? 'unknown'}.',
     );
   }
 
-  static Future<void> _shutdownRuntime() async {
-    if (!_initialized) return;
-    final report = await Rpcs3InternalBridge.shutdown();
-    if (report['success'] != true) {
-      throw Rpcs3InternalException(
-        'coreShutdownFailed',
-        report['message']?.toString() ?? 'RPCS3 Core could not shut down.',
-      );
-    }
-    _initialized = false;
-    _initializedForGameplay = false;
-    _log.i('RPCS3 internal Core shut down for runtime mode transition.');
-  }
-
-  static Future<void> _ensureRuntime({required bool gameplay}) async {
+  static Future<void> _ensureRuntime() async {
     if (!supported) {
       throw const Rpcs3InternalException(
         'unsupported',
         'RPCS3 internal is available on iOS only.',
       );
     }
-
-    if (_initialized && _initializedForGameplay == gameplay) return;
+    if (_initialized) return;
 
     if (_initializing) {
       while (_initializing) {
         await Future<void>.delayed(const Duration(milliseconds: 50));
       }
-      if (_initialized && _initializedForGameplay == gameplay) return;
-      return _ensureRuntime(gameplay: gameplay);
+      if (_initialized) return;
+      return _ensureRuntime();
     }
 
     _initializing = true;
     try {
-      if (_initialized && _initializedForGameplay != gameplay) {
-        await _shutdownRuntime();
-      }
-
-      // Firmware and content installation do not need JIT. JIT is requested
-      // only when the user actually launches a game.
-      if (gameplay) await _ensureJit();
+      // RPCS3's own iOS loader requires JIT before dlopen. Do not move this
+      // below initialize(): the Core reserves its JIT arena while loading.
+      await _ensureJit();
 
       final data = await dataDirectory();
       final cache = await cacheDirectory();
       final report = await Rpcs3InternalBridge.initialize(
         supportPath: data.path,
         cachePath: cache.path,
-        expandedJitRegion: gameplay,
+        expandedJitRegion: true,
       );
       if (report['success'] != true) {
         throw Rpcs3InternalException(
@@ -172,30 +160,24 @@ class Rpcs3InternalService {
       }
 
       _initialized = true;
-      _initializedForGameplay = gameplay;
-      _log.i(
-        'RPCS3 internal Core initialized in ${gameplay ? 'gameplay/JIT' : 'maintenance'} mode.',
-      );
+      _log.i('RPCS3 internal Core initialized with validated expanded JIT.');
     } finally {
       _initializing = false;
     }
   }
 
-  /// Opens RPCS3 for firmware/content management without requiring JIT.
-  static Future<void> ensureManagementInitialized() =>
-      _ensureRuntime(gameplay: false);
+  /// Opens the internal RPCS3 runtime for firmware/content management.
+  /// RPCS3 0.8.1 still requires JIT before its Core can be loaded.
+  static Future<void> ensureManagementInitialized() => _ensureRuntime();
 
-  /// Keeps the historical API name for callers that mean "ready to play".
-  static Future<void> ensureInitialized() => _ensureRuntime(gameplay: true);
+  static Future<void> ensureInitialized() => _ensureRuntime();
 
-  static Future<void> ensureGameplayInitialized() =>
-      _ensureRuntime(gameplay: true);
+  static Future<void> ensureGameplayInitialized() => _ensureRuntime();
 
-  static Future<void> closeManagementRuntime() async {
-    if (_initialized && !_initializedForGameplay) {
-      await _shutdownRuntime();
-    }
-  }
+  /// Closing the manager only closes NeoStation's manager UI. The Core remains
+  /// loaded with the same JIT-arena policy so a later game can boot directly;
+  /// RPCS3 itself treats changing that policy after dlopen as relaunch-only.
+  static Future<void> closeManagementRuntime() async {}
 
   static Future<String> firmwareVersion() async {
     await ensureManagementInitialized();
@@ -225,6 +207,11 @@ class Rpcs3InternalService {
   }
 
   static Future<bool> importFirmware() async {
+    // Prepare RPCS3 before presenting the document picker. This mirrors the
+    // standalone loader and ensures the selected security-scoped file is used
+    // immediately instead of waiting for a long JIT transaction afterwards.
+    await ensureManagementInitialized();
+
     final picked = await FilePicker.pickFiles(
       dialogTitle: 'Select official PS3UPDAT.PUP firmware',
       allowMultiple: false,
@@ -242,7 +229,6 @@ class Rpcs3InternalService {
       );
     }
 
-    await ensureManagementInitialized();
     String? stagedPath;
     try {
       // Keep a private copy while the native installer runs. This avoids the
@@ -275,6 +261,8 @@ class Rpcs3InternalService {
   }
 
   static Future<Rpcs3ImportResult> importGames() async {
+    await ensureManagementInitialized();
+
     final picked = await FilePicker.pickFiles(
       dialogTitle: 'Import PlayStation 3 games',
       allowMultiple: true,
@@ -285,8 +273,6 @@ class Rpcs3InternalService {
     if (picked == null) {
       return const Rpcs3ImportResult(imported: 0, rejected: 0);
     }
-
-    await ensureManagementInitialized();
 
     var imported = 0;
     var rejected = 0;
@@ -337,12 +323,13 @@ class Rpcs3InternalService {
   }
 
   static Future<bool> importExtractedGameFolder() async {
+    await ensureManagementInitialized();
+
     final folder = await FilePicker.getDirectoryPath(
       dialogTitle: 'Import extracted PlayStation 3 game folder',
     );
     if (folder == null) return false;
 
-    await ensureManagementInitialized();
     final report = await Rpcs3InternalBridge.installFolder(folder);
     if (report['success'] != true) {
       throw Rpcs3InternalException(
@@ -358,9 +345,7 @@ class Rpcs3InternalService {
     final normalized = titleId.trim().toUpperCase();
     if (normalized.isEmpty) return false;
 
-    // Read firmware in maintenance mode first. Only after this check succeeds
-    // do we transition to the JIT-enabled gameplay runtime.
-    await ensureManagementInitialized();
+    await ensureGameplayInitialized();
     final firmware = (await Rpcs3InternalBridge.firmwareVersion()).trim();
     if (firmware.isEmpty) {
       throw const Rpcs3InternalException(
@@ -369,9 +354,8 @@ class Rpcs3InternalService {
       );
     }
 
-    await ensureGameplayInitialized();
-
-    // Direct Core boot: no standalone RPCS3 launch screen is presented.
+    // Direct Core boot: no standalone RPCS3 Start/Commencer screen is ever
+    // presented. NeoStation calls rpcs3_ios_boot_game for the selected title.
     final report = await Rpcs3InternalBridge.launchGame(
       titleId: normalized,
       savestateId: savestateId,

--- a/packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm
+++ b/packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm
@@ -3,11 +3,85 @@
 
 #import <Metal/Metal.h>
 #import <QuartzCore/CAMetalLayer.h>
+#import <Security/Security.h>
 #import <UIKit/UIKit.h>
 #import <dlfcn.h>
+#import <errno.h>
+#import <sys/mman.h>
+#import <unistd.h>
 
 static NSString* const kRpcs3Channel = @"neostation/rpcs3_internal";
 static const uint32_t kExpectedAbi = 30;
+
+extern "C" {
+void* SecTaskCreateFromSelf(CFAllocatorRef allocator);
+CFTypeRef SecTaskCopyValueForEntitlement(
+    void* task,
+    CFStringRef entitlement,
+    CFErrorRef* error);
+int csops(pid_t pid, unsigned int ops, void* useraddr, size_t usersize);
+}
+
+#ifndef CS_OPS_STATUS
+#define CS_OPS_STATUS 0
+#endif
+#ifndef CS_DEBUGGED
+#define CS_DEBUGGED 0x10000000
+#endif
+
+static BOOL RPCS3HostIsDebugged(void) {
+  uint32_t flags = 0;
+  if (csops(getpid(), CS_OPS_STATUS, &flags, sizeof(flags)) != 0) return NO;
+  return (flags & CS_DEBUGGED) != 0;
+}
+
+static BOOL RPCS3HostHasEntitlement(CFStringRef entitlement) {
+  void* task = SecTaskCreateFromSelf(NULL);
+  if (task == NULL) return NO;
+  CFTypeRef value = SecTaskCopyValueForEntitlement(task, entitlement, NULL);
+  BOOL enabled = value == kCFBooleanTrue;
+  if (value != NULL) CFRelease(value);
+  CFRelease(task);
+  return enabled;
+}
+
+// RPCS3 0.8.1 performs the same kind of readiness check before it dlopens its
+// Core. A successful debugger attach is not sufficient if iOS still rejects
+// the RW -> RX transition that the JIT arena needs. Probe that transition here
+// so NeoStation can report an error instead of letting the Core abort at load.
+static BOOL RPCS3ProbeExecutableMemory(NSString** error) {
+  size_t pageSize = (size_t)getpagesize();
+  void* page = mmap(NULL,
+                    pageSize,
+                    PROT_READ | PROT_WRITE,
+                    MAP_PRIVATE | MAP_ANON,
+                    -1,
+                    0);
+  if (page == MAP_FAILED) {
+    if (error) {
+      *error = [NSString stringWithFormat:
+          @"RPCS3 JIT readiness allocation failed (errno %d).", errno];
+    }
+    return NO;
+  }
+
+  ((volatile unsigned char*)page)[0] = 0;
+  if (mprotect(page, pageSize, PROT_READ | PROT_EXEC) != 0) {
+    int savedErrno = errno;
+    munmap(page, pageSize);
+    if (error) {
+      *error = [NSString stringWithFormat:
+          @"JIT is attached, but iOS rejected RPCS3 executable memory (errno %d).",
+          savedErrno];
+    }
+    return NO;
+  }
+
+  // Restore writable permissions before releasing the test page.
+  mprotect(page, pageSize, PROT_READ | PROT_WRITE);
+  munmap(page, pageSize);
+  return YES;
+}
 
 static UIViewController* RPCS3RootViewController(void) {
   UIWindow* keyWindow = nil;
@@ -83,6 +157,7 @@ static UIViewController* RPCS3RootViewController(void) {
 @property(nonatomic, strong) RPCS3GameViewController* gameController;
 @property(nonatomic, assign) BOOL initialized;
 @property(nonatomic, assign) BOOL initializedWithExpandedJit;
+@property(nonatomic, assign) BOOL coreLoadedWithExpandedJit;
 @property(nonatomic, assign) BOOL operationBusy;
 @end
 
@@ -146,14 +221,57 @@ static void RPCS3Progress(void* context,
   return @"Unknown RPCS3 error";
 }
 
-- (BOOL)loadCore:(NSString**)error {
-  if (_api.handle) return YES;
+- (BOOL)loadCoreWithExpandedJit:(BOOL)expanded error:(NSString**)error {
+  if (_api.handle) {
+    if (self.coreLoadedWithExpandedJit != expanded) {
+      if (error) {
+        *error = @"RPCS3 JIT arena policy cannot change after the Core is loaded; relaunch NeoStation.";
+      }
+      return NO;
+    }
+    return YES;
+  }
+
+  // The original RPCS3 iOS loader requires JIT to be active before dlopen.
+  if (!RPCS3HostIsDebugged()) {
+    if (error) *error = @"JIT must be ready before loading RPCS3 Core.";
+    return NO;
+  }
+
+  if (expanded) {
+    if (!RPCS3HostHasEntitlement(CFSTR("com.apple.developer.kernel.extended-virtual-addressing")) ||
+        !RPCS3HostHasEntitlement(CFSTR("com.apple.developer.kernel.increased-memory-limit"))) {
+      if (error) {
+        *error = @"RPCS3 requires extended-virtual-addressing and increased-memory-limit entitlements in the signed NeoStation IPA.";
+      }
+      return NO;
+    }
+  }
+
+  NSString* readinessError = nil;
+  if (!RPCS3ProbeExecutableMemory(&readinessError)) {
+    if (error) *error = readinessError;
+    return NO;
+  }
+
+  // RPCS3 reads this policy while the dylib is being loaded, before
+  // rpcs3_ios_initialize is ever called. Setting it afterwards is too late.
+  if (setenv("RPCS3_IOS_EXPANDED_JIT_ARENA", expanded ? "1" : "0", 1) != 0) {
+    if (error) {
+      *error = [NSString stringWithFormat:
+          @"Unable to configure the RPCS3 JIT arena before loading (errno %d).",
+          errno];
+    }
+    return NO;
+  }
+
   NSString* frameworks = NSBundle.mainBundle.privateFrameworksPath ?: @"";
   NSArray<NSString*>* candidates = @[
     [frameworks stringByAppendingPathComponent:@"libRPCS3Core.dylib"],
     [NSBundle.mainBundle.bundlePath stringByAppendingPathComponent:@"Frameworks/libRPCS3Core.dylib"],
   ];
   void* handle = NULL;
+  dlerror();
   for (NSString* path in candidates) {
     if ([NSFileManager.defaultManager fileExistsAtPath:path]) {
       handle = dlopen(path.fileSystemRepresentation, RTLD_NOW | RTLD_LOCAL);
@@ -164,8 +282,9 @@ static void RPCS3Progress(void* context,
     if (error) *error = [NSString stringWithFormat:@"libRPCS3Core.dylib is missing or could not load: %s", dlerror() ?: "unknown"];
     return NO;
   }
-#define LOAD(name, field) do { _api.field = (__typeof__(_api.field))dlsym(handle, name); if (!_api.field) { if (error) *error = [NSString stringWithFormat:@"Missing RPCS3 symbol %s", name]; dlclose(handle); memset(&_api, 0, sizeof(_api)); return NO; } } while (0)
+#define LOAD(name, field) do { _api.field = (__typeof__(_api.field))dlsym(handle, name); if (!_api.field) { if (error) *error = [NSString stringWithFormat:@"Missing RPCS3 symbol %s", name]; dlclose(handle); memset(&_api, 0, sizeof(_api)); self.coreLoadedWithExpandedJit = NO; return NO; } } while (0)
   _api.handle = handle;
+  self.coreLoadedWithExpandedJit = expanded;
   LOAD("rpcs3_ios_abi_version", abi_version);
   LOAD("rpcs3_ios_build_info", build_info);
   LOAD("rpcs3_ios_initialize", initialize);
@@ -184,7 +303,9 @@ static void RPCS3Progress(void* context,
 #undef LOAD
   if (_api.abi_version() != kExpectedAbi) {
     if (error) *error = [NSString stringWithFormat:@"Unsupported RPCS3 iOS ABI %u (expected %u).", _api.abi_version(), kExpectedAbi];
-    dlclose(handle); memset(&_api, 0, sizeof(_api));
+    dlclose(handle);
+    memset(&_api, 0, sizeof(_api));
+    self.coreLoadedWithExpandedJit = NO;
     return NO;
   }
   return YES;
@@ -197,19 +318,28 @@ static void RPCS3Progress(void* context,
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
   if ([call.method isEqualToString:@"diagnostics"]) {
-    NSString* error = nil;
-    BOOL loaded = [self loadCore:&error];
+    NSString* frameworks = NSBundle.mainBundle.privateFrameworksPath ?: @"";
+    NSString* corePath = [frameworks stringByAppendingPathComponent:@"libRPCS3Core.dylib"];
+    BOOL present = [NSFileManager.defaultManager fileExistsAtPath:corePath];
     NSString* build = @"";
     uint32_t abi = 0;
-    if (loaded) {
+    if (_api.handle) {
       abi = _api.abi_version();
       const char* value = _api.build_info();
       if (value) build = [NSString stringWithUTF8String:value] ?: @"";
     }
-    result(@{@"coreLoaded": @(loaded), @"abi": @(abi), @"build": build,
-             @"initialized": @(self.initialized),
-             @"expandedJitRegion": @(self.initializedWithExpandedJit),
-             @"message": error ?: @""});
+    result(@{
+      @"corePresent": @(present),
+      @"coreLoaded": @(_api.handle != NULL),
+      @"abi": @(abi),
+      @"build": build,
+      @"initialized": @(self.initialized),
+      @"expandedJitRegion": @(self.initializedWithExpandedJit),
+      @"jitReady": @(RPCS3HostIsDebugged()),
+      @"extendedVirtualAddressing": @(RPCS3HostHasEntitlement(CFSTR("com.apple.developer.kernel.extended-virtual-addressing"))),
+      @"increasedMemoryLimit": @(RPCS3HostHasEntitlement(CFSTR("com.apple.developer.kernel.increased-memory-limit"))),
+      @"message": @"",
+    });
     return;
   }
 
@@ -220,7 +350,12 @@ static void RPCS3Progress(void* context,
     BOOL expanded = [args[@"expandedJitRegion"] boolValue];
     dispatch_async(_runtimeQueue, ^{
       NSString* error = nil;
-      if (![self loadCore:&error]) { dispatch_async(dispatch_get_main_queue(), ^{ result(@{@"success": @NO, @"message": error ?: @"Core unavailable"}); }); return; }
+      if (![self loadCoreWithExpandedJit:expanded error:&error]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+          result(@{@"success": @NO, @"message": error ?: @"Core unavailable"});
+        });
+        return;
+      }
       if (self.initialized) {
         if (self.initializedWithExpandedJit == expanded) {
           dispatch_async(dispatch_get_main_queue(), ^{ result(@{@"success": @YES, @"alreadyInitialized": @YES, @"expandedJitRegion": @(expanded)}); });

--- a/test/rpcs3_internal_integration_test.dart
+++ b/test/rpcs3_internal_integration_test.dart
@@ -26,7 +26,7 @@ void main() {
       expect(helper, isNot(contains('com.xitrix.RPCS3')));
     });
 
-    test('maintenance mode installs firmware/content without requiring JIT', () {
+    test('JIT and arena policy are ready before RPCS3 Core dlopen', () {
       final service = File(
         'lib/services/rpcs3_internal_service.dart',
       ).readAsStringSync();
@@ -34,14 +34,63 @@ void main() {
         'packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm',
       ).readAsStringSync();
 
+      final serviceJit = service.indexOf('await _ensureJit();');
+      final serviceInitialize = service.indexOf('Rpcs3InternalBridge.initialize');
+      expect(serviceJit, greaterThanOrEqualTo(0));
+      expect(serviceInitialize, greaterThan(serviceJit));
+
+      expect(bridge, contains('RPCS3HostIsDebugged'));
+      expect(bridge, contains('RPCS3ProbeExecutableMemory'));
+      expect(bridge, contains('RPCS3_IOS_EXPANDED_JIT_ARENA'));
+      final setenvIndex = bridge.indexOf(
+        'setenv("RPCS3_IOS_EXPANDED_JIT_ARENA"',
+      );
+      final dlopenIndex = bridge.indexOf('dlopen(path.fileSystemRepresentation');
+      expect(setenvIndex, greaterThanOrEqualTo(0));
+      expect(dlopenIndex, greaterThan(setenvIndex));
+
+      // Diagnostics must never be the first code path that loads RPCS3.
+      final diagnosticsStart = bridge.indexOf(
+        'if ([call.method isEqualToString:@"diagnostics"])',
+      );
+      final initializeStart = bridge.indexOf(
+        'if ([call.method isEqualToString:@"initialize"])',
+      );
+      final diagnosticsBlock = bridge.substring(diagnosticsStart, initializeStart);
+      expect(diagnosticsBlock, isNot(contains('loadCoreWithExpandedJit')));
+    });
+
+    test('firmware and game imports use the same validated RPCS3 runtime', () {
+      final service = File(
+        'lib/services/rpcs3_internal_service.dart',
+      ).readAsStringSync();
+
       expect(service, contains('ensureManagementInitialized'));
-      expect(service, contains('if (gameplay) await _ensureJit();'));
-      expect(service, contains('expandedJitRegion: gameplay'));
-      expect(service, contains('await ensureManagementInitialized();'));
+      expect(service, contains('expandedJitRegion: true'));
       expect(service, contains('Rpcs3InternalBridge.installFirmware'));
       expect(service, contains('_stageFirmware'));
-      expect(bridge, contains('@"shutdown"'));
-      expect(bridge, contains('initializedWithExpandedJit'));
+      expect(service, isNot(contains('expandedJitRegion: gameplay')));
+      expect(service, isNot(contains('if (gameplay) await _ensureJit();')));
+    });
+
+    test('RPCS3 signing capabilities match the original iOS runtime needs', () {
+      final config = File(
+        'build-utils/configure_rpcs3_ios_v2.py',
+      ).readAsStringSync();
+
+      expect(config, contains("'get-task-allow': True"));
+      expect(
+        config,
+        contains("'com.apple.developer.kernel.extended-virtual-addressing': True"),
+      );
+      expect(
+        config,
+        contains("'com.apple.developer.kernel.increased-memory-limit': True"),
+      );
+      expect(
+        config,
+        contains("'com.apple.developer.kernel.increased-debugging-memory-limit': True"),
+      );
     });
 
     test('launch boots the selected title directly through RPCS3 Core', () {
@@ -75,13 +124,13 @@ void main() {
       final service = File(
         'lib/services/rpcs3_internal_service.dart',
       ).readAsStringSync();
-      final firmwareCheck = service.indexOf("'firmwareRequired'");
       final gameplayInit = service.indexOf('await ensureGameplayInitialized();');
+      final firmwareCheck = service.indexOf("'firmwareRequired'");
       final launchCall = service.indexOf('Rpcs3InternalBridge.launchGame');
 
-      expect(firmwareCheck, greaterThanOrEqualTo(0));
-      expect(gameplayInit, greaterThan(firmwareCheck));
-      expect(launchCall, greaterThan(gameplayInit));
+      expect(gameplayInit, greaterThanOrEqualTo(0));
+      expect(firmwareCheck, greaterThan(gameplayInit));
+      expect(launchCall, greaterThan(firmwareCheck));
     });
 
     test('PS3 library exposes emulator manager and all import actions', () {


### PR DESCRIPTION
Fixes the runtime crash when opening RPCS3 or importing firmware by matching the original RPCS3 iOS loader contract: validate JIT before dlopen, probe executable memory, set RPCS3_IOS_EXPANDED_JIT_ARENA before loading the Core, restore required signing entitlements, keep direct game boot without the standalone Start screen, and prepare Build 219. DolphiniOS is untouched.