### PR TITLE
Fix RPCS3 infinite JIT loading and responsive manager

### DIFF
--- a/.github/workflows/build-ipa-once.yml
+++ b/.github/workflows/build-ipa-once.yml
@@ -1,5 +1,5 @@
-name: NeoStation iOS Build 220
-run-name: NeoStation iOS Build 220 • ${{ github.sha }}
+name: NeoStation iOS Build 221
+run-name: NeoStation iOS Build 221 • ${{ github.sha }}
 
 on:
   push:
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: neostation-ios-build-220
+  group: neostation-ios-build-221
   cancel-in-progress: true
 
 jobs:
@@ -21,9 +21,9 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 180
     env:
-      BUILD_NUMBER: '220'
-      IPA_NAME: 'NeoStation-iOS-Build-220'
-      ARTIFACT_NAME: 'NeoStation-iOS-Build-220'
+      BUILD_NUMBER: '221'
+      IPA_NAME: 'NeoStation-iOS-Build-221'
+      ARTIFACT_NAME: 'NeoStation-iOS-Build-221'
       DOLPHIN_SHA: 7cac54161659421ed95c2cd1c0b0746539a4cd38
       HOMEBREW_NO_AUTO_UPDATE: '1'
       BUNDLE_GEMFILE: ${{ github.workspace }}/build-utils/Gemfile.dolphin
@@ -271,7 +271,7 @@ jobs:
           missing = [key for key in required if payload.get(key) is not True]
           if missing:
               raise SystemExit(
-                  'Build 220 is missing required RPCS3 signing entitlements: ' + ', '.join(missing)
+                  'Build 221 is missing required RPCS3 signing entitlements: ' + ', '.join(missing)
               )
           print(f'RPCS3 lazy IPA validation passed: {cores[0]} + RPCS3JITHelper; required JIT/memory entitlements emitted')
           PY

--- a/lib/screens/rpcs3_manager_screen.dart
+++ b/lib/screens/rpcs3_manager_screen.dart
@@ -6,9 +6,8 @@ import '../services/rpcs3_internal_service.dart';
 
 /// User-facing management surface for the embedded RPCS3 engine.
 ///
-/// RPCS3 iOS 0.8.1 requires JIT before its Core can be loaded, even for
-/// firmware/content maintenance. Opening this screen prepares that runtime and
-/// then exposes the Core's native installation APIs through NeoStation.
+/// Opening this screen pre-warms JIT in the background but deliberately keeps
+/// libRPCS3Core.dylib dormant until a firmware/content/game action needs it.
 class Rpcs3ManagerScreen extends StatefulWidget {
   const Rpcs3ManagerScreen({
     super.key,
@@ -22,11 +21,15 @@ class Rpcs3ManagerScreen extends StatefulWidget {
 }
 
 class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
-  bool _loading = true;
+  StreamSubscription<Rpcs3RuntimeState>? _runtimeSubscription;
   bool _busy = false;
-  String _firmwareVersion = '';
+  bool _preparing = false;
+  bool _jitReady = false;
+  bool _coreReady = false;
+  String? _firmwareVersion;
   String _build = '';
   int _abi = 0;
+  String _statusMessage = '';
   String? _error;
 
   bool get _fr => Localizations.localeOf(context).languageCode == 'fr';
@@ -34,13 +37,24 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _refresh());
+    _runtimeSubscription = Rpcs3InternalService.runtimeStates.listen((state) {
+      if (!mounted) return;
+      setState(() {
+        _jitReady = state.jitReady;
+        _coreReady = state.coreReady;
+        _statusMessage = state.message;
+        _error = state.error;
+        _preparing = state.phase == Rpcs3RuntimePhase.checkingJit ||
+            state.phase == Rpcs3RuntimePhase.enablingJit ||
+            state.phase == Rpcs3RuntimePhase.initializingCore;
+      });
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) => _bootstrap());
   }
 
   @override
   void dispose() {
-    // Closing the manager leaves the validated RPCS3 Core ready for a later
-    // direct game boot; it is not an external emulator process.
+    _runtimeSubscription?.cancel();
     unawaited(Rpcs3InternalService.closeManagementRuntime());
     super.dispose();
   }
@@ -52,19 +66,14 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
     );
   }
 
-  Future<void> _refresh() async {
-    if (!mounted) return;
-    setState(() {
-      _loading = true;
-      _error = null;
-    });
+  Future<void> _readDiagnostics() async {
     try {
-      await Rpcs3InternalService.ensureManagementInitialized();
-      final version = await Rpcs3InternalService.firmwareVersion();
       final diagnostics = await Rpcs3InternalService.diagnostics();
+      final jit = diagnostics['jit'];
       if (!mounted) return;
       setState(() {
-        _firmwareVersion = version;
+        _jitReady = jit is Map && jit['debugged'] == true;
+        _coreReady = diagnostics['initialized'] == true;
         _build = diagnostics['build']?.toString() ?? '';
         _abi = (diagnostics['abi'] as num?)?.toInt() ?? 0;
       });
@@ -72,27 +81,69 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
       if (mounted) setState(() => _error = error.message);
     } catch (error) {
       if (mounted) setState(() => _error = error.toString());
-    } finally {
-      if (mounted) setState(() => _loading = false);
     }
+  }
+
+  Future<void> _bootstrap() async {
+    if (_preparing) return;
+    setState(() {
+      _preparing = true;
+      _error = null;
+    });
+
+    // Render the manager immediately, then warm up only JIT in the background.
+    await _readDiagnostics();
+    try {
+      await Rpcs3InternalService.prepareManager();
+      await _readDiagnostics();
+      if (!mounted) return;
+      setState(() {
+        _jitReady = true;
+        _statusMessage = _fr
+            ? 'JIT prêt. RPCS3 Core sera chargé uniquement quand une action le demande.'
+            : 'JIT ready. RPCS3 Core will load only when an action needs it.';
+      });
+    } on Rpcs3InternalException catch (error) {
+      if (mounted) setState(() => _error = error.message);
+    } catch (error) {
+      if (mounted) setState(() => _error = error.toString());
+    } finally {
+      if (mounted) setState(() => _preparing = false);
+    }
+  }
+
+  Future<void> _refresh() async {
+    setState(() => _error = null);
+    await _readDiagnostics();
+    if (!_jitReady) await _bootstrap();
+  }
+
+  Future<void> _refreshFirmwareVersion() async {
+    final version = await Rpcs3InternalService.firmwareVersion();
+    if (mounted) setState(() => _firmwareVersion = version);
   }
 
   Future<void> _installFirmware() async {
     if (_busy) return;
-    setState(() => _busy = true);
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
     try {
       if (await Rpcs3InternalService.importFirmware()) {
-        _firmwareVersion = await Rpcs3InternalService.firmwareVersion();
+        await _refreshFirmwareVersion();
         _notice(
           _fr
-              ? 'Firmware PS3 installé : $_firmwareVersion'
-              : 'PS3 firmware installed: $_firmwareVersion',
+              ? 'Firmware PS3 installé : ${_firmwareVersion ?? ''}'
+              : 'PS3 firmware installed: ${_firmwareVersion ?? ''}',
         );
-        if (mounted) setState(() {});
       }
+      await _readDiagnostics();
     } on Rpcs3InternalException catch (error) {
+      if (mounted) setState(() => _error = error.message);
       _notice(error.message);
     } catch (error) {
+      if (mounted) setState(() => _error = error.toString());
       _notice(error.toString());
     } finally {
       if (mounted) setState(() => _busy = false);
@@ -101,7 +152,10 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
 
   Future<void> _importGames() async {
     if (_busy) return;
-    setState(() => _busy = true);
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
     try {
       final result = await Rpcs3InternalService.importGames();
       if (result.imported > 0) {
@@ -119,9 +173,12 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
               : (_fr ? 'Import RPCS3 refusé.' : 'RPCS3 import rejected.'),
         );
       }
+      await _readDiagnostics();
     } on Rpcs3InternalException catch (error) {
+      if (mounted) setState(() => _error = error.message);
       _notice(error.message);
     } catch (error) {
+      if (mounted) setState(() => _error = error.toString());
       _notice(error.toString());
     } finally {
       if (mounted) setState(() => _busy = false);
@@ -130,7 +187,10 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
 
   Future<void> _importFolder() async {
     if (_busy) return;
-    setState(() => _busy = true);
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
     try {
       if (await Rpcs3InternalService.importExtractedGameFolder()) {
         await widget.onLibraryChanged();
@@ -138,19 +198,44 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
           _fr ? 'Dossier de jeu PS3 importé.' : 'PS3 game folder imported.',
         );
       }
+      await _readDiagnostics();
     } on Rpcs3InternalException catch (error) {
+      if (mounted) setState(() => _error = error.message);
       _notice(error.message);
     } catch (error) {
+      if (mounted) setState(() => _error = error.toString());
       _notice(error.toString());
     } finally {
       if (mounted) setState(() => _busy = false);
     }
   }
 
+  Widget _statusRow({
+    required IconData icon,
+    required String label,
+    required String value,
+    required Color color,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          Icon(icon, size: 20, color: color),
+          const SizedBox(width: 10),
+          Expanded(child: Text(label)),
+          Text(value, style: TextStyle(color: color)),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
-    final firmwareInstalled = _firmwareVersion.isNotEmpty;
+    final firmwareChecked = _firmwareVersion != null;
+    final firmwareInstalled = _firmwareVersion?.isNotEmpty == true;
+    final currentState = Rpcs3InternalService.runtimeState;
+    final working = _busy || _preparing || currentState.busy;
 
     return Scaffold(
       appBar: AppBar(
@@ -178,10 +263,7 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
                       children: [
                         Row(
                           children: [
-                            Icon(
-                              Icons.memory,
-                              color: scheme.primary,
-                            ),
+                            Icon(Icons.memory, color: scheme.primary),
                             const SizedBox(width: 12),
                             Expanded(
                               child: Text(
@@ -196,15 +278,57 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
                         const SizedBox(height: 12),
                         Text(
                           _fr
-                              ? 'RPCS3 active d’abord le JIT requis par son moteur, puis ce menu permet d’installer le firmware et les jeux. Le lancement d’un jeu reste direct depuis NeoStation.'
-                              : 'RPCS3 first enables the JIT required by its engine, then this menu can install firmware and games. Games still boot directly from NeoStation.',
+                              ? 'Le JIT est vérifié automatiquement à l’ouverture. Le Core RPCS3 reste dormant jusqu’à l’installation du firmware, l’import d’un jeu ou le lancement d’un titre.'
+                              : 'JIT is checked automatically when this screen opens. RPCS3 Core stays dormant until firmware installation, game import or title launch.',
                         ),
+                        const SizedBox(height: 16),
+                        _statusRow(
+                          icon: _jitReady
+                              ? Icons.check_circle
+                              : _preparing
+                                  ? Icons.hourglass_top
+                                  : Icons.radio_button_unchecked,
+                          label: 'JIT',
+                          value: _jitReady
+                              ? (_fr ? 'Activé' : 'Enabled')
+                              : _preparing
+                                  ? (_fr ? 'Activation…' : 'Enabling…')
+                                  : (_fr ? 'Inactif' : 'Inactive'),
+                          color: _jitReady
+                              ? scheme.primary
+                              : _preparing
+                                  ? scheme.tertiary
+                                  : scheme.onSurfaceVariant,
+                        ),
+                        _statusRow(
+                          icon: _coreReady
+                              ? Icons.check_circle
+                              : Icons.pause_circle_outline,
+                          label: 'RPCS3 Core',
+                          value: _coreReady
+                              ? (_fr ? 'Prêt' : 'Ready')
+                              : (_fr ? 'À la demande' : 'On demand'),
+                          color: _coreReady
+                              ? scheme.primary
+                              : scheme.onSurfaceVariant,
+                        ),
+                        if (_statusMessage.isNotEmpty) ...[
+                          const SizedBox(height: 8),
+                          Text(
+                            _statusMessage,
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                        ],
                         if (_build.isNotEmpty || _abi != 0) ...[
                           const SizedBox(height: 8),
                           Text(
                             'Core ${_build.isEmpty ? '' : _build}${_abi == 0 ? '' : ' • ABI $_abi'}',
                             style: Theme.of(context).textTheme.bodySmall,
                           ),
+                        ],
+                        if (working) ...[
+                          const SizedBox(height: 12),
+                          const LinearProgressIndicator(),
                         ],
                       ],
                     ),
@@ -214,26 +338,40 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
                 Card(
                   child: ListTile(
                     leading: Icon(
-                      firmwareInstalled
-                          ? Icons.check_circle
-                          : Icons.warning_amber_rounded,
-                      color: firmwareInstalled
-                          ? scheme.primary
-                          : scheme.error,
+                      !firmwareChecked
+                          ? Icons.help_outline
+                          : firmwareInstalled
+                              ? Icons.check_circle
+                              : Icons.warning_amber_rounded,
+                      color: !firmwareChecked
+                          ? scheme.onSurfaceVariant
+                          : firmwareInstalled
+                              ? scheme.primary
+                              : scheme.error,
                     ),
                     title: Text(
-                      firmwareInstalled
+                      !firmwareChecked
                           ? (_fr
-                                ? 'Firmware PS3 installé'
-                                : 'PS3 firmware installed')
-                          : (_fr ? 'Firmware PS3 requis' : 'PS3 firmware required'),
+                              ? 'Firmware PS3 non vérifié'
+                              : 'PS3 firmware not checked')
+                          : firmwareInstalled
+                              ? (_fr
+                                  ? 'Firmware PS3 installé'
+                                  : 'PS3 firmware installed')
+                              : (_fr
+                                  ? 'Firmware PS3 requis'
+                                  : 'PS3 firmware required'),
                     ),
                     subtitle: Text(
-                      firmwareInstalled
-                          ? _firmwareVersion
-                          : (_fr
-                                ? 'Installez le fichier officiel PS3UPDAT.PUP.'
-                                : 'Install the official PS3UPDAT.PUP file.'),
+                      !firmwareChecked
+                          ? (_fr
+                              ? 'Il sera vérifié dès que RPCS3 Core sera chargé.'
+                              : 'It will be checked as soon as RPCS3 Core is loaded.')
+                          : firmwareInstalled
+                              ? _firmwareVersion!
+                              : (_fr
+                                  ? 'Installez le fichier officiel PS3UPDAT.PUP.'
+                                  : 'Install the official PS3UPDAT.PUP file.'),
                     ),
                   ),
                 ),
@@ -243,9 +381,20 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
                     color: scheme.errorContainer,
                     child: Padding(
                       padding: const EdgeInsets.all(16),
-                      child: Text(
-                        _error!,
-                        style: TextStyle(color: scheme.onErrorContainer),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            _error!,
+                            style: TextStyle(color: scheme.onErrorContainer),
+                          ),
+                          const SizedBox(height: 10),
+                          TextButton.icon(
+                            onPressed: _busy ? null : _bootstrap,
+                            icon: const Icon(Icons.refresh),
+                            label: Text(_fr ? 'Réessayer' : 'Retry'),
+                          ),
+                        ],
                       ),
                     ),
                   ),
@@ -253,7 +402,7 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
                 const SizedBox(height: 20),
                 FilledButton.icon(
                   key: const ValueKey('rpcs3-manager-firmware'),
-                  onPressed: _loading || _busy ? null : _installFirmware,
+                  onPressed: _busy ? null : _installFirmware,
                   icon: const Icon(Icons.system_update_alt),
                   label: Text(
                     _fr ? 'Installer le firmware PS3' : 'Install PS3 firmware',
@@ -262,14 +411,14 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
                 const SizedBox(height: 12),
                 FilledButton.tonalIcon(
                   key: const ValueKey('rpcs3-manager-games'),
-                  onPressed: _loading || _busy ? null : _importGames,
+                  onPressed: _busy ? null : _importGames,
                   icon: const Icon(Icons.file_upload_outlined),
                   label: Text(_fr ? 'Importer des jeux' : 'Import games'),
                 ),
                 const SizedBox(height: 12),
                 FilledButton.tonalIcon(
                   key: const ValueKey('rpcs3-manager-folder'),
-                  onPressed: _loading || _busy ? null : _importFolder,
+                  onPressed: _busy ? null : _importFolder,
                   icon: const Icon(Icons.folder_open),
                   label: Text(
                     _fr
@@ -277,10 +426,6 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
                         : 'Import a game folder',
                   ),
                 ),
-                if (_loading || _busy) ...[
-                  const SizedBox(height: 24),
-                  const Center(child: CircularProgressIndicator()),
-                ],
               ],
             ),
           ),

--- a/lib/services/rpcs3_internal_service.dart
+++ b/lib/services/rpcs3_internal_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
@@ -8,6 +9,52 @@ import 'package:rpcs3_internal_bridge/rpcs3_internal_bridge.dart';
 import 'logger_service.dart';
 import 'pairing_file_service.dart';
 import 'rpcs3_library_service.dart';
+
+enum Rpcs3RuntimePhase {
+  idle,
+  checkingJit,
+  enablingJit,
+  jitReady,
+  initializingCore,
+  ready,
+  installingFirmware,
+  importingContent,
+  launching,
+  error,
+}
+
+class Rpcs3RuntimeState {
+  const Rpcs3RuntimeState({
+    required this.phase,
+    required this.message,
+    required this.jitReady,
+    required this.coreReady,
+    this.error,
+  });
+
+  const Rpcs3RuntimeState.idle()
+    : phase = Rpcs3RuntimePhase.idle,
+      message = '',
+      jitReady = false,
+      coreReady = false,
+      error = null;
+
+  final Rpcs3RuntimePhase phase;
+  final String message;
+  final bool jitReady;
+  final bool coreReady;
+  final String? error;
+
+  bool get busy => switch (phase) {
+    Rpcs3RuntimePhase.checkingJit ||
+    Rpcs3RuntimePhase.enablingJit ||
+    Rpcs3RuntimePhase.initializingCore ||
+    Rpcs3RuntimePhase.installingFirmware ||
+    Rpcs3RuntimePhase.importingContent ||
+    Rpcs3RuntimePhase.launching => true,
+    _ => false,
+  };
+}
 
 class Rpcs3ImportResult {
   const Rpcs3ImportResult({
@@ -33,22 +80,63 @@ class Rpcs3InternalException implements Exception {
 
 /// Owns the in-process PlayStation 3 engine embedded in NeoStation iOS.
 ///
-/// RPCS3 iOS 0.8.1 requires JIT to be active before libRPCS3Core.dylib is
-/// dlopened, including for firmware/content management. NeoStation therefore
-/// prepares and validates JIT first, loads one expanded RPCS3 runtime, and then
-/// uses that same runtime for firmware installation, game import and direct
-/// title boot. The standalone RPCS3 SwiftUI application is never launched.
+/// RPCS3 iOS 0.8.1 requires JIT before libRPCS3Core.dylib is dlopened. The
+/// runtime therefore checks whether NeoStation is already JIT-enabled first,
+/// reuses that state when possible, and only invokes StikJIT when necessary.
 class Rpcs3InternalService {
   Rpcs3InternalService._();
 
   static final _log = LoggerService.instance;
+  static final _stateController =
+      StreamController<Rpcs3RuntimeState>.broadcast(sync: true);
+
+  static const _statusTimeout = Duration(seconds: 5);
+  static const _jitTimeout = Duration(seconds: 90);
+  static const _coreTimeout = Duration(seconds: 60);
+  static const _firmwareInstallTimeout = Duration(minutes: 10);
+  static const _contentInstallTimeout = Duration(minutes: 30);
+
   static bool _initializing = false;
   static bool _initialized = false;
   static bool _jitPrepared = false;
+  static Future<void>? _jitPreparation;
+  static Rpcs3RuntimeState _state = const Rpcs3RuntimeState.idle();
 
   static bool get supported => Platform.isIOS;
   static bool get initialized => _initialized;
   static bool get gameplayMode => _initialized;
+  static Rpcs3RuntimeState get runtimeState => _state;
+  static Stream<Rpcs3RuntimeState> get runtimeStates => _stateController.stream;
+
+  static void _emit(
+    Rpcs3RuntimePhase phase,
+    String message, {
+    bool? jitReady,
+    bool? coreReady,
+    String? error,
+  }) {
+    _state = Rpcs3RuntimeState(
+      phase: phase,
+      message: message,
+      jitReady: jitReady ?? _state.jitReady,
+      coreReady: coreReady ?? _initialized,
+      error: error,
+    );
+    _stateController.add(_state);
+  }
+
+  static Future<T> _bounded<T>(
+    Future<T> future,
+    Duration timeout,
+    String code,
+    String message,
+  ) async {
+    try {
+      return await future.timeout(timeout);
+    } on TimeoutException {
+      throw Rpcs3InternalException(code, message);
+    }
+  }
 
   static Future<Directory> rootDirectory() async {
     final support = await getApplicationSupportDirectory();
@@ -71,9 +159,23 @@ class Rpcs3InternalService {
     return directory;
   }
 
+  static Future<Map<String, dynamic>> _jitStatus() => _bounded(
+    Rpcs3InternalBridge.jitStatus(),
+    _statusTimeout,
+    'jitStatusTimeout',
+    'RPCS3 could not read the current JIT state.',
+  );
+
   static Future<Map<String, dynamic>> diagnostics() async {
-    final core = await Rpcs3InternalBridge.diagnostics();
-    final jit = await Rpcs3InternalBridge.jitStatus();
+    final core = await _bounded(
+      Rpcs3InternalBridge.diagnostics(),
+      _statusTimeout,
+      'diagnosticsTimeout',
+      'RPCS3 diagnostics did not respond.',
+    );
+    final jit = await _jitStatus();
+    final jitReady = jit['debugged'] == true;
+    if (jitReady) _jitPrepared = true;
     return <String, dynamic>{
       ...core,
       'jit': jit,
@@ -82,23 +184,49 @@ class Rpcs3InternalService {
     };
   }
 
-  static Future<void> _ensureJit() async {
-    if (_jitPrepared) {
-      final current = await Rpcs3InternalBridge.jitStatus();
-      if (current['debugged'] == true) return;
-      _jitPrepared = false;
+  static Future<void> _prepareJitInternal() async {
+    _emit(
+      Rpcs3RuntimePhase.checkingJit,
+      'Vérification du JIT RPCS3…',
+      coreReady: _initialized,
+    );
+
+    // Always inspect the real process state first. A signed/JIT-enabled
+    // NeoStation must never start another StikJIT transaction unnecessarily.
+    final current = await _jitStatus();
+    if (current['debugged'] == true) {
+      _jitPrepared = true;
+      _emit(
+        Rpcs3RuntimePhase.jitReady,
+        'JIT RPCS3 déjà actif.',
+        jitReady: true,
+        coreReady: _initialized,
+      );
+      _log.i('RPCS3 is reusing the JIT state already active on NeoStation.');
+      return;
     }
 
+    _jitPrepared = false;
     if (!await PairingFileService.hasStoredPairingFile()) {
       throw const Rpcs3InternalException(
         'pairingRequired',
-        'Import the NeoStation Pairing File before opening RPCS3 or installing PS3 firmware/games.',
+        'Import the NeoStation Pairing File before starting RPCS3 JIT.',
       );
     }
 
+    _emit(
+      Rpcs3RuntimePhase.enablingJit,
+      'Activation du JIT RPCS3 avec StikJIT…',
+      jitReady: false,
+      coreReady: _initialized,
+    );
+
     final pairing = await PairingFileService.storedFile();
-    final jit = await Rpcs3InternalBridge.prepareJit(
-      pairingFilePath: pairing.path,
+    final jit = await _bounded(
+      Rpcs3InternalBridge.prepareJit(pairingFilePath: pairing.path),
+      _jitTimeout,
+      'jitTimeout',
+      'L’activation JIT RPCS3 a dépassé 90 secondes. Réessayez après avoir vérifié le Pairing File et StikJIT.',
     );
     if (jit['success'] != true) {
       throw Rpcs3InternalException(
@@ -108,7 +236,7 @@ class Rpcs3InternalService {
       );
     }
 
-    final status = await Rpcs3InternalBridge.jitStatus();
+    final status = await _jitStatus();
     if (status['debugged'] != true) {
       throw const Rpcs3InternalException(
         'jitNotPersistent',
@@ -117,9 +245,38 @@ class Rpcs3InternalService {
     }
 
     _jitPrepared = true;
+    _emit(
+      Rpcs3RuntimePhase.jitReady,
+      'JIT RPCS3 activé.',
+      jitReady: true,
+      coreReady: _initialized,
+    );
     _log.i(
       'RPCS3 internal JIT prepared for NeoStation pid=${jit['pid'] ?? 'unknown'}.',
     );
+  }
+
+  /// Ensures exactly one JIT transaction can be active at a time.
+  static Future<void> ensureJitReady() async {
+    final pending = _jitPreparation;
+    if (pending != null) return pending;
+
+    final future = _prepareJitInternal();
+    _jitPreparation = future;
+    try {
+      await future;
+    } on Rpcs3InternalException catch (error) {
+      _emit(
+        Rpcs3RuntimePhase.error,
+        error.message,
+        jitReady: false,
+        coreReady: _initialized,
+        error: error.message,
+      );
+      rethrow;
+    } finally {
+      if (identical(_jitPreparation, future)) _jitPreparation = null;
+    }
   }
 
   static Future<void> _ensureRuntime() async {
@@ -129,28 +286,52 @@ class Rpcs3InternalService {
         'RPCS3 internal is available on iOS only.',
       );
     }
-    if (_initialized) return;
+    if (_initialized) {
+      _emit(
+        Rpcs3RuntimePhase.ready,
+        'RPCS3 Core prêt.',
+        jitReady: true,
+        coreReady: true,
+      );
+      return;
+    }
 
     if (_initializing) {
-      while (_initializing) {
+      final deadline = DateTime.now().add(_coreTimeout);
+      while (_initializing && DateTime.now().isBefore(deadline)) {
         await Future<void>.delayed(const Duration(milliseconds: 50));
       }
       if (_initialized) return;
+      if (_initializing) {
+        throw const Rpcs3InternalException(
+          'coreInitializeTimeout',
+          'RPCS3 Core initialization is still blocked. Restart NeoStation and retry.',
+        );
+      }
       return _ensureRuntime();
     }
 
     _initializing = true;
     try {
-      // RPCS3's own iOS loader requires JIT before dlopen. Do not move this
-      // below initialize(): the Core reserves its JIT arena while loading.
-      await _ensureJit();
+      await ensureJitReady();
+      _emit(
+        Rpcs3RuntimePhase.initializingCore,
+        'Initialisation du Core RPCS3…',
+        jitReady: true,
+        coreReady: false,
+      );
 
       final data = await dataDirectory();
       final cache = await cacheDirectory();
-      final report = await Rpcs3InternalBridge.initialize(
-        supportPath: data.path,
-        cachePath: cache.path,
-        expandedJitRegion: true,
+      final report = await _bounded(
+        Rpcs3InternalBridge.initialize(
+          supportPath: data.path,
+          cachePath: cache.path,
+          expandedJitRegion: true,
+        ),
+        _coreTimeout,
+        'coreInitializeTimeout',
+        'RPCS3 Core n’a pas répondu dans les 60 secondes.',
       );
       if (report['success'] != true) {
         throw Rpcs3InternalException(
@@ -160,28 +341,45 @@ class Rpcs3InternalService {
       }
 
       _initialized = true;
+      _emit(
+        Rpcs3RuntimePhase.ready,
+        'RPCS3 Core prêt.',
+        jitReady: true,
+        coreReady: true,
+      );
       _log.i('RPCS3 internal Core initialized with validated expanded JIT.');
+    } on Rpcs3InternalException catch (error) {
+      _emit(
+        Rpcs3RuntimePhase.error,
+        error.message,
+        jitReady: _jitPrepared,
+        coreReady: false,
+        error: error.message,
+      );
+      rethrow;
     } finally {
       _initializing = false;
     }
   }
 
-  /// Opens the internal RPCS3 runtime for firmware/content management.
-  /// RPCS3 0.8.1 still requires JIT before its Core can be loaded.
+  /// Opening the RPCS3 manager pre-warms only JIT. The Core stays dormant until
+  /// an explicit firmware/content/game action actually needs it.
+  static Future<void> prepareManager() => ensureJitReady();
+
   static Future<void> ensureManagementInitialized() => _ensureRuntime();
-
   static Future<void> ensureInitialized() => _ensureRuntime();
-
   static Future<void> ensureGameplayInitialized() => _ensureRuntime();
-
-  /// Closing the manager only closes NeoStation's manager UI. The Core remains
-  /// loaded with the same JIT-arena policy so a later game can boot directly;
-  /// RPCS3 itself treats changing that policy after dlopen as relaunch-only.
   static Future<void> closeManagementRuntime() async {}
 
   static Future<String> firmwareVersion() async {
     await ensureManagementInitialized();
-    return (await Rpcs3InternalBridge.firmwareVersion()).trim();
+    return (await _bounded(
+      Rpcs3InternalBridge.firmwareVersion(),
+      _statusTimeout,
+      'firmwareStatusTimeout',
+      'RPCS3 did not return the firmware state.',
+    ))
+        .trim();
   }
 
   static Future<bool> hasFirmware() async {
@@ -207,11 +405,8 @@ class Rpcs3InternalService {
   }
 
   static Future<bool> importFirmware() async {
-    // Prepare RPCS3 before presenting the document picker. This mirrors the
-    // standalone loader and ensures the selected security-scoped file is used
-    // immediately instead of waiting for a long JIT transaction afterwards.
-    await ensureManagementInitialized();
-
+    // Present the picker immediately. JIT/Core preparation happens only after
+    // the user has actually selected a firmware file.
     final picked = await FilePicker.pickFiles(
       dialogTitle: 'Select official PS3UPDAT.PUP firmware',
       allowMultiple: false,
@@ -231,10 +426,20 @@ class Rpcs3InternalService {
 
     String? stagedPath;
     try {
-      // Keep a private copy while the native installer runs. This avoids the
-      // iOS document-picker security scope disappearing mid-install.
       stagedPath = await _stageFirmware(sourcePath);
-      final report = await Rpcs3InternalBridge.installFirmware(stagedPath);
+      await ensureManagementInitialized();
+      _emit(
+        Rpcs3RuntimePhase.installingFirmware,
+        'Installation du firmware PS3…',
+        jitReady: true,
+        coreReady: true,
+      );
+      final report = await _bounded(
+        Rpcs3InternalBridge.installFirmware(stagedPath),
+        _firmwareInstallTimeout,
+        'firmwareInstallTimeout',
+        'L’installation du firmware RPCS3 a dépassé 10 minutes.',
+      );
       if (report['success'] != true) {
         throw Rpcs3InternalException(
           'firmwareInstallFailed',
@@ -242,13 +447,25 @@ class Rpcs3InternalService {
         );
       }
 
-      final version = (await Rpcs3InternalBridge.firmwareVersion()).trim();
+      final version = (await _bounded(
+        Rpcs3InternalBridge.firmwareVersion(),
+        _statusTimeout,
+        'firmwareStatusTimeout',
+        'RPCS3 did not confirm the installed firmware.',
+      ))
+          .trim();
       if (version.isEmpty) {
         throw const Rpcs3InternalException(
           'firmwareVerificationFailed',
           'RPCS3 did not report an installed firmware after import.',
         );
       }
+      _emit(
+        Rpcs3RuntimePhase.ready,
+        'Firmware PS3 installé. RPCS3 est prêt.',
+        jitReady: true,
+        coreReady: true,
+      );
       _log.i('RPCS3 firmware installed successfully: $version');
       return true;
     } finally {
@@ -261,8 +478,6 @@ class Rpcs3InternalService {
   }
 
   static Future<Rpcs3ImportResult> importGames() async {
-    await ensureManagementInitialized();
-
     final picked = await FilePicker.pickFiles(
       dialogTitle: 'Import PlayStation 3 games',
       allowMultiple: true,
@@ -273,6 +488,14 @@ class Rpcs3InternalService {
     if (picked == null) {
       return const Rpcs3ImportResult(imported: 0, rejected: 0);
     }
+
+    await ensureManagementInitialized();
+    _emit(
+      Rpcs3RuntimePhase.importingContent,
+      'Import des jeux PS3…',
+      jitReady: true,
+      coreReady: true,
+    );
 
     var imported = 0;
     var rejected = 0;
@@ -288,14 +511,29 @@ class Rpcs3InternalService {
       final extension = path.extension(item.name).toLowerCase();
       Map<String, dynamic> report;
       if (extension == '.pkg') {
-        report = await Rpcs3InternalBridge.installPackage(sourcePath);
+        report = await _bounded(
+          Rpcs3InternalBridge.installPackage(sourcePath),
+          _contentInstallTimeout,
+          'gameImportTimeout',
+          '${item.name}: RPCS3 import timed out.',
+        );
       } else if (extension == '.zip') {
-        report = await Rpcs3InternalBridge.installZip(sourcePath);
+        report = await _bounded(
+          Rpcs3InternalBridge.installZip(sourcePath),
+          _contentInstallTimeout,
+          'gameImportTimeout',
+          '${item.name}: RPCS3 import timed out.',
+        );
       } else if (extension == '.iso') {
         final key = File(path.setExtension(sourcePath, '.key'));
-        report = await Rpcs3InternalBridge.installIso(
-          sourcePath,
-          keyPath: await key.exists() ? key.path : null,
+        report = await _bounded(
+          Rpcs3InternalBridge.installIso(
+            sourcePath,
+            keyPath: await key.exists() ? key.path : null,
+          ),
+          _contentInstallTimeout,
+          'gameImportTimeout',
+          '${item.name}: RPCS3 import timed out.',
         );
       } else {
         report = const <String, dynamic>{
@@ -315,6 +553,12 @@ class Rpcs3InternalService {
     }
 
     await Rpcs3LibraryService.syncInternalLibrary();
+    _emit(
+      Rpcs3RuntimePhase.ready,
+      'RPCS3 prêt.',
+      jitReady: true,
+      coreReady: true,
+    );
     return Rpcs3ImportResult(
       imported: imported,
       rejected: rejected,
@@ -323,14 +567,24 @@ class Rpcs3InternalService {
   }
 
   static Future<bool> importExtractedGameFolder() async {
-    await ensureManagementInitialized();
-
     final folder = await FilePicker.getDirectoryPath(
       dialogTitle: 'Import extracted PlayStation 3 game folder',
     );
     if (folder == null) return false;
 
-    final report = await Rpcs3InternalBridge.installFolder(folder);
+    await ensureManagementInitialized();
+    _emit(
+      Rpcs3RuntimePhase.importingContent,
+      'Import du dossier PS3…',
+      jitReady: true,
+      coreReady: true,
+    );
+    final report = await _bounded(
+      Rpcs3InternalBridge.installFolder(folder),
+      _contentInstallTimeout,
+      'gameImportTimeout',
+      'RPCS3 folder import timed out.',
+    );
     if (report['success'] != true) {
       throw Rpcs3InternalException(
         'gameImportFailed',
@@ -338,6 +592,12 @@ class Rpcs3InternalService {
       );
     }
     await Rpcs3LibraryService.syncInternalLibrary();
+    _emit(
+      Rpcs3RuntimePhase.ready,
+      'RPCS3 prêt.',
+      jitReady: true,
+      coreReady: true,
+    );
     return true;
   }
 
@@ -346,7 +606,13 @@ class Rpcs3InternalService {
     if (normalized.isEmpty) return false;
 
     await ensureGameplayInitialized();
-    final firmware = (await Rpcs3InternalBridge.firmwareVersion()).trim();
+    final firmware = (await _bounded(
+      Rpcs3InternalBridge.firmwareVersion(),
+      _statusTimeout,
+      'firmwareStatusTimeout',
+      'RPCS3 did not return the firmware state.',
+    ))
+        .trim();
     if (firmware.isEmpty) {
       throw const Rpcs3InternalException(
         'firmwareRequired',
@@ -354,8 +620,12 @@ class Rpcs3InternalService {
       );
     }
 
-    // Direct Core boot: no standalone RPCS3 Start/Commencer screen is ever
-    // presented. NeoStation calls rpcs3_ios_boot_game for the selected title.
+    _emit(
+      Rpcs3RuntimePhase.launching,
+      'Lancement du jeu PS3…',
+      jitReady: true,
+      coreReady: true,
+    );
     final report = await Rpcs3InternalBridge.launchGame(
       titleId: normalized,
       savestateId: savestateId,
@@ -366,6 +636,12 @@ class Rpcs3InternalService {
         report['message']?.toString() ?? 'RPCS3 could not boot this game.',
       );
     }
+    _emit(
+      Rpcs3RuntimePhase.ready,
+      'RPCS3 en cours d’exécution.',
+      jitReady: true,
+      coreReady: true,
+    );
     return true;
   }
 

--- a/test/rpcs3_internal_integration_test.dart
+++ b/test/rpcs3_internal_integration_test.dart
@@ -26,6 +26,27 @@ void main() {
       expect(helper, isNot(contains('com.xitrix.RPCS3')));
     });
 
+    test('existing process JIT is reused before launching StikJIT again', () {
+      final service = File(
+        'lib/services/rpcs3_internal_service.dart',
+      ).readAsStringSync();
+
+      final statusIndex = service.indexOf('final current = await _jitStatus();');
+      final debuggedIndex = service.indexOf("current['debugged'] == true");
+      final pairingIndex = service.indexOf(
+        'PairingFileService.hasStoredPairingFile',
+      );
+      final prepareIndex = service.indexOf('Rpcs3InternalBridge.prepareJit');
+
+      expect(statusIndex, greaterThanOrEqualTo(0));
+      expect(debuggedIndex, greaterThan(statusIndex));
+      expect(pairingIndex, greaterThan(debuggedIndex));
+      expect(prepareIndex, greaterThan(pairingIndex));
+      expect(service, contains('static Future<void>? _jitPreparation'));
+      expect(service, contains("'jitTimeout'"));
+      expect(service, contains('Duration(seconds: 90)'));
+    });
+
     test('JIT and arena policy are ready before RPCS3 Core dlopen', () {
       final service = File(
         'lib/services/rpcs3_internal_service.dart',
@@ -34,7 +55,7 @@ void main() {
         'packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm',
       ).readAsStringSync();
 
-      final serviceJit = service.indexOf('await _ensureJit();');
+      final serviceJit = service.indexOf('await ensureJitReady();');
       final serviceInitialize = service.indexOf('Rpcs3InternalBridge.initialize');
       expect(serviceJit, greaterThanOrEqualTo(0));
       expect(serviceInitialize, greaterThan(serviceJit));
@@ -49,7 +70,6 @@ void main() {
       expect(setenvIndex, greaterThanOrEqualTo(0));
       expect(dlopenIndex, greaterThan(setenvIndex));
 
-      // Diagnostics must never be the first code path that loads RPCS3.
       final diagnosticsStart = bridge.indexOf(
         'if ([call.method isEqualToString:@"diagnostics"])',
       );
@@ -60,17 +80,40 @@ void main() {
       expect(diagnosticsBlock, isNot(contains('loadCoreWithExpandedJit')));
     });
 
-    test('firmware and game imports use the same validated RPCS3 runtime', () {
+    test('manager pre-warms JIT without loading RPCS3 Core', () {
       final service = File(
         'lib/services/rpcs3_internal_service.dart',
       ).readAsStringSync();
+      final manager = File(
+        'lib/screens/rpcs3_manager_screen.dart',
+      ).readAsStringSync();
 
-      expect(service, contains('ensureManagementInitialized'));
-      expect(service, contains('expandedJitRegion: true'));
-      expect(service, contains('Rpcs3InternalBridge.installFirmware'));
-      expect(service, contains('_stageFirmware'));
-      expect(service, isNot(contains('expandedJitRegion: gameplay')));
-      expect(service, isNot(contains('if (gameplay) await _ensureJit();')));
+      expect(service, contains('static Future<void> prepareManager() => ensureJitReady();'));
+      expect(manager, contains('Rpcs3InternalService.prepareManager()'));
+      expect(manager, contains('RPCS3 Core'));
+      expect(manager, contains('À la demande'));
+      expect(manager, isNot(contains('const Center(child: CircularProgressIndicator())')));
+      expect(manager, contains('LinearProgressIndicator'));
+      expect(manager, contains('Réessayer'));
+    });
+
+    test('firmware picker is shown before RPCS3 runtime initialization', () {
+      final service = File(
+        'lib/services/rpcs3_internal_service.dart',
+      ).readAsStringSync();
+      final methodStart = service.indexOf('static Future<bool> importFirmware()');
+      final methodEnd = service.indexOf(
+        'static Future<Rpcs3ImportResult> importGames()',
+        methodStart,
+      );
+      final method = service.substring(methodStart, methodEnd);
+      final picker = method.indexOf('FilePicker.pickFiles');
+      final initialize = method.indexOf('ensureManagementInitialized');
+
+      expect(picker, greaterThanOrEqualTo(0));
+      expect(initialize, greaterThan(picker));
+      expect(method, contains('_stageFirmware'));
+      expect(method, contains("'firmwareInstallTimeout'"));
     });
 
     test('RPCS3 signing capabilities match the original iOS runtime needs', () {
@@ -112,9 +155,6 @@ void main() {
       expect(launcher, isNot(contains('openJitRequest')));
       expect(launcher, isNot(contains('com.xitrix.RPCS3')));
       expect(service, contains('await ensureGameplayInitialized();'));
-
-      // The standalone SwiftUI gate is not embedded or recreated. Game launch
-      // goes directly to rpcs3_ios_boot_game after firmware + JIT readiness.
       expect(plugin, isNot(contains('setTitle:@"Start"')));
       expect(plugin, isNot(contains('setTitle:@"Commencer"')));
       expect(service, isNot(contains('com.xitrix.RPCS3')));


### PR DESCRIPTION
Build 221: reuse an already-active NeoStation JIT state before launching StikJIT again, serialize JIT preparation, add bounded JIT/Core waits, keep the RPCS3 manager responsive, pre-warm JIT without loading the Core, open the firmware picker before runtime initialization, and surface JIT/Core state plus retry/error UI. DolphiniOS is untouched.