### PR TITLE
Fix PS3 firmware library flow and Universal JIT startup (build 224)

### DIFF
--- a/.github/workflows/build-ipa-once.yml
+++ b/.github/workflows/build-ipa-once.yml
@@ -1,10 +1,10 @@
-name: NeoStation iOS Build 222
-run-name: NeoStation iOS Build 222 • ${{ github.sha }}
+name: NeoStation iOS Build 223
+run-name: NeoStation iOS Build 223 • ${{ github.sha }}
 
 on:
   push:
     branches:
-      - fix/rpcs3-jit-status-build221
+      - fix/rpcs3-firmware-library-build223
     paths:
       - .github/workflows/build-ipa-once.yml
 
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: neostation-ios-build-222
+  group: neostation-ios-build-223
   cancel-in-progress: true
 
 jobs:
@@ -21,9 +21,9 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 180
     env:
-      BUILD_NUMBER: '222'
-      IPA_NAME: 'NeoStation-iOS-Build-222'
-      ARTIFACT_NAME: 'NeoStation-iOS-Build-222'
+      BUILD_NUMBER: '223'
+      IPA_NAME: 'NeoStation-iOS-Build-223'
+      ARTIFACT_NAME: 'NeoStation-iOS-Build-223'
       DOLPHIN_SHA: 7cac54161659421ed95c2cd1c0b0746539a4cd38
       HOMEBREW_NO_AUTO_UPDATE: '1'
       BUNDLE_GEMFILE: ${{ github.workspace }}/build-utils/Gemfile.dolphin
@@ -271,7 +271,7 @@ jobs:
           missing = [key for key in required if payload.get(key) is not True]
           if missing:
               raise SystemExit(
-                  'Build 222 is missing required RPCS3 signing entitlements: ' + ', '.join(missing)
+                  'Build 223 is missing required RPCS3 signing entitlements: ' + ', '.join(missing)
               )
           print(f'RPCS3 lazy IPA validation passed: {cores[0]} + RPCS3JITHelper; required JIT/memory entitlements emitted')
           PY

--- a/.github/workflows/build-ipa-once.yml
+++ b/.github/workflows/build-ipa-once.yml
@@ -1,5 +1,5 @@
 name: NeoStation iOS Build 223
-run-name: NeoStation iOS Build 223 • ${{ github.sha }}
+run-name: NeoStation iOS Build 223 (firmware UI) • ${{ github.sha }}
 
 on:
   push:

--- a/.github/workflows/build-ipa-once.yml
+++ b/.github/workflows/build-ipa-once.yml
@@ -1,10 +1,10 @@
-name: NeoStation iOS Build 221
-run-name: NeoStation iOS Build 221 • ${{ github.sha }}
+name: NeoStation iOS Build 222
+run-name: NeoStation iOS Build 222 • ${{ github.sha }}
 
 on:
   push:
     branches:
-      - main
+      - fix/rpcs3-jit-status-build221
     paths:
       - .github/workflows/build-ipa-once.yml
 
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: neostation-ios-build-221
+  group: neostation-ios-build-222
   cancel-in-progress: true
 
 jobs:
@@ -21,9 +21,9 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 180
     env:
-      BUILD_NUMBER: '221'
-      IPA_NAME: 'NeoStation-iOS-Build-221'
-      ARTIFACT_NAME: 'NeoStation-iOS-Build-221'
+      BUILD_NUMBER: '222'
+      IPA_NAME: 'NeoStation-iOS-Build-222'
+      ARTIFACT_NAME: 'NeoStation-iOS-Build-222'
       DOLPHIN_SHA: 7cac54161659421ed95c2cd1c0b0746539a4cd38
       HOMEBREW_NO_AUTO_UPDATE: '1'
       BUNDLE_GEMFILE: ${{ github.workspace }}/build-utils/Gemfile.dolphin
@@ -271,7 +271,7 @@ jobs:
           missing = [key for key in required if payload.get(key) is not True]
           if missing:
               raise SystemExit(
-                  'Build 221 is missing required RPCS3 signing entitlements: ' + ', '.join(missing)
+                  'Build 222 is missing required RPCS3 signing entitlements: ' + ', '.join(missing)
               )
           print(f'RPCS3 lazy IPA validation passed: {cores[0]} + RPCS3JITHelper; required JIT/memory entitlements emitted')
           PY

--- a/.github/workflows/build-ipa-once.yml
+++ b/.github/workflows/build-ipa-once.yml
@@ -1,5 +1,5 @@
-name: NeoStation iOS Build 223
-run-name: NeoStation iOS Build 223 (firmware UI) • ${{ github.sha }}
+name: NeoStation iOS Build 224
+run-name: NeoStation iOS Build 224 (RPCS3 JIT handshake) • ${{ github.sha }}
 
 on:
   push:
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: neostation-ios-build-223
+  group: neostation-ios-build-224
   cancel-in-progress: true
 
 jobs:
@@ -21,9 +21,9 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 180
     env:
-      BUILD_NUMBER: '223'
-      IPA_NAME: 'NeoStation-iOS-Build-223'
-      ARTIFACT_NAME: 'NeoStation-iOS-Build-223'
+      BUILD_NUMBER: '224'
+      IPA_NAME: 'NeoStation-iOS-Build-224'
+      ARTIFACT_NAME: 'NeoStation-iOS-Build-224'
       DOLPHIN_SHA: 7cac54161659421ed95c2cd1c0b0746539a4cd38
       HOMEBREW_NO_AUTO_UPDATE: '1'
       BUNDLE_GEMFILE: ${{ github.workspace }}/build-utils/Gemfile.dolphin
@@ -133,6 +133,7 @@ jobs:
           flutter pub get --enforce-lockfile
           flutter analyze --no-fatal-infos
           flutter test --no-pub
+          python3 test/rpcs3_jit_handshake_test.py
           git diff --exit-code -- pubspec.yaml pubspec.lock
 
       - name: Generate iOS host
@@ -271,7 +272,7 @@ jobs:
           missing = [key for key in required if payload.get(key) is not True]
           if missing:
               raise SystemExit(
-                  'Build 223 is missing required RPCS3 signing entitlements: ' + ', '.join(missing)
+                  'Build 224 is missing required RPCS3 signing entitlements: ' + ', '.join(missing)
               )
           print(f'RPCS3 lazy IPA validation passed: {cores[0]} + RPCS3JITHelper; required JIT/memory entitlements emitted')
           PY

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -106,6 +106,9 @@ class _SystemGamesListState extends State<SystemGamesList> {
   // Navigation & State orchestration.
   bool _isLoading = true;
   bool _isLoadingGames = false; // Prevents redundant reload triggers.
+  bool _rpcs3FirmwareReady = false;
+  bool get _isRpcs3Library =>
+      Platform.isIOS && widget.system.folderName.toLowerCase() == 'ps3';
   int _selectedGameIndex = 0;
   late GamepadNavigation
   _gamepadNav; // Unified controller/keyboard input handler.
@@ -618,7 +621,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
               ),
 
             // Content Layer: hide entirely while game dialog is active.
-            if (!_isGameLaunching)
+            if (!_isGameLaunching && (!_isRpcs3Library || _rpcs3FirmwareReady))
               SizedBox(
                 child: _isLoading
                     ? _buildLoadingState()
@@ -643,7 +646,7 @@ class _SystemGamesListState extends State<SystemGamesList> {
             // Navigation Layer: Visual alphabetical feedback for rapid scrolling.
             if (_currentLetter != null && !_isGameLaunching)
               _buildLetterIndicator(),
-            GameViewModeDropdown(),
+            if (!_isRpcs3Library || _rpcs3FirmwareReady) GameViewModeDropdown(),
 
             // DOLPHIN_ISOLATION_BEGIN: playlist_actions
             if (!_isGameLaunching &&
@@ -676,31 +679,28 @@ class _SystemGamesListState extends State<SystemGamesList> {
               ),
             // DOLPHIN_ISOLATION_END: playlist_actions
             // RPCS3_INTERNAL_BEGIN: playlist_actions
-            if (!_isGameLaunching &&
-                Platform.isIOS &&
-                widget.system.folderName.toLowerCase() == 'ps3')
-              Positioned(
-                top: 8.r,
-                right: 10.r,
-                child: SafeArea(
-                  child: Material(
-                    color: Theme.of(context).colorScheme.surface,
-                    borderRadius: BorderRadius.circular(12.r),
-                    child: Rpcs3InternalPlaylistActions(
-                      onInteractionChanged: (active) {
-                        if (!mounted) return;
-                        if (active) {
-                          _gamepadNav.deactivate();
-                        } else {
-                          _gamepadNav.activate();
-                        }
-                      },
-                      onLibraryChanged: () async {
-                        if (!mounted) return;
-                        await _loadGames();
-                      },
-                    ),
-                  ),
+            if (!_isGameLaunching && _isRpcs3Library)
+              Positioned.fill(
+                child: Rpcs3InternalPlaylistActions(
+                  onBack: _goBack,
+                  onFirmwareChanged: (installed) {
+                    if (!mounted) return;
+                    final wasReady = _rpcs3FirmwareReady;
+                    setState(() => _rpcs3FirmwareReady = installed);
+                    if (installed && !wasReady) _loadGames();
+                  },
+                  onInteractionChanged: (active) {
+                    if (!mounted) return;
+                    if (active || !_rpcs3FirmwareReady) {
+                      _gamepadNav.deactivate();
+                    } else {
+                      _gamepadNav.activate();
+                    }
+                  },
+                  onLibraryChanged: () async {
+                    if (!mounted) return;
+                    await _loadGames();
+                  },
                 ),
               ),
             // RPCS3_INTERNAL_END: playlist_actions
@@ -835,7 +835,11 @@ class _SystemGamesListState extends State<SystemGamesList> {
             ),
             SizedBox(height: 4.r),
             Text(
-              AppLocale.checkRomFiles.getString(context),
+              isRpcs3Library
+                  ? (Localizations.localeOf(context).languageCode == 'fr'
+                        ? 'Utilisez le menu d’import pour ajouter des jeux PS3.'
+                        : 'Use the import menu to add PS3 games.')
+                  : AppLocale.checkRomFiles.getString(context),
               style: TextStyle(
                 fontSize: 11.r,
                 fontWeight: FontWeight.w400,

--- a/lib/screens/game_screen/my_games_list.dart
+++ b/lib/screens/game_screen/my_games_list.dart
@@ -773,6 +773,8 @@ class _SystemGamesListState extends State<SystemGamesList> {
   /// specialized view for systems with zero detected media files.
   /// includes controls for recursive scanning and directory management.
   Widget _buildEmptyState() {
+    final isRpcs3Library =
+        Platform.isIOS && widget.system.folderName.toLowerCase() == 'ps3';
     bool currentScanValue = widget.system.recursiveScan;
 
     return Center(
@@ -846,202 +848,205 @@ class _SystemGamesListState extends State<SystemGamesList> {
             ),
             SizedBox(height: 16.r),
 
-            // Configuration Component: Recursive Library Scanning.
-            StatefulBuilder(
-              builder: (context, setStateBuilder) {
-                return Column(
-                  children: [
-                    Container(
-                      margin: EdgeInsets.only(bottom: 12.r),
-                      padding: EdgeInsets.symmetric(
-                        horizontal: 12.r,
-                        vertical: 8.r,
-                      ),
-                      decoration: BoxDecoration(
-                        color: Colors.black.withValues(alpha: 0.2),
-                        borderRadius: BorderRadius.circular(12.r),
-                        border: Border.all(
-                          color: Colors.white.withValues(alpha: 0.05),
+            // PS3 content is managed by the embedded RPCS3 engine. Recursive
+            // ROM scanning is not a meaningful onboarding step for this system;
+            // firmware/import actions live in the dedicated RPCS3 menu instead.
+            if (!isRpcs3Library)
+              StatefulBuilder(
+                builder: (context, setStateBuilder) {
+                  return Column(
+                    children: [
+                      Container(
+                        margin: EdgeInsets.only(bottom: 12.r),
+                        padding: EdgeInsets.symmetric(
+                          horizontal: 12.r,
+                          vertical: 8.r,
+                        ),
+                        decoration: BoxDecoration(
+                          color: Colors.black.withValues(alpha: 0.2),
+                          borderRadius: BorderRadius.circular(12.r),
+                          border: Border.all(
+                            color: Colors.white.withValues(alpha: 0.05),
+                          ),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              Symbols.folder_shared_rounded,
+                              color: Colors.white.withValues(alpha: 0.7),
+                              size: 16.r,
+                            ),
+                            SizedBox(width: 8.r),
+                            Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  AppLocale.recursiveScan.getString(context),
+                                  style: TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 12.r,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                                Text(
+                                  AppLocale.recursiveScanSubtitle.getString(
+                                    context,
+                                  ),
+                                  style: TextStyle(
+                                    color: Colors.white.withValues(alpha: 0.5),
+                                    fontSize: 10.r,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            SizedBox(width: 16.r),
+                            Switch(
+                              value: currentScanValue,
+                              activeThumbColor: Theme.of(
+                                context,
+                              ).colorScheme.primary,
+                              onChanged: (value) async {
+                                final oldSystem = widget.system;
+                                setStateBuilder(() {
+                                  currentScanValue = value;
+                                });
+
+                                try {
+                                  await SystemRepository.setRecursiveScan(
+                                    oldSystem.id!,
+                                    value,
+                                  );
+
+                                  if (!context.mounted) return;
+                                  final configProvider = context
+                                      .read<SqliteConfigProvider>();
+
+                                  await configProvider.scanSystems();
+                                  if (!context.mounted) return;
+
+                                  await Provider.of<SqliteDatabaseProvider>(
+                                    context,
+                                    listen: false,
+                                  ).loadDatabase();
+                                  if (!context.mounted) return;
+
+                                  await _loadGames();
+                                } catch (e) {
+                                  _log.e('Error toggling recursive scan: $e');
+                                  if (!context.mounted) return;
+                                  AppNotification.showNotification(
+                                    context,
+                                    AppLocale.failedToSaveSetting.getString(
+                                      context,
+                                    ),
+                                    type: NotificationType.error,
+                                  );
+                                }
+                              },
+                            ),
+                          ],
                         ),
                       ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(
-                            Symbols.folder_shared_rounded,
-                            color: Colors.white.withValues(alpha: 0.7),
-                            size: 16.r,
-                          ),
-                          SizedBox(width: 8.r),
-                          Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                AppLocale.recursiveScan.getString(context),
-                                style: TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 12.r,
-                                  fontWeight: FontWeight.w500,
-                                ),
+
+                      // Real-time Scan Progress Feedback.
+                      Consumer<SqliteConfigProvider>(
+                        builder: (context, provider, child) {
+                          if (!provider.isScanning ||
+                              provider.totalSystemsToScan <= 0) {
+                            return const SizedBox.shrink();
+                          }
+
+                          return Container(
+                            width: 320.r,
+                            margin: EdgeInsets.only(bottom: 12.r),
+                            padding: EdgeInsets.all(12.r),
+                            decoration: BoxDecoration(
+                              color: Colors.black.withValues(alpha: 0.2),
+                              borderRadius: BorderRadius.circular(12.r),
+                              border: Border.all(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.primary.withValues(alpha: 0.2),
+                                width: 1.r,
                               ),
-                              Text(
-                                AppLocale.recursiveScanSubtitle.getString(
-                                  context,
-                                ),
-                                style: TextStyle(
-                                  color: Colors.white.withValues(alpha: 0.5),
-                                  fontSize: 10.r,
-                                ),
-                              ),
-                            ],
-                          ),
-                          SizedBox(width: 16.r),
-                          Switch(
-                            value: currentScanValue,
-                            activeThumbColor: Theme.of(
-                              context,
-                            ).colorScheme.primary,
-                            onChanged: (value) async {
-                              final oldSystem = widget.system;
-                              setStateBuilder(() {
-                                currentScanValue = value;
-                              });
-
-                              try {
-                                await SystemRepository.setRecursiveScan(
-                                  oldSystem.id!,
-                                  value,
-                                );
-
-                                if (!context.mounted) return;
-                                final configProvider = context
-                                    .read<SqliteConfigProvider>();
-
-                                await configProvider.scanSystems();
-                                if (!context.mounted) return;
-
-                                await Provider.of<SqliteDatabaseProvider>(
-                                  context,
-                                  listen: false,
-                                ).loadDatabase();
-                                if (!context.mounted) return;
-
-                                await _loadGames();
-                              } catch (e) {
-                                _log.e('Error toggling recursive scan: $e');
-                                if (!context.mounted) return;
-                                AppNotification.showNotification(
-                                  context,
-                                  AppLocale.failedToSaveSetting.getString(
-                                    context,
-                                  ),
-                                  type: NotificationType.error,
-                                );
-                              }
-                            },
-                          ),
-                        ],
-                      ),
-                    ),
-
-                    // Real-time Scan Progress Feedback.
-                    Consumer<SqliteConfigProvider>(
-                      builder: (context, provider, child) {
-                        if (!provider.isScanning ||
-                            provider.totalSystemsToScan <= 0) {
-                          return const SizedBox.shrink();
-                        }
-
-                        return Container(
-                          width: 320.r,
-                          margin: EdgeInsets.only(bottom: 12.r),
-                          padding: EdgeInsets.all(12.r),
-                          decoration: BoxDecoration(
-                            color: Colors.black.withValues(alpha: 0.2),
-                            borderRadius: BorderRadius.circular(12.r),
-                            border: Border.all(
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.primary.withValues(alpha: 0.2),
-                              width: 1.r,
                             ),
-                          ),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Row(
-                                mainAxisAlignment:
-                                    MainAxisAlignment.spaceBetween,
-                                children: [
-                                  Text(
-                                    provider.scanStatus,
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .titleSmall
-                                        ?.copyWith(
-                                          fontWeight: FontWeight.bold,
-                                          fontSize: 10.r,
-                                          color: Theme.of(
-                                            context,
-                                          ).colorScheme.primary,
-                                        ),
-                                  ),
-                                  Text(
-                                    '${(provider.scanProgress * 100).toInt()}%',
-                                    style: Theme.of(context).textTheme.bodySmall
-                                        ?.copyWith(
-                                          fontWeight: FontWeight.bold,
-                                          fontSize: 10.r,
-                                          color: Theme.of(
-                                            context,
-                                          ).colorScheme.primary,
-                                        ),
-                                  ),
-                                ],
-                              ),
-                              SizedBox(height: 8.r),
-                              ClipRRect(
-                                borderRadius: BorderRadius.circular(4.r),
-                                child: LinearProgressIndicator(
-                                  value: provider.scanProgress,
-                                  minHeight: 6.r,
-                                  backgroundColor: Theme.of(
-                                    context,
-                                  ).colorScheme.primary.withValues(alpha: 0.1),
-                                  valueColor: AlwaysStoppedAnimation<Color>(
-                                    Theme.of(context).colorScheme.primary,
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    Text(
+                                      provider.scanStatus,
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .titleSmall
+                                          ?.copyWith(
+                                            fontWeight: FontWeight.bold,
+                                            fontSize: 10.r,
+                                            color: Theme.of(
+                                              context,
+                                            ).colorScheme.primary,
+                                          ),
+                                    ),
+                                    Text(
+                                      '${(provider.scanProgress * 100).toInt()}%',
+                                      style: Theme.of(context).textTheme.bodySmall
+                                          ?.copyWith(
+                                            fontWeight: FontWeight.bold,
+                                            fontSize: 10.r,
+                                            color: Theme.of(
+                                              context,
+                                            ).colorScheme.primary,
+                                          ),
+                                    ),
+                                  ],
+                                ),
+                                SizedBox(height: 8.r),
+                                ClipRRect(
+                                  borderRadius: BorderRadius.circular(4.r),
+                                  child: LinearProgressIndicator(
+                                    value: provider.scanProgress,
+                                    minHeight: 6.r,
+                                    backgroundColor: Theme.of(
+                                      context,
+                                    ).colorScheme.primary.withValues(alpha: 0.1),
+                                    valueColor: AlwaysStoppedAnimation<Color>(
+                                      Theme.of(context).colorScheme.primary,
+                                    ),
                                   ),
                                 ),
-                              ),
-                              SizedBox(height: 4.r),
-                              Text(
-                                AppLocale.scanningSystemOf
-                                    .getString(context)
-                                    .replaceFirst(
-                                      '{current}',
-                                      provider.scannedSystemsCount.toString(),
-                                    )
-                                    .replaceFirst(
-                                      '{total}',
-                                      provider.totalSystemsToScan.toString(),
-                                    ),
-                                style: Theme.of(context).textTheme.bodySmall
-                                    ?.copyWith(
-                                      fontSize: 9.r,
-                                      color: Colors.white.withValues(
-                                        alpha: 0.6,
+                                SizedBox(height: 4.r),
+                                Text(
+                                  AppLocale.scanningSystemOf
+                                      .getString(context)
+                                      .replaceFirst(
+                                        '{current}',
+                                        provider.scannedSystemsCount.toString(),
+                                      )
+                                      .replaceFirst(
+                                        '{total}',
+                                        provider.totalSystemsToScan.toString(),
                                       ),
-                                    ),
-                              ),
-                            ],
-                          ),
-                        );
-                      },
-                    ),
-                  ],
-                );
-              },
-            ),
+                                  style: Theme.of(context).textTheme.bodySmall
+                                      ?.copyWith(
+                                        fontSize: 9.r,
+                                        color: Colors.white.withValues(
+                                          alpha: 0.6,
+                                        ),
+                                      ),
+                                ),
+                              ],
+                            ),
+                          );
+                        },
+                      ),
+                    ],
+                  );
+                },
+              ),
 
             // Navigation Component: Exit Action.
             Material(

--- a/lib/screens/game_screen/my_games_list/data_loading.dart
+++ b/lib/screens/game_screen/my_games_list/data_loading.dart
@@ -61,6 +61,7 @@ extension _DataLoading on _SystemGamesListState {
 
   Future<void> _loadGames() async {
     if (!mounted || _isLoadingGames) return;
+    if (_isRpcs3Library && !_rpcs3FirmwareReady) return;
     _isLoadingGames = true;
 
     final isInitialLoad = _games.isEmpty;

--- a/lib/screens/game_screen/my_games_list/launch_flow.dart
+++ b/lib/screens/game_screen/my_games_list/launch_flow.dart
@@ -116,6 +116,7 @@ extension _LaunchFlow on _SystemGamesListState {
 
   /// Orchestrates the complex sequence for launching a game through an external emulator.
   Future<void> _selectCurrentGame() async {
+    if (_isRpcs3Library && !_rpcs3FirmwareReady) return;
     if (_selectedGame == null) return;
 
     // Special handling for the Integrated Music Player.

--- a/lib/screens/rpcs3_manager_screen.dart
+++ b/lib/screens/rpcs3_manager_screen.dart
@@ -9,10 +9,7 @@ import '../services/rpcs3_internal_service.dart';
 /// Opening this screen pre-warms JIT in the background but deliberately keeps
 /// libRPCS3Core.dylib dormant until a firmware/content/game action needs it.
 class Rpcs3ManagerScreen extends StatefulWidget {
-  const Rpcs3ManagerScreen({
-    super.key,
-    required this.onLibraryChanged,
-  });
+  const Rpcs3ManagerScreen({super.key, required this.onLibraryChanged});
 
   final Future<void> Function() onLibraryChanged;
 
@@ -44,7 +41,8 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
         _coreReady = state.coreReady;
         _statusMessage = state.message;
         _error = state.error;
-        _preparing = state.phase == Rpcs3RuntimePhase.checkingJit ||
+        _preparing =
+            state.phase == Rpcs3RuntimePhase.checkingJit ||
             state.phase == Rpcs3RuntimePhase.enablingJit ||
             state.phase == Rpcs3RuntimePhase.initializingCore;
       });
@@ -61,9 +59,8 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
 
   void _notice(String message) {
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(message)),
-    );
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
   }
 
   Future<void> _readDiagnostics() async {
@@ -72,7 +69,11 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
       final jit = diagnostics['jit'];
       if (!mounted) return;
       setState(() {
-        _jitReady = jit is Map && jit['debugged'] == true;
+        _jitReady =
+            jit is Map &&
+            jit['debugged'] == true &&
+            (jit['requiresCoreHandshake'] != true ||
+                diagnostics['initialized'] == true);
         _coreReady = diagnostics['initialized'] == true;
         _build = diagnostics['build']?.toString() ?? '';
         _abi = (diagnostics['abi'] as num?)?.toInt() ?? 0;
@@ -91,7 +92,7 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
       _error = null;
     });
 
-    // Render the manager immediately, then warm up only JIT in the background.
+    // Inspection only: Universal JIT must attach as part of Core startup.
     try {
       await _refreshFirmwareVersion();
       await _readDiagnostics();
@@ -99,10 +100,9 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
       await _readDiagnostics();
       if (!mounted) return;
       setState(() {
-        _jitReady = true;
         _statusMessage = _fr
-            ? 'JIT prêt. RPCS3 Core sera chargé uniquement quand une action le demande.'
-            : 'JIT ready. RPCS3 Core will load only when an action needs it.';
+            ? 'Le JIT et RPCS3 Core seront préparés lors de l’importation ou du lancement.'
+            : 'JIT and RPCS3 Core will be prepared when importing or launching.';
       });
     } on Rpcs3InternalException catch (error) {
       if (mounted) setState(() => _error = error.message);
@@ -287,19 +287,19 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
                           icon: _jitReady
                               ? Icons.check_circle
                               : _preparing
-                                  ? Icons.hourglass_top
-                                  : Icons.radio_button_unchecked,
+                              ? Icons.hourglass_top
+                              : Icons.radio_button_unchecked,
                           label: 'JIT',
                           value: _jitReady
                               ? (_fr ? 'Activé' : 'Enabled')
                               : _preparing
-                                  ? (_fr ? 'Activation…' : 'Enabling…')
-                                  : (_fr ? 'Inactif' : 'Inactive'),
+                              ? (_fr ? 'Activation…' : 'Enabling…')
+                              : (_fr ? 'Inactif' : 'Inactive'),
                           color: _jitReady
                               ? scheme.primary
                               : _preparing
-                                  ? scheme.tertiary
-                                  : scheme.onSurfaceVariant,
+                              ? scheme.tertiary
+                              : scheme.onSurfaceVariant,
                         ),
                         _statusRow(
                           icon: _coreReady
@@ -342,37 +342,37 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
                       !firmwareChecked
                           ? Icons.help_outline
                           : firmwareInstalled
-                              ? Icons.check_circle
-                              : Icons.warning_amber_rounded,
+                          ? Icons.check_circle
+                          : Icons.warning_amber_rounded,
                       color: !firmwareChecked
                           ? scheme.onSurfaceVariant
                           : firmwareInstalled
-                              ? scheme.primary
-                              : scheme.error,
+                          ? scheme.primary
+                          : scheme.error,
                     ),
                     title: Text(
                       !firmwareChecked
                           ? (_fr
-                              ? 'Firmware PS3 non vérifié'
-                              : 'PS3 firmware not checked')
+                                ? 'Firmware PS3 non vérifié'
+                                : 'PS3 firmware not checked')
                           : firmwareInstalled
-                              ? (_fr
-                                  ? 'Firmware PS3 installé'
-                                  : 'PS3 firmware installed')
-                              : (_fr
-                                  ? 'Firmware PS3 requis'
-                                  : 'PS3 firmware required'),
+                          ? (_fr
+                                ? 'Firmware PS3 installé'
+                                : 'PS3 firmware installed')
+                          : (_fr
+                                ? 'Firmware PS3 requis'
+                                : 'PS3 firmware required'),
                     ),
                     subtitle: Text(
                       !firmwareChecked
                           ? (_fr
-                              ? 'Vérification des fichiers du firmware…'
-                              : 'Checking the installed firmware files…')
+                                ? 'Vérification des fichiers du firmware…'
+                                : 'Checking the installed firmware files…')
                           : firmwareInstalled
-                              ? _firmwareVersion!
-                              : (_fr
-                                  ? 'Installez le fichier officiel PS3UPDAT.PUP.'
-                                  : 'Install the official PS3UPDAT.PUP file.'),
+                          ? _firmwareVersion!
+                          : (_fr
+                                ? 'Installez le fichier officiel PS3UPDAT.PUP.'
+                                : 'Install the official PS3UPDAT.PUP file.'),
                     ),
                   ),
                 ),
@@ -422,9 +422,7 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
                   onPressed: _busy ? null : _importFolder,
                   icon: const Icon(Icons.folder_open),
                   label: Text(
-                    _fr
-                        ? 'Importer un dossier de jeu'
-                        : 'Import a game folder',
+                    _fr ? 'Importer un dossier de jeu' : 'Import a game folder',
                   ),
                 ),
               ],

--- a/lib/screens/rpcs3_manager_screen.dart
+++ b/lib/screens/rpcs3_manager_screen.dart
@@ -92,8 +92,9 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
     });
 
     // Render the manager immediately, then warm up only JIT in the background.
-    await _readDiagnostics();
     try {
+      await _refreshFirmwareVersion();
+      await _readDiagnostics();
       await Rpcs3InternalService.prepareManager();
       await _readDiagnostics();
       if (!mounted) return;
@@ -365,8 +366,8 @@ class _Rpcs3ManagerScreenState extends State<Rpcs3ManagerScreen> {
                     subtitle: Text(
                       !firmwareChecked
                           ? (_fr
-                              ? 'Il sera vérifié dès que RPCS3 Core sera chargé.'
-                              : 'It will be checked as soon as RPCS3 Core is loaded.')
+                              ? 'Vérification des fichiers du firmware…'
+                              : 'Checking the installed firmware files…')
                           : firmwareInstalled
                               ? _firmwareVersion!
                               : (_fr

--- a/lib/services/rpcs3_internal_service.dart
+++ b/lib/services/rpcs3_internal_service.dart
@@ -372,14 +372,30 @@ class Rpcs3InternalService {
   static Future<void> closeManagementRuntime() async {}
 
   static Future<String> firmwareVersion() async {
-    await ensureManagementInitialized();
-    return (await _bounded(
-      Rpcs3InternalBridge.firmwareVersion(),
-      _statusTimeout,
-      'firmwareStatusTimeout',
-      'RPCS3 did not return the firmware state.',
-    ))
-        .trim();
+    // RPCS3's utils::get_firmware_version reads this same file under dev_flash.
+    // Opening a library must not dlopen the Core or request JIT just to read it.
+    // Read the actual install every time, including installs from older builds
+    // or the manager, instead of trusting a preference flag.
+    final data = await dataDirectory();
+    final file = File(
+      path.join(data.path, 'dev_flash', 'vsh', 'etc', 'version.txt'),
+    );
+    if (!await file.exists()) return '';
+    final size = await file.length();
+    if (size == 0 || size > 65536) return '';
+    final record = await file.readAsString();
+    final match = RegExp(
+      r'^release:(\d+)\.(\d+):',
+      multiLine: true,
+    ).firstMatch(record.trim());
+    if (match == null) return '';
+    final major = int.tryParse(match.group(1)!);
+    if (major == null) return '';
+    var minor = match.group(2)!;
+    while (minor.length > 2 && minor.endsWith('0')) {
+      minor = minor.substring(0, minor.length - 1);
+    }
+    return '$major.${minor.padRight(2, '0')}';
   }
 
   static Future<bool> hasFirmware() async {

--- a/lib/services/rpcs3_internal_service.dart
+++ b/lib/services/rpcs3_internal_service.dart
@@ -81,25 +81,29 @@ class Rpcs3InternalException implements Exception {
 /// Owns the in-process PlayStation 3 engine embedded in NeoStation iOS.
 ///
 /// RPCS3 iOS 0.8.1 requires JIT before libRPCS3Core.dylib is dlopened. The
-/// runtime therefore checks whether NeoStation is already JIT-enabled first,
-/// reuses that state when possible, and only invokes StikJIT when necessary.
+/// Universal JIT is a two-phase transaction: attach, load/initialize the Core
+/// while the debugger prepares its arena, then confirm the helper detached.
 class Rpcs3InternalService {
   Rpcs3InternalService._();
 
   static final _log = LoggerService.instance;
-  static final _stateController =
-      StreamController<Rpcs3RuntimeState>.broadcast(sync: true);
+  static final _stateController = StreamController<Rpcs3RuntimeState>.broadcast(
+    sync: true,
+  );
 
   static const _statusTimeout = Duration(seconds: 5);
-  static const _jitTimeout = Duration(seconds: 90);
-  static const _coreTimeout = Duration(seconds: 60);
+  static const _jitTimeout = Duration(minutes: 11);
+  static const _coreTimeout = Duration(minutes: 3);
+  static const _jitCompletionTimeout = Duration(seconds: 130);
   static const _firmwareInstallTimeout = Duration(minutes: 10);
   static const _contentInstallTimeout = Duration(minutes: 30);
 
-  static bool _initializing = false;
+  static Future<void>? _runtimePreparation;
   static bool _initialized = false;
   static bool _jitPrepared = false;
   static Future<void>? _jitPreparation;
+  static bool _jitCompletionPending = false;
+  static bool _restartRequired = false;
   static Rpcs3RuntimeState _state = const Rpcs3RuntimeState.idle();
 
   static bool get supported => Platform.isIOS;
@@ -174,8 +178,6 @@ class Rpcs3InternalService {
       'RPCS3 diagnostics did not respond.',
     );
     final jit = await _jitStatus();
-    final jitReady = jit['debugged'] == true;
-    if (jitReady) _jitPrepared = true;
     return <String, dynamic>{
       ...core,
       'jit': jit,
@@ -191,10 +193,11 @@ class Rpcs3InternalService {
       coreReady: _initialized,
     );
 
-    // Always inspect the real process state first. A signed/JIT-enabled
-    // NeoStation must never start another StikJIT transaction unnecessarily.
+    // CS_DEBUGGED persists after detach. It is enough for the legacy backend,
+    // but never proves that an iOS 26 Universal script is currently attached.
     final current = await _jitStatus();
-    if (current['debugged'] == true) {
+    if (current['debugged'] == true &&
+        current['requiresCoreHandshake'] != true) {
       _jitPrepared = true;
       _emit(
         Rpcs3RuntimePhase.jitReady,
@@ -222,12 +225,35 @@ class Rpcs3InternalService {
     );
 
     final pairing = await PairingFileService.storedFile();
-    final jit = await _bounded(
-      Rpcs3InternalBridge.prepareJit(pairingFilePath: pairing.path),
-      _jitTimeout,
-      'jitTimeout',
-      'L’activation JIT RPCS3 a dépassé 90 secondes. Réessayez après avoir vérifié le Pairing File et StikJIT.',
-    );
+    var readingProgress = false;
+    final progress = Timer.periodic(const Duration(seconds: 1), (_) async {
+      if (readingProgress) return;
+      readingProgress = true;
+      try {
+        final status = await _jitStatus();
+        final message = status['message']?.toString() ?? '';
+        if (_state.phase == Rpcs3RuntimePhase.enablingJit &&
+            message.isNotEmpty &&
+            message != _state.message) {
+          _emit(Rpcs3RuntimePhase.enablingJit, message, jitReady: false);
+        }
+      } catch (_) {
+        // Progress is optional; the transaction reports the authoritative error.
+      } finally {
+        readingProgress = false;
+      }
+    });
+    late final Map<String, dynamic> jit;
+    try {
+      jit = await _bounded(
+        Rpcs3InternalBridge.prepareJit(pairingFilePath: pairing.path),
+        _jitTimeout,
+        'jitTimeout',
+        'La préparation StikJIT/DDI ne répond plus. Relancez NeoStation avant de réessayer.',
+      );
+    } finally {
+      progress.cancel();
+    }
     if (jit['success'] != true) {
       throw Rpcs3InternalException(
         'jitFailed',
@@ -235,6 +261,8 @@ class Rpcs3InternalService {
             'StikJIT could not enable JIT for NeoStation.',
       );
     }
+
+    _jitCompletionPending = jit['requiresCompletion'] == true;
 
     final status = await _jitStatus();
     if (status['debugged'] != true) {
@@ -244,11 +272,12 @@ class Rpcs3InternalService {
       );
     }
 
-    _jitPrepared = true;
+    // Attached is not ready: Core initialization must still prepare and seal
+    // the arena before completeJit can confirm success.
     _emit(
-      Rpcs3RuntimePhase.jitReady,
-      'JIT RPCS3 activé.',
-      jitReady: true,
+      Rpcs3RuntimePhase.initializingCore,
+      'Helper JIT attaché. Préparation de la mémoire RPCS3…',
+      jitReady: false,
       coreReady: _initialized,
     );
     _log.i(
@@ -257,7 +286,7 @@ class Rpcs3InternalService {
   }
 
   /// Ensures exactly one JIT transaction can be active at a time.
-  static Future<void> ensureJitReady() async {
+  static Future<void> _attachJitForCore() async {
     final pending = _jitPreparation;
     if (pending != null) return pending;
 
@@ -279,11 +308,27 @@ class Rpcs3InternalService {
     }
   }
 
-  static Future<void> _ensureRuntime() async {
+  static Future<void> _ensureRuntime() {
+    final pending = _runtimePreparation;
+    if (pending != null) return pending;
+    final future = _initializeRuntime();
+    _runtimePreparation = future;
+    return future.whenComplete(() {
+      if (identical(_runtimePreparation, future)) _runtimePreparation = null;
+    });
+  }
+
+  static Future<void> _initializeRuntime() async {
     if (!supported) {
       throw const Rpcs3InternalException(
         'unsupported',
         'RPCS3 internal is available on iOS only.',
+      );
+    }
+    if (_restartRequired) {
+      throw const Rpcs3InternalException(
+        'restartRequired',
+        'La transaction JIT précédente est incomplète. Fermez complètement NeoStation puis relancez-le avant de réessayer.',
       );
     }
     if (_initialized) {
@@ -296,33 +341,19 @@ class Rpcs3InternalService {
       return;
     }
 
-    if (_initializing) {
-      final deadline = DateTime.now().add(_coreTimeout);
-      while (_initializing && DateTime.now().isBefore(deadline)) {
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-      }
-      if (_initialized) return;
-      if (_initializing) {
-        throw const Rpcs3InternalException(
-          'coreInitializeTimeout',
-          'RPCS3 Core initialization is still blocked. Restart NeoStation and retry.',
-        );
-      }
-      return _ensureRuntime();
-    }
-
-    _initializing = true;
     try {
-      await ensureJitReady();
+      // Resolve paths before attaching: once attached, advance straight into
+      // Core initialization so the Universal script can service its BRKs.
+      final data = await dataDirectory();
+      final cache = await cacheDirectory();
+      await _attachJitForCore();
       _emit(
         Rpcs3RuntimePhase.initializingCore,
         'Initialisation du Core RPCS3…',
-        jitReady: true,
+        jitReady: _jitPrepared,
         coreReady: false,
       );
 
-      final data = await dataDirectory();
-      final cache = await cacheDirectory();
       final report = await _bounded(
         Rpcs3InternalBridge.initialize(
           supportPath: data.path,
@@ -331,7 +362,7 @@ class Rpcs3InternalService {
         ),
         _coreTimeout,
         'coreInitializeTimeout',
-        'RPCS3 Core n’a pas répondu dans les 60 secondes.',
+        'La préparation mémoire RPCS3 ne répond plus. Relancez NeoStation avant de réessayer.',
       );
       if (report['success'] != true) {
         throw Rpcs3InternalException(
@@ -340,6 +371,22 @@ class Rpcs3InternalService {
         );
       }
 
+      if (_jitCompletionPending) {
+        final completion = await _bounded(
+          Rpcs3InternalBridge.completeJit(),
+          _jitCompletionTimeout,
+          'jitCompletionTimeout',
+          'Le helper JIT n’a pas confirmé sa fin. Relancez NeoStation avant de réessayer.',
+        );
+        if (completion['success'] != true) {
+          throw Rpcs3InternalException(
+            'jitCompletionFailed',
+            completion['message']?.toString() ?? 'RPCS3 JIT did not complete.',
+          );
+        }
+        _jitCompletionPending = false;
+      }
+      _jitPrepared = true;
       _initialized = true;
       _emit(
         Rpcs3RuntimePhase.ready,
@@ -349,6 +396,10 @@ class Rpcs3InternalService {
       );
       _log.i('RPCS3 internal Core initialized with validated expanded JIT.');
     } on Rpcs3InternalException catch (error) {
+      _restartRequired =
+          _jitCompletionPending ||
+          error.code == 'jitTimeout' ||
+          error.code == 'coreInitializeTimeout';
       _emit(
         Rpcs3RuntimePhase.error,
         error.message,
@@ -357,14 +408,19 @@ class Rpcs3InternalService {
         error: error.message,
       );
       rethrow;
-    } finally {
-      _initializing = false;
+    } catch (_) {
+      _restartRequired = _jitCompletionPending;
+      rethrow;
     }
   }
 
-  /// Opening the RPCS3 manager pre-warms only JIT. The Core stays dormant until
-  /// an explicit firmware/content/game action actually needs it.
-  static Future<void> prepareManager() => ensureJitReady();
+  /// A Universal attach cannot be pre-warmed independently of the Core.
+  /// Opening the manager only inspects status; an explicit action starts JIT.
+  static Future<void> prepareManager() async {
+    await _jitStatus();
+  }
+
+  static Future<void> ensureJitReady() => _ensureRuntime();
 
   static Future<void> ensureManagementInitialized() => _ensureRuntime();
   static Future<void> ensureInitialized() => _ensureRuntime();
@@ -468,8 +524,7 @@ class Rpcs3InternalService {
         _statusTimeout,
         'firmwareStatusTimeout',
         'RPCS3 did not confirm the installed firmware.',
-      ))
-          .trim();
+      )).trim();
       if (version.isEmpty) {
         throw const Rpcs3InternalException(
           'firmwareVerificationFailed',
@@ -627,8 +682,7 @@ class Rpcs3InternalService {
       _statusTimeout,
       'firmwareStatusTimeout',
       'RPCS3 did not return the firmware state.',
-    ))
-        .trim();
+    )).trim();
     if (firmware.isEmpty) {
       throw const Rpcs3InternalException(
         'firmwareRequired',

--- a/lib/widgets/rpcs3_internal_playlist_actions.dart
+++ b/lib/widgets/rpcs3_internal_playlist_actions.dart
@@ -24,6 +24,7 @@ class Rpcs3InternalPlaylistActions extends StatefulWidget {
 class _Rpcs3InternalPlaylistActionsState
     extends State<Rpcs3InternalPlaylistActions> {
   bool _busy = false;
+  bool _firmwareBootstrapStarted = false;
   String _firmwareVersion = '';
 
   bool get _fr => Localizations.localeOf(context).languageCode == 'fr';
@@ -38,11 +39,24 @@ class _Rpcs3InternalPlaylistActionsState
   String get _failed =>
       _fr ? 'Échec de l’opération RPCS3.' : 'RPCS3 operation failed.';
 
+  @override
+  void initState() {
+    super.initState();
+
+    // The PS3 library itself is now the entry point. On first display, verify
+    // the embedded Core's firmware and ask for PS3UPDAT.PUP immediately when
+    // it is missing. Once the firmware exists, the user remains in the normal
+    // NeoStation library and uses this compact menu only for imports/updates.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _ensureFirmwareForLibrary();
+    });
+  }
+
   void _interaction(bool active) => widget.onInteractionChanged?.call(active);
 
   // Opening the popup alone must not initialize or dlopen RPCS3. The Core is
   // loaded only after the user explicitly opens RPCS3, imports content, or
-  // launches a PS3 game.
+  // when this library performs its one-time firmware readiness check.
   Future<void> _opened() async {
     _interaction(true);
   }
@@ -52,6 +66,37 @@ class _Rpcs3InternalPlaylistActionsState
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  Future<void> _ensureFirmwareForLibrary() async {
+    if (_firmwareBootstrapStarted || _busy) return;
+    _firmwareBootstrapStarted = true;
+
+    setState(() => _busy = true);
+    _interaction(true);
+    try {
+      final version = await Rpcs3InternalService.firmwareVersion();
+      if (!mounted) return;
+      if (version.isNotEmpty) {
+        setState(() => _firmwareVersion = version);
+        return;
+      }
+
+      // No firmware: present the official PUP picker directly instead of
+      // exposing the generic recursive-ROM-scan onboarding step.
+      final installed = await Rpcs3InternalService.importFirmware();
+      if (!installed || !mounted) return;
+
+      _firmwareVersion = await Rpcs3InternalService.firmwareVersion();
+      if (mounted) setState(() {});
+    } on Rpcs3InternalException catch (error) {
+      _notice(error.message);
+    } catch (error) {
+      _notice('$_failed $error');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+      _interaction(false);
+    }
   }
 
   Future<void> _openManager() async {

--- a/lib/widgets/rpcs3_internal_playlist_actions.dart
+++ b/lib/widgets/rpcs3_internal_playlist_actions.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../screens/rpcs3_manager_screen.dart';
 import '../services/rpcs3_internal_service.dart';
@@ -23,8 +24,13 @@ class Rpcs3InternalPlaylistActions extends StatefulWidget {
 
 class _Rpcs3InternalPlaylistActionsState
     extends State<Rpcs3InternalPlaylistActions> {
+  static const _firmwareInstalledKey =
+      'rpcs3_internal_firmware_installed_v1';
+  static const _firmwareVersionKey = 'rpcs3_internal_firmware_version_v1';
+
   bool _busy = false;
-  bool _firmwareBootstrapStarted = false;
+  bool _onboardingShown = false;
+  bool _firmwareKnownInstalled = false;
   String _firmwareVersion = '';
 
   bool get _fr => Localizations.localeOf(context).languageCode == 'fr';
@@ -43,20 +49,18 @@ class _Rpcs3InternalPlaylistActionsState
   void initState() {
     super.initState();
 
-    // The PS3 library itself is now the entry point. On first display, verify
-    // the embedded Core's firmware and ask for PS3UPDAT.PUP immediately when
-    // it is missing. Once the firmware exists, the user remains in the normal
-    // NeoStation library and uses this compact menu only for imports/updates.
+    // Do not initialize or query RPCS3 Core just to decide whether onboarding
+    // should be shown. Build 222 did that through firmwareVersion(), which can
+    // wait on JIT/Core startup before the user ever sees the PUP picker. Load a
+    // lightweight local marker instead and present the firmware CTA immediately
+    // on a fresh PS3 library.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _ensureFirmwareForLibrary();
+      if (mounted) _restoreFirmwareStateAndShowOnboarding();
     });
   }
 
   void _interaction(bool active) => widget.onInteractionChanged?.call(active);
 
-  // Opening the popup alone must not initialize or dlopen RPCS3. The Core is
-  // loaded only after the user explicitly opens RPCS3, imports content, or
-  // when this library performs its one-time firmware readiness check.
   Future<void> _opened() async {
     _interaction(true);
   }
@@ -68,30 +72,99 @@ class _Rpcs3InternalPlaylistActionsState
     ).showSnackBar(SnackBar(content: Text(message)));
   }
 
-  Future<void> _ensureFirmwareForLibrary() async {
-    if (_firmwareBootstrapStarted || _busy) return;
-    _firmwareBootstrapStarted = true;
+  Future<void> _restoreFirmwareStateAndShowOnboarding() async {
+    final preferences = await SharedPreferences.getInstance();
+    final installed = preferences.getBool(_firmwareInstalledKey) ?? false;
+    final version = preferences.getString(_firmwareVersionKey) ?? '';
 
+    if (!mounted) return;
+    setState(() {
+      _firmwareKnownInstalled = installed;
+      _firmwareVersion = version;
+    });
+
+    if (!installed) {
+      await _showFirmwareOnboarding();
+    }
+  }
+
+  Future<void> _showFirmwareOnboarding() async {
+    if (!mounted || _onboardingShown || _busy || _firmwareKnownInstalled) {
+      return;
+    }
+    _onboardingShown = true;
+    _interaction(true);
+
+    final install = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: Text(_fr ? 'Firmware PS3 requis' : 'PS3 firmware required'),
+          content: Text(
+            _fr
+                ? 'RPCS3 nécessite le firmware officiel PS3 avant de pouvoir utiliser la bibliothèque. Sélectionnez le fichier PS3UPDAT.PUP pour continuer.'
+                : 'RPCS3 requires the official PS3 firmware before the library can be used. Select PS3UPDAT.PUP to continue.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: Text(_fr ? 'Retour' : 'Back'),
+            ),
+            FilledButton.icon(
+              key: const ValueKey('rpcs3-library-install-firmware'),
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              icon: const Icon(Icons.system_update_alt),
+              label: Text(
+                _fr ? 'Installer le firmware PS3' : 'Install PS3 firmware',
+              ),
+            ),
+          ],
+        );
+      },
+    );
+
+    _interaction(false);
+    if (install == true && mounted) {
+      await _installFirmware();
+    }
+  }
+
+  Future<void> _rememberInstalledFirmware() async {
+    final preferences = await SharedPreferences.getInstance();
+    await preferences.setBool(_firmwareInstalledKey, true);
+    if (_firmwareVersion.isNotEmpty) {
+      await preferences.setString(_firmwareVersionKey, _firmwareVersion);
+    }
+  }
+
+  Future<void> _installFirmware() async {
+    if (_busy) return;
     setState(() => _busy = true);
     _interaction(true);
     try {
-      final version = await Rpcs3InternalService.firmwareVersion();
-      if (!mounted) return;
-      if (version.isNotEmpty) {
-        setState(() => _firmwareVersion = version);
-        return;
+      // importFirmware() opens the PUP picker first. JIT/Core initialization is
+      // deferred until the user has actually selected the firmware file.
+      if (await Rpcs3InternalService.importFirmware()) {
+        _firmwareVersion = await Rpcs3InternalService.firmwareVersion();
+        _firmwareKnownInstalled = true;
+        await _rememberInstalledFirmware();
+        if (mounted) setState(() {});
+        _notice(
+          _fr
+              ? 'Firmware PS3 installé${_firmwareVersion.isEmpty ? '' : ' : $_firmwareVersion'}.'
+              : 'PS3 firmware installed${_firmwareVersion.isEmpty ? '' : ': $_firmwareVersion'}.',
+        );
+      } else {
+        // Picker cancelled: allow onboarding to be presented again next time
+        // the PS3 library is opened.
+        _onboardingShown = false;
       }
-
-      // No firmware: present the official PUP picker directly instead of
-      // exposing the generic recursive-ROM-scan onboarding step.
-      final installed = await Rpcs3InternalService.importFirmware();
-      if (!installed || !mounted) return;
-
-      _firmwareVersion = await Rpcs3InternalService.firmwareVersion();
-      if (mounted) setState(() {});
     } on Rpcs3InternalException catch (error) {
+      _onboardingShown = false;
       _notice(error.message);
     } catch (error) {
+      _onboardingShown = false;
       _notice('$_failed $error');
     } finally {
       if (mounted) setState(() => _busy = false);
@@ -112,6 +185,8 @@ class _Rpcs3InternalPlaylistActionsState
     try {
       if (await Rpcs3InternalService.hasFirmware()) {
         _firmwareVersion = await Rpcs3InternalService.firmwareVersion();
+        _firmwareKnownInstalled = true;
+        await _rememberInstalledFirmware();
       }
     } catch (_) {
       // Firmware state is shown again the next time the manager is opened.
@@ -129,8 +204,19 @@ class _Rpcs3InternalPlaylistActionsState
       return;
     }
 
+    if (action == 'firmware') {
+      await _installFirmware();
+      return;
+    }
+
     setState(() => _busy = true);
     try {
+      if (!_firmwareKnownInstalled) {
+        _onboardingShown = false;
+        await _showFirmwareOnboarding();
+        return;
+      }
+
       if (action == 'games') {
         final result = await Rpcs3InternalService.importGames();
         if (result.imported > 0) await widget.onLibraryChanged();
@@ -140,11 +226,6 @@ class _Rpcs3InternalPlaylistActionsState
       } else if (action == 'folder') {
         if (await Rpcs3InternalService.importExtractedGameFolder()) {
           await widget.onLibraryChanged();
-        }
-      } else if (action == 'firmware') {
-        if (await Rpcs3InternalService.importFirmware()) {
-          _firmwareVersion = await Rpcs3InternalService.firmwareVersion();
-          if (mounted) setState(() {});
         }
       }
     } on Rpcs3InternalException catch (error) {
@@ -161,9 +242,11 @@ class _Rpcs3InternalPlaylistActionsState
   Widget build(BuildContext context) {
     if (!Platform.isIOS) return const SizedBox.shrink();
     final scheme = Theme.of(context).colorScheme;
-    final firmwareLabel = _firmwareVersion.isEmpty
-        ? _firmwareMissing
-        : '${_fr ? 'Firmware installé' : 'Firmware installed'}: $_firmwareVersion';
+    final firmwareLabel = _firmwareKnownInstalled
+        ? (_firmwareVersion.isEmpty
+              ? (_fr ? 'Firmware installé' : 'Firmware installed')
+              : '${_fr ? 'Firmware installé' : 'Firmware installed'}: $_firmwareVersion')
+        : _firmwareMissing;
 
     return Container(
       width: 36.r,
@@ -208,9 +291,9 @@ class _Rpcs3InternalPlaylistActionsState
             child: Row(
               children: [
                 Icon(
-                  _firmwareVersion.isEmpty
-                      ? Icons.warning_amber_rounded
-                      : Icons.check_circle_outline,
+                  _firmwareKnownInstalled
+                      ? Icons.check_circle_outline
+                      : Icons.warning_amber_rounded,
                   size: 18.r,
                 ),
                 SizedBox(width: 8.r),
@@ -231,8 +314,16 @@ class _Rpcs3InternalPlaylistActionsState
           ),
           const PopupMenuDivider(),
           PopupMenuItem(value: 'firmware', child: Text(_firmware)),
-          PopupMenuItem(value: 'games', child: Text(_games)),
-          PopupMenuItem(value: 'folder', child: Text(_folder)),
+          PopupMenuItem(
+            value: 'games',
+            enabled: _firmwareKnownInstalled,
+            child: Text(_games),
+          ),
+          PopupMenuItem(
+            value: 'folder',
+            enabled: _firmwareKnownInstalled,
+            child: Text(_folder),
+          ),
         ],
       ),
     );

--- a/lib/widgets/rpcs3_internal_playlist_actions.dart
+++ b/lib/widgets/rpcs3_internal_playlist_actions.dart
@@ -35,6 +35,7 @@ class _Rpcs3InternalPlaylistActionsState
   String _firmwareVersion = '';
   String? _error;
   Rpcs3RuntimePhase _phase = Rpcs3RuntimePhase.idle;
+  String _progressMessage = '';
 
   bool get _firmwareInstalled => _firmwareVersion.isNotEmpty;
   bool get _fr => Localizations.localeOf(context).languageCode == 'fr';
@@ -45,7 +46,12 @@ class _Rpcs3InternalPlaylistActionsState
   void initState() {
     super.initState();
     _runtimeSubscription = Rpcs3InternalService.runtimeStates.listen((state) {
-      if (mounted && _busy) setState(() => _phase = state.phase);
+      if (mounted && _busy) {
+        setState(() {
+          _phase = state.phase;
+          _progressMessage = state.message;
+        });
+      }
     });
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) _checkFirmware();
@@ -103,6 +109,7 @@ class _Rpcs3InternalPlaylistActionsState
       _busy = true;
       _error = null;
       _phase = Rpcs3RuntimePhase.idle;
+      _progressMessage = '';
     });
     _interaction(true);
     try {
@@ -182,7 +189,9 @@ class _Rpcs3InternalPlaylistActionsState
     final checkingLabel = _fr
         ? 'Vérification du firmware PS3…'
         : 'Checking PS3 firmware…';
-    final progressLabel = _phase == Rpcs3RuntimePhase.installingFirmware
+    final progressLabel = _progressMessage.isNotEmpty
+        ? _progressMessage
+        : _phase == Rpcs3RuntimePhase.installingFirmware
         ? (_fr ? 'Installation du firmware PS3…' : 'Installing PS3 firmware…')
         : (_fr ? 'Préparation de l’installation…' : 'Preparing installation…');
 

--- a/lib/widgets/rpcs3_internal_playlist_actions.dart
+++ b/lib/widgets/rpcs3_internal_playlist_actions.dart
@@ -1,20 +1,25 @@
-import 'dart:io';
+import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../screens/rpcs3_manager_screen.dart';
 import '../services/rpcs3_internal_service.dart';
 
+/// Owns the PS3 firmware gate and, once installed, the library import menu.
+/// The host mounts this over the library before loading or displaying games.
 class Rpcs3InternalPlaylistActions extends StatefulWidget {
   const Rpcs3InternalPlaylistActions({
     super.key,
     required this.onLibraryChanged,
+    required this.onFirmwareChanged,
+    required this.onBack,
     this.onInteractionChanged,
   });
 
   final Future<void> Function() onLibraryChanged;
+  final ValueChanged<bool> onFirmwareChanged;
+  final VoidCallback onBack;
   final ValueChanged<bool>? onInteractionChanged;
 
   @override
@@ -24,39 +29,33 @@ class Rpcs3InternalPlaylistActions extends StatefulWidget {
 
 class _Rpcs3InternalPlaylistActionsState
     extends State<Rpcs3InternalPlaylistActions> {
-  static const _firmwareInstalledKey =
-      'rpcs3_internal_firmware_installed_v1';
-  static const _firmwareVersionKey = 'rpcs3_internal_firmware_version_v1';
-
+  StreamSubscription<Rpcs3RuntimeState>? _runtimeSubscription;
+  bool _checking = true;
   bool _busy = false;
-  bool _onboardingShown = false;
-  bool _firmwareKnownInstalled = false;
   String _firmwareVersion = '';
+  String? _error;
+  Rpcs3RuntimePhase _phase = Rpcs3RuntimePhase.idle;
 
+  bool get _firmwareInstalled => _firmwareVersion.isNotEmpty;
   bool get _fr => Localizations.localeOf(context).languageCode == 'fr';
-  String get _import => _fr ? 'RPCS3 / Importer' : 'RPCS3 / Import';
-  String get _open => _fr ? 'Ouvrir RPCS3' : 'Open RPCS3';
-  String get _games => _fr ? 'Importer des jeux' : 'Import games';
-  String get _folder =>
-      _fr ? 'Importer un dossier de jeu' : 'Import game folder';
-  String get _firmware =>
-      _fr ? 'Importer le firmware PS3' : 'Import PS3 firmware';
-  String get _firmwareMissing => _fr ? 'Firmware requis' : 'Firmware required';
   String get _failed =>
       _fr ? 'Échec de l’opération RPCS3.' : 'RPCS3 operation failed.';
 
   @override
   void initState() {
     super.initState();
-
-    // Do not initialize or query RPCS3 Core just to decide whether onboarding
-    // should be shown. Build 222 did that through firmwareVersion(), which can
-    // wait on JIT/Core startup before the user ever sees the PUP picker. Load a
-    // lightweight local marker instead and present the firmware CTA immediately
-    // on a fresh PS3 library.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _restoreFirmwareStateAndShowOnboarding();
+    _runtimeSubscription = Rpcs3InternalService.runtimeStates.listen((state) {
+      if (mounted && _busy) setState(() => _phase = state.phase);
     });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _checkFirmware();
+    });
+  }
+
+  @override
+  void dispose() {
+    _runtimeSubscription?.cancel();
+    super.dispose();
   }
 
   void _interaction(bool active) => widget.onInteractionChanged?.call(active);
@@ -67,138 +66,78 @@ class _Rpcs3InternalPlaylistActionsState
 
   void _notice(String message) {
     if (!mounted) return;
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
   }
 
-  Future<void> _restoreFirmwareStateAndShowOnboarding() async {
-    final preferences = await SharedPreferences.getInstance();
-    final installed = preferences.getBool(_firmwareInstalledKey) ?? false;
-    final version = preferences.getString(_firmwareVersionKey) ?? '';
-
-    if (!mounted) return;
+  Future<void> _checkFirmware() async {
     setState(() {
-      _firmwareKnownInstalled = installed;
-      _firmwareVersion = version;
+      _checking = true;
+      _error = null;
     });
-
-    if (!installed) {
-      await _showFirmwareOnboarding();
-    }
-  }
-
-  Future<void> _showFirmwareOnboarding() async {
-    if (!mounted || _onboardingShown || _busy || _firmwareKnownInstalled) {
-      return;
-    }
-    _onboardingShown = true;
     _interaction(true);
-
-    final install = await showDialog<bool>(
-      context: context,
-      barrierDismissible: false,
-      builder: (dialogContext) {
-        return AlertDialog(
-          title: Text(_fr ? 'Firmware PS3 requis' : 'PS3 firmware required'),
-          content: Text(
-            _fr
-                ? 'RPCS3 nécessite le firmware officiel PS3 avant de pouvoir utiliser la bibliothèque. Sélectionnez le fichier PS3UPDAT.PUP pour continuer.'
-                : 'RPCS3 requires the official PS3 firmware before the library can be used. Select PS3UPDAT.PUP to continue.',
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(dialogContext).pop(false),
-              child: Text(_fr ? 'Retour' : 'Back'),
-            ),
-            FilledButton.icon(
-              key: const ValueKey('rpcs3-library-install-firmware'),
-              onPressed: () => Navigator.of(dialogContext).pop(true),
-              icon: const Icon(Icons.system_update_alt),
-              label: Text(
-                _fr ? 'Installer le firmware PS3' : 'Install PS3 firmware',
-              ),
-            ),
-          ],
-        );
-      },
-    );
-
-    _interaction(false);
-    if (install == true && mounted) {
-      await _installFirmware();
-    }
-  }
-
-  Future<void> _rememberInstalledFirmware() async {
-    final preferences = await SharedPreferences.getInstance();
-    await preferences.setBool(_firmwareInstalledKey, true);
-    if (_firmwareVersion.isNotEmpty) {
-      await preferences.setString(_firmwareVersionKey, _firmwareVersion);
+    try {
+      // Reads the installed version file. No JIT, Core startup or ROM scan.
+      final version = await Rpcs3InternalService.firmwareVersion();
+      if (!mounted) return;
+      setState(() => _firmwareVersion = version);
+      widget.onFirmwareChanged(_firmwareInstalled);
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _firmwareVersion = '';
+        _error = '$_failed $error';
+      });
+      widget.onFirmwareChanged(false);
+    } finally {
+      if (mounted) {
+        setState(() => _checking = false);
+        _interaction(!_firmwareInstalled);
+      }
     }
   }
 
   Future<void> _installFirmware() async {
-    if (_busy) return;
-    setState(() => _busy = true);
+    if (_busy || _checking) return;
+    setState(() {
+      _busy = true;
+      _error = null;
+      _phase = Rpcs3RuntimePhase.idle;
+    });
     _interaction(true);
     try {
-      // importFirmware() opens the PUP picker first. JIT/Core initialization is
-      // deferred until the user has actually selected the firmware file.
+      // The picker opens before JIT/Core preparation. Cancel keeps this gate.
       if (await Rpcs3InternalService.importFirmware()) {
-        _firmwareVersion = await Rpcs3InternalService.firmwareVersion();
-        _firmwareKnownInstalled = true;
-        await _rememberInstalledFirmware();
-        if (mounted) setState(() {});
-        _notice(
-          _fr
-              ? 'Firmware PS3 installé${_firmwareVersion.isEmpty ? '' : ' : $_firmwareVersion'}.'
-              : 'PS3 firmware installed${_firmwareVersion.isEmpty ? '' : ': $_firmwareVersion'}.',
-        );
-      } else {
-        // Picker cancelled: allow onboarding to be presented again next time
-        // the PS3 library is opened.
-        _onboardingShown = false;
+        await _checkFirmware();
+        if (!mounted) return;
+        if (_firmwareInstalled) {
+          _notice(_fr ? 'Firmware PS3 installé.' : 'PS3 firmware installed.');
+        }
       }
     } on Rpcs3InternalException catch (error) {
-      _onboardingShown = false;
-      _notice(error.message);
+      if (mounted) setState(() => _error = error.message);
     } catch (error) {
-      _onboardingShown = false;
-      _notice('$_failed $error');
+      if (mounted) setState(() => _error = '$_failed $error');
     } finally {
-      if (mounted) setState(() => _busy = false);
-      _interaction(false);
+      if (mounted) {
+        setState(() => _busy = false);
+        _interaction(!_firmwareInstalled);
+      }
     }
   }
 
   Future<void> _openManager() async {
-    _interaction(false);
     await Navigator.of(context).push(
       MaterialPageRoute<void>(
-        builder: (_) => Rpcs3ManagerScreen(
-          onLibraryChanged: widget.onLibraryChanged,
-        ),
+        builder: (_) =>
+            Rpcs3ManagerScreen(onLibraryChanged: widget.onLibraryChanged),
       ),
     );
-    if (!mounted) return;
-    try {
-      if (await Rpcs3InternalService.hasFirmware()) {
-        _firmwareVersion = await Rpcs3InternalService.firmwareVersion();
-        _firmwareKnownInstalled = true;
-        await _rememberInstalledFirmware();
-      }
-    } catch (_) {
-      // Firmware state is shown again the next time the manager is opened.
-    } finally {
-      await Rpcs3InternalService.closeManagementRuntime();
-    }
-    if (mounted) setState(() {});
+    if (mounted) await _checkFirmware();
   }
 
   Future<void> _selected(String action) async {
-    if (_busy) return;
-
+    if (_busy || _checking) return;
     if (action == 'open') {
       await _openManager();
       return;
@@ -208,15 +147,14 @@ class _Rpcs3InternalPlaylistActionsState
       await _installFirmware();
       return;
     }
+    if (!_firmwareInstalled) {
+      _interaction(true);
+      return;
+    }
 
     setState(() => _busy = true);
+    _interaction(true);
     try {
-      if (!_firmwareKnownInstalled) {
-        _onboardingShown = false;
-        await _showFirmwareOnboarding();
-        return;
-      }
-
       if (action == 'games') {
         final result = await Rpcs3InternalService.importGames();
         if (result.imported > 0) await widget.onLibraryChanged();
@@ -233,99 +171,180 @@ class _Rpcs3InternalPlaylistActionsState
     } catch (error) {
       _notice('$_failed $error');
     } finally {
-      if (mounted) setState(() => _busy = false);
-      _interaction(false);
+      if (mounted) {
+        setState(() => _busy = false);
+        _interaction(false);
+      }
     }
+  }
+
+  Widget _buildFirmwareGate() {
+    final checkingLabel = _fr
+        ? 'Vérification du firmware PS3…'
+        : 'Checking PS3 firmware…';
+    final progressLabel = _phase == Rpcs3RuntimePhase.installingFirmware
+        ? (_fr ? 'Installation du firmware PS3…' : 'Installing PS3 firmware…')
+        : (_fr ? 'Préparation de l’installation…' : 'Preparing installation…');
+
+    return Material(
+      key: const ValueKey('rpcs3-library-firmware-gate'),
+      color: Theme.of(context).scaffoldBackgroundColor,
+      child: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 520),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.system_update_alt, size: 48),
+                  const SizedBox(height: 20),
+                  Text(
+                    _checking
+                        ? checkingLabel
+                        : (_fr
+                              ? 'Firmware PS3 requis'
+                              : 'PS3 firmware required'),
+                    style: Theme.of(context).textTheme.headlineSmall,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 16),
+                  if (_checking || _busy) ...[
+                    const LinearProgressIndicator(),
+                    if (_busy) ...[
+                      const SizedBox(height: 12),
+                      Text(progressLabel, textAlign: TextAlign.center),
+                    ],
+                  ] else ...[
+                    Text(
+                      _fr
+                          ? 'Installez le firmware officiel PS3 pour ouvrir votre bibliothèque. Sélectionnez votre fichier PS3UPDAT.PUP.'
+                          : 'Install the official PS3 firmware to open your library. Select your PS3UPDAT.PUP file.',
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 20),
+                    FilledButton.icon(
+                      key: const ValueKey('rpcs3-library-install-firmware'),
+                      onPressed: _installFirmware,
+                      icon: const Icon(Icons.file_upload_outlined),
+                      label: Text(
+                        _fr
+                            ? 'Installer le firmware PS3'
+                            : 'Install PS3 firmware',
+                      ),
+                    ),
+                  ],
+                  if (_error != null) ...[
+                    const SizedBox(height: 16),
+                    Text(_error!, textAlign: TextAlign.center),
+                    TextButton(
+                      onPressed: _busy ? null : _checkFirmware,
+                      child: Text(_fr ? 'Réessayer' : 'Retry'),
+                    ),
+                  ],
+                  const SizedBox(height: 12),
+                  TextButton(
+                    onPressed: _busy ? null : widget.onBack,
+                    child: Text(_fr ? 'Retour' : 'Back'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    if (!Platform.isIOS) return const SizedBox.shrink();
+    if (_checking || !_firmwareInstalled) return _buildFirmwareGate();
     final scheme = Theme.of(context).colorScheme;
-    final firmwareLabel = _firmwareKnownInstalled
-        ? (_firmwareVersion.isEmpty
-              ? (_fr ? 'Firmware installé' : 'Firmware installed')
-              : '${_fr ? 'Firmware installé' : 'Firmware installed'}: $_firmwareVersion')
-        : _firmwareMissing;
-
-    return Container(
-      width: 36.r,
-      height: 36.r,
-      decoration: BoxDecoration(
-        color: scheme.tertiaryFixed,
-        borderRadius: BorderRadius.circular(10.r),
-        border: Border.all(color: scheme.tertiaryFixed, width: 2.r),
-        boxShadow: [
-          BoxShadow(
-            color: scheme.shadow.withValues(alpha: 0.3),
-            blurRadius: 3.r,
-            offset: Offset(1.5.r, 1.5.r),
-          ),
-        ],
-      ),
-      child: PopupMenuButton<String>(
-        key: const ValueKey('rpcs3-internal-import-menu'),
-        tooltip: _import,
-        enabled: !_busy,
-        padding: EdgeInsets.zero,
-        onOpened: _opened,
-        onCanceled: () => _interaction(false),
-        onSelected: _selected,
-        icon: _busy
-            ? SizedBox(
-                width: 18.r,
-                height: 18.r,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
-                  color: scheme.onTertiaryFixed,
+    return Stack(
+      children: [
+        Positioned(
+          top: 8.r,
+          right: 10.r,
+          child: SafeArea(
+            child: Material(
+              color: scheme.tertiaryFixed,
+              borderRadius: BorderRadius.circular(10.r),
+              child: SizedBox(
+                width: 36.r,
+                height: 36.r,
+                child: PopupMenuButton<String>(
+                  key: const ValueKey('rpcs3-internal-import-menu'),
+                  tooltip: _fr ? 'RPCS3 / Importer' : 'RPCS3 / Import',
+                  enabled: !_busy,
+                  padding: EdgeInsets.zero,
+                  onOpened: _opened,
+                  onCanceled: () => _interaction(false),
+                  onSelected: _selected,
+                  icon: _busy
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : Icon(
+                          Icons.file_upload_outlined,
+                          size: 18.r,
+                          color: scheme.onTertiaryFixed,
+                        ),
+                  itemBuilder: (context) => [
+                    PopupMenuItem(
+                      enabled: false,
+                      child: Text(
+                        '${_fr ? 'Firmware installé' : 'Firmware installed'} : $_firmwareVersion',
+                      ),
+                    ),
+                    const PopupMenuDivider(),
+                    PopupMenuItem(
+                      value: 'games',
+                      child: Text(_fr ? 'Importer des jeux' : 'Import games'),
+                    ),
+                    PopupMenuItem(
+                      value: 'folder',
+                      child: Text(
+                        _fr
+                            ? 'Importer un dossier de jeu'
+                            : 'Import game folder',
+                      ),
+                    ),
+                    PopupMenuItem(
+                      value: 'firmware',
+                      child: Text(
+                        _fr
+                            ? 'Importer le firmware PS3'
+                            : 'Import PS3 firmware',
+                      ),
+                    ),
+                    const PopupMenuDivider(),
+                    PopupMenuItem(
+                      value: 'open',
+                      child: Text(_fr ? 'Ouvrir RPCS3' : 'Open RPCS3'),
+                    ),
+                  ],
                 ),
-              )
-            : Icon(
-                Icons.file_upload_outlined,
-                size: 18.r,
-                color: scheme.onTertiaryFixed,
               ),
-        itemBuilder: (context) => [
-          PopupMenuItem(
-            enabled: false,
-            child: Row(
-              children: [
-                Icon(
-                  _firmwareKnownInstalled
-                      ? Icons.check_circle_outline
-                      : Icons.warning_amber_rounded,
-                  size: 18.r,
+            ),
+          ),
+        ),
+        if (_error != null)
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: SafeArea(
+              child: Material(
+                color: scheme.errorContainer,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Text(_error!),
                 ),
-                SizedBox(width: 8.r),
-                Expanded(child: Text(firmwareLabel)),
-              ],
+              ),
             ),
           ),
-          const PopupMenuDivider(),
-          PopupMenuItem(
-            value: 'open',
-            child: Row(
-              children: [
-                const Icon(Icons.memory),
-                SizedBox(width: 8.r),
-                Text(_open),
-              ],
-            ),
-          ),
-          const PopupMenuDivider(),
-          PopupMenuItem(value: 'firmware', child: Text(_firmware)),
-          PopupMenuItem(
-            value: 'games',
-            enabled: _firmwareKnownInstalled,
-            child: Text(_games),
-          ),
-          PopupMenuItem(
-            value: 'folder',
-            enabled: _firmwareKnownInstalled,
-            child: Text(_folder),
-          ),
-        ],
-      ),
+      ],
     );
   }
 }

--- a/packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm
+++ b/packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm
@@ -1,4 +1,5 @@
 #import "Rpcs3InternalBridgePlugin.h"
+#import "Rpcs3JitBridgePlugin.h"
 #import "Rpcs3CoreABI.h"
 
 #import <Metal/Metal.h>
@@ -45,11 +46,15 @@ static BOOL RPCS3HostHasEntitlement(CFStringRef entitlement) {
   return enabled;
 }
 
-// RPCS3 0.8.1 performs the same kind of readiness check before it dlopens its
-// Core. A successful debugger attach is not sufficient if iOS still rejects
-// the RW -> RX transition that the JIT arena needs. Probe that transition here
-// so NeoStation can report an error instead of letting the Core abort at load.
+// Only the legacy Core backend uses an ordinary RW -> RX transition. On
+// iOS 26 the Core itself prepares RX pages through the attached Universal
+// debugger and creates mirrored RW aliases; this legacy probe cannot test it.
 static BOOL RPCS3ProbeExecutableMemory(NSString** error) {
+  if (@available(iOS 26.0, *)) {
+    if (RPCS3JitHasActiveCoreHandshake()) return YES;
+    if (error) *error = @"RPCS3 requires a fresh Universal JIT attachment before loading its Core.";
+    return NO;
+  }
   size_t pageSize = (size_t)getpagesize();
   void* page = mmap(NULL,
                     pageSize,

--- a/packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm
+++ b/packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm
@@ -238,16 +238,12 @@ static void RPCS3Progress(void* context,
     return NO;
   }
 
-  if (expanded) {
-    if (!RPCS3HostHasEntitlement(CFSTR("com.apple.developer.kernel.extended-virtual-addressing")) ||
-        !RPCS3HostHasEntitlement(CFSTR("com.apple.developer.kernel.increased-memory-limit"))) {
-      if (error) {
-        *error = @"RPCS3 requires extended-virtual-addressing and increased-memory-limit entitlements in the signed NeoStation IPA.";
-      }
-      return NO;
-    }
-  }
-
+  // libRPCS3Core.dylib is loaded into NeoStation itself, not a child process.
+  // The Core therefore executes with the entitlements of the signed NeoStation
+  // host process. Do not gate dlopen on a second SecTask entitlement lookup:
+  // some sideload signing paths can make that diagnostic lookup report a false
+  // negative even though the kernel has already granted the host capabilities.
+  // The executable-memory probe below remains the runtime source of truth.
   NSString* readinessError = nil;
   if (!RPCS3ProbeExecutableMemory(&readinessError)) {
     if (error) *error = readinessError;

--- a/packages/rpcs3_internal_bridge/ios/Classes/Rpcs3JitBridgePlugin.h
+++ b/packages/rpcs3_internal_bridge/ios/Classes/Rpcs3JitBridgePlugin.h
@@ -1,4 +1,7 @@
 #import <Flutter/Flutter.h>
 
+// CS_DEBUGGED alone is not proof that Universal JIT is still attached.
+BOOL RPCS3JitHasActiveCoreHandshake(void);
+
 @interface Rpcs3JitBridgePlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/rpcs3_internal_bridge/ios/Classes/Rpcs3JitBridgePlugin.mm
+++ b/packages/rpcs3_internal_bridge/ios/Classes/Rpcs3JitBridgePlugin.mm
@@ -15,7 +15,9 @@
 static NSString* const kRpcs3JitChannel = @"neostation/rpcs3_jit";
 static NSString* const kRpcs3JitRequestType = @"com.neogamelab.neostation.rpcs3-jit-request";
 static NSTimeInterval const kRpcs3HelperConnectTimeout = 30.0;
-static NSTimeInterval const kRpcs3AttachTimeout = 240.0;
+// First use may download and mount a DDI. Dart allows this native deadline
+// (plus the connection deadline) to finish and report its actual error.
+static NSTimeInterval const kRpcs3AttachTimeout = 600.0;
 static NSTimeInterval const kRpcs3CompletionTimeout = 120.0;
 
 extern "C" {
@@ -53,6 +55,11 @@ static BOOL RPCS3HostIsDebugged(void) {
   return (flags & CS_DEBUGGED) != 0;
 }
 
+static BOOL RPCS3RequiresCoreHandshake(void) {
+  if (@available(iOS 26.0, *)) return YES;
+  return NO;
+}
+
 @interface RPCS3JitSession : NSObject
 @property(nonatomic, readonly) uint16_t port;
 @property(nonatomic, readonly) NSString* token;
@@ -62,6 +69,8 @@ static BOOL RPCS3HostIsDebugged(void) {
 @property(nonatomic, readonly) BOOL success;
 @property(nonatomic, readonly) NSString* finalMessage;
 @property(nonatomic, readonly) NSArray<NSString*>* logs;
+@property(nonatomic, readonly) BOOL closed;
+@property(nonatomic, assign) BOOL requiresCoreHandshake;
 @property(nonatomic, strong, nullable) id extensionObject;
 @property(nonatomic, strong, nullable) id requestIdentifier;
 - (nullable instancetype)initWithError:(NSError**)error;
@@ -82,6 +91,7 @@ static BOOL RPCS3HostIsDebugged(void) {
   BOOL _attached;
   BOOL _finished;
   BOOL _success;
+  BOOL _closed;
   NSString* _finalMessage;
   NSMutableArray<NSString*>* _mutableLogs;
   dispatch_queue_t _readerQueue;
@@ -145,6 +155,27 @@ static BOOL RPCS3HostIsDebugged(void) {
 
 - (uint16_t)port { return _port; }
 - (NSString*)token { return _token; }
+
+- (BOOL)closed {
+  [_condition lock];
+  BOOL value = _closed;
+  [_condition unlock];
+  return value;
+}
+
+- (void)cancelExtensionRequest {
+  id extension = self.extensionObject;
+  id identifier = self.requestIdentifier;
+  if (!extension || !identifier) return;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    SEL selector = NSSelectorFromString(@"cancelExtensionRequestWithIdentifier:");
+    if ([extension respondsToSelector:selector]) {
+      void (*cancelMessage)(id, SEL, id) =
+          reinterpret_cast<void (*)(id, SEL, id)>(objc_msgSend);
+      cancelMessage(extension, selector, identifier);
+    }
+  });
+}
 
 - (BOOL)connected {
   [_condition lock];
@@ -214,20 +245,30 @@ static BOOL RPCS3HostIsDebugged(void) {
       return;
     }
 
-    strongSelf->_client = accept(strongSelf->_listener, NULL, NULL);
-    if (strongSelf->_client < 0) {
+    int accepted = accept(strongSelf->_listener, NULL, NULL);
+    if (accepted < 0) {
       [strongSelf markFinished:NO
                        message:@"The RPCS3 JIT helper socket could not be accepted."];
       return;
     }
 
-    FILE* stream = fdopen(strongSelf->_client, "r");
+    FILE* stream = fdopen(accepted, "r");
     if (stream == NULL) {
+      close(accepted);
       [strongSelf markFinished:NO
                        message:@"The RPCS3 JIT helper stream could not be opened."];
       return;
     }
-    strongSelf->_client = -1;
+    // Keep a duplicate solely for shutdown. fclose owns the original fd;
+    // closing a timed-out session must also unblock its fgets reader.
+    [strongSelf->_condition lock];
+    if (strongSelf->_closed) {
+      [strongSelf->_condition unlock];
+      fclose(stream);
+      return;
+    }
+    strongSelf->_client = dup(fileno(stream));
+    [strongSelf->_condition unlock];
 
     char buffer[65536];
     while (fgets(buffer, sizeof(buffer), stream) != NULL) {
@@ -306,7 +347,10 @@ static BOOL RPCS3HostIsDebugged(void) {
   [self waitForPredicate:^BOOL {
     return self->_attached || self->_finished;
   } timeout:timeout];
-  return self.attached;
+  // StikJIT's pre-TXM attach/detach path does not log a universal vAttach
+  // reply. Its successful completion is sufficient only on the legacy Core.
+  return self.attached ||
+      (!self.requiresCoreHandshake && self.connected && self.finished && self.success);
 }
 
 - (BOOL)waitUntilFinished:(NSTimeInterval)timeout {
@@ -316,6 +360,12 @@ static BOOL RPCS3HostIsDebugged(void) {
 }
 
 - (void)close {
+  [_condition lock];
+  if (_closed) {
+    [_condition unlock];
+    return;
+  }
+  _closed = YES;
   if (_listener >= 0) {
     shutdown(_listener, SHUT_RDWR);
     close(_listener);
@@ -326,6 +376,9 @@ static BOOL RPCS3HostIsDebugged(void) {
     close(_client);
     _client = -1;
   }
+  [_condition broadcast];
+  [_condition unlock];
+  if (!self.finished) [self cancelExtensionRequest];
 }
 
 - (void)dealloc {
@@ -379,6 +432,7 @@ static BOOL RPCS3LaunchJitHelper(
     @"port" : @(session.port),
     @"token" : session.token,
     @"pairingData" : [pairingData base64EncodedStringWithOptions:0],
+    @"requiresCoreHandshake" : @(session.requiresCoreHandshake),
   };
   NSData* requestData = [NSJSONSerialization dataWithJSONObject:request
                                                         options:0
@@ -418,10 +472,11 @@ static BOOL RPCS3LaunchJitHelper(
   }
   session.extensionObject = extensionObject;
 
-  __weak RPCS3JitSession* weakSession = session;
+  // Retain until launch returns its request identifier, even if the connection
+  // timed out first, so that a late extension can still be cancelled.
   void (^completion)(id) = ^(id requestIdentifier) {
-    RPCS3JitSession* strongSession = weakSession;
-    strongSession.requestIdentifier = requestIdentifier;
+    session.requestIdentifier = requestIdentifier;
+    if (session.closed) [session cancelExtensionRequest];
   };
   void (*beginMessage)(id, SEL, NSArray*, id) =
       reinterpret_cast<void (*)(id, SEL, NSArray*, id)>(objc_msgSend);
@@ -431,9 +486,18 @@ static BOOL RPCS3LaunchJitHelper(
 
 @interface Rpcs3JitBridgePlugin ()
 @property(nonatomic, strong) FlutterMethodChannel* channel;
-@property(nonatomic, strong, nullable) RPCS3JitSession* activeSession;
+@property(atomic, strong, nullable) RPCS3JitSession* activeSession;
 @property(nonatomic, assign) BOOL operationInProgress;
+@property(nonatomic, assign) BOOL completionInProgress;
 @end
+
+static __weak Rpcs3JitBridgePlugin* gRpcs3JitBridge;
+
+BOOL RPCS3JitHasActiveCoreHandshake(void) {
+  RPCS3JitSession* session = gRpcs3JitBridge.activeSession;
+  return session != nil && session.requiresCoreHandshake &&
+      session.attached && !session.finished && !session.closed;
+}
 
 @implementation Rpcs3JitBridgePlugin {
   dispatch_queue_t _jitQueue;
@@ -444,6 +508,7 @@ static BOOL RPCS3LaunchJitHelper(
       methodChannelWithName:kRpcs3JitChannel
             binaryMessenger:registrar.messenger];
   Rpcs3JitBridgePlugin* instance = [Rpcs3JitBridgePlugin new];
+  gRpcs3JitBridge = instance;
   instance.channel = channel;
   [registrar addMethodCallDelegate:instance channel:channel];
 }
@@ -464,6 +529,38 @@ static BOOL RPCS3LaunchJitHelper(
       @"getTaskAllow" : @(RPCS3HostHasGetTaskAllow()),
       @"debugged" : @(RPCS3HostIsDebugged()),
       @"busy" : @(self.operationInProgress),
+      @"requiresCoreHandshake" : @(RPCS3RequiresCoreHandshake()),
+      @"message" : self.activeSession.logs.lastObject ?: @"",
+    });
+    return;
+  }
+
+  if ([call.method isEqualToString:@"completeJit"]) {
+    RPCS3JitSession* session = self.activeSession;
+    if (session == nil || self.completionInProgress) {
+      result(@{@"success": @NO, @"message": @"No RPCS3 JIT transaction is ready to complete."});
+      return;
+    }
+    self.completionInProgress = YES;
+    dispatch_async(_jitQueue, ^{
+      BOOL completed = [session waitUntilFinished:kRpcs3CompletionTimeout];
+      BOOL success = completed && session.success && RPCS3HostIsDebugged();
+      NSDictionary* response = @{
+        @"success": @(success),
+        @"logs": session.logs,
+        @"message": success ? @"RPCS3 JIT arena prepared and helper detached." :
+            (session.finalMessage.length ? session.finalMessage :
+             @"RPCS3 JIT helper did not confirm completion. Relaunch NeoStation before retrying."),
+      };
+      // A failed/incomplete handshake may still own a debugger. Keep the
+      // transaction locked in that case instead of starting another attach.
+      if (completed) {
+        [session close];
+        self.activeSession = nil;
+        self.operationInProgress = NO;
+      }
+      self.completionInProgress = NO;
+      dispatch_async(dispatch_get_main_queue(), ^{ result(response); });
     });
     return;
   }
@@ -555,6 +652,7 @@ static BOOL RPCS3LaunchJitHelper(
       return;
     }
     self.activeSession = session;
+    session.requiresCoreHandshake = RPCS3RequiresCoreHandshake();
     [session startReader];
 
     NSError* launchError = nil;
@@ -583,8 +681,7 @@ static BOOL RPCS3LaunchJitHelper(
     }
     response[@"pidAttached"] = @YES;
 
-    if (![session waitUntilFinished:kRpcs3CompletionTimeout] ||
-        !session.success) {
+    if (session.finished && !session.success) {
       response[@"message"] = session.finalMessage.length
           ? session.finalMessage
           : @"The RPCS3 JIT transaction did not complete successfully.";
@@ -602,9 +699,13 @@ static BOOL RPCS3LaunchJitHelper(
       return;
     }
 
+    // Do NOT wait for universal.js to finish here. Core constructors and
+    // initialize prepare the RX arena and issue BRK #0xf00d / command 0.
+    // Waiting before dlopen deadlocks host and helper (the old 90s failure).
     response[@"success"] = @YES;
-    response[@"message"] = @"RPCS3 JIT is enabled for the NeoStation process.";
-    finish();
+    response[@"requiresCompletion"] = @YES;
+    response[@"message"] = @"RPCS3 helper attached; initialize the Core before completing JIT.";
+    dispatch_async(dispatch_get_main_queue(), ^{ result(response); });
   });
 }
 

--- a/packages/rpcs3_internal_bridge/lib/rpcs3_internal_bridge.dart
+++ b/packages/rpcs3_internal_bridge/lib/rpcs3_internal_bridge.dart
@@ -44,6 +44,13 @@ class Rpcs3InternalBridge {
         const <String, dynamic>{},
   );
 
+  /// Call only after initialize has prepared and sealed the Core JIT arena.
+  static Future<Map<String, dynamic>> completeJit() async =>
+      Map<String, dynamic>.from(
+        await _jitChannel.invokeMapMethod<String, dynamic>('completeJit') ??
+            const <String, dynamic>{},
+      );
+
   static Future<Map<String, dynamic>> shutdown() async =>
       Map<String, dynamic>.from(
         await _channel.invokeMapMethod<String, dynamic>('shutdown') ??

--- a/packages/rpcs3_jit_helper/ios/Classes/Rpcs3JITRequestHandlerBase.swift
+++ b/packages/rpcs3_jit_helper/ios/Classes/Rpcs3JITRequestHandlerBase.swift
@@ -96,6 +96,10 @@ open class Rpcs3JITRequestHandlerBase: NSObject, NSExtensionRequestHandling {
       }
 
       let targetPID = targetPIDNumber.int32Value
+      // RPCS3 selects its mirrored Universal arena by OS version, not TXM
+      // detection. Even a non-TXM device on iOS 26 needs this script running
+      // when Core constructors request their executable regions.
+      let requiresCoreHandshake = object["requiresCoreHandshake"] as? Bool ?? false
       reporter = try Rpcs3HelperReporter(
         port: portNumber.uint16Value,
         token: token
@@ -153,7 +157,7 @@ open class Rpcs3JITRequestHandlerBase: NSObject, NSExtensionRequestHandling {
         ddiPaths: ddiPaths,
         configuration: configuration,
         script: .universal,
-        forceScript: false,
+        forceScript: requiresCoreHandshake,
         preparationProgress: { stage in
           try? reporter?.send(
             event: "log",

--- a/test/rpcs3_firmware_library_test.dart
+++ b/test/rpcs3_firmware_library_test.dart
@@ -1,0 +1,185 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:neostation/services/rpcs3_internal_service.dart';
+import 'package:neostation/widgets/rpcs3_internal_playlist_actions.dart';
+import 'package:path/path.dart' as path;
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  const paths = MethodChannel('plugins.flutter.io/path_provider');
+  const core = MethodChannel('neostation/rpcs3_internal');
+  const jit = MethodChannel('neostation/rpcs3_jit');
+  late Directory support;
+  late File versionFile;
+  final nativeCalls = <String>[];
+
+  setUp(() async {
+    support = await Directory.systemTemp.createTemp('rpcs3-firmware-library-');
+    versionFile = File(
+      path.join(
+        support.path,
+        'NeoStation',
+        'RPCS3',
+        'Data',
+        'dev_flash',
+        'vsh',
+        'etc',
+        'version.txt',
+      ),
+    );
+    nativeCalls.clear();
+    SharedPreferences.setMockInitialValues({});
+    messenger.setMockMethodCallHandler(paths, (_) async => support.path);
+    for (final channel in [core, jit]) {
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        nativeCalls.add('${channel.name}/${call.method}');
+        throw PlatformException(code: 'runtimeMustRemainDormant');
+      });
+    }
+  });
+
+  tearDown(() async {
+    for (final channel in [paths, core, jit]) {
+      messenger.setMockMethodCallHandler(channel, null);
+    }
+    await support.delete(recursive: true);
+  });
+
+  Future<void> writeVersion(String contents) async {
+    await versionFile.parent.create(recursive: true);
+    await versionFile.writeAsString(contents);
+  }
+
+  test(
+    'recognizes a pre-existing firmware without a preference or Core',
+    () async {
+      await writeVersion('release:04.9100:\nbuild:50999,2025:');
+      expect(await Rpcs3InternalService.firmwareVersion(), '4.91');
+      expect(await Rpcs3InternalService.hasFirmware(), isTrue);
+      expect(nativeCalls, isEmpty);
+    },
+  );
+
+  test(
+    'deletion and malformed metadata cannot reuse a stale installed flag',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        'rpcs3_internal_firmware_installed_v1': true,
+        'rpcs3_internal_firmware_version_v1': '4.91',
+      });
+      expect(await Rpcs3InternalService.firmwareVersion(), isEmpty);
+      await writeVersion('release:04.9000:\n');
+      expect(await Rpcs3InternalService.firmwareVersion(), '4.90');
+      await versionFile.delete();
+      expect(await Rpcs3InternalService.hasFirmware(), isFalse);
+      await writeVersion('release:broken:\n');
+      expect(await Rpcs3InternalService.hasFirmware(), isFalse);
+      expect(nativeCalls, isEmpty);
+    },
+  );
+
+  Future<List<bool>> openLibrary(
+    WidgetTester tester, {
+    VoidCallback? onBack,
+  }) async {
+    final states = <bool>[];
+    final checked = Completer<void>();
+    final instanceKey = UniqueKey();
+    await tester.runAsync(() async {
+      await tester.pumpWidget(
+        ScreenUtilInit(
+          designSize: const Size(800, 600),
+          builder: (_, _) => MaterialApp(
+            home: Scaffold(
+              body: Stack(
+                children: [
+                  Positioned.fill(
+                    child: Rpcs3InternalPlaylistActions(
+                      key: instanceKey,
+                      onLibraryChanged: () async {},
+                      onFirmwareChanged: (value) {
+                        states.add(value);
+                        if (!checked.isCompleted) checked.complete();
+                      },
+                      onBack: onBack ?? () {},
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await checked.future.timeout(const Duration(seconds: 5));
+    });
+    await tester.pumpAndSettle();
+    return states;
+  }
+
+  testWidgets(
+    'missing firmware shows install screen immediately and can go back',
+    (tester) async {
+      var backedOut = false;
+      final states = await openLibrary(tester, onBack: () => backedOut = true);
+      expect(states, [false]);
+      expect(find.text('PS3 firmware required'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('rpcs3-library-install-firmware')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('rpcs3-internal-import-menu')),
+        findsNothing,
+      );
+      expect(find.byType(AlertDialog), findsNothing);
+      await tester.tap(find.text('Back'));
+      expect(backedOut, isTrue);
+      expect(nativeCalls, isEmpty);
+      await tester.pumpWidget(const SizedBox.shrink());
+    },
+  );
+
+  testWidgets(
+    'installed firmware opens import menu directly, including on reopening',
+    (tester) async {
+      await tester.runAsync(() => writeVersion('release:04.9100:\n'));
+      for (var opening = 0; opening < 2; opening++) {
+        expect(await openLibrary(tester), [true]);
+        expect(
+          find.byKey(const ValueKey('rpcs3-library-firmware-gate')),
+          findsNothing,
+        );
+        await tester.tap(
+          find.byKey(const ValueKey('rpcs3-internal-import-menu')),
+        );
+        await tester.pumpAndSettle();
+        expect(find.text('Import games'), findsOneWidget);
+        expect(find.text('Import game folder'), findsOneWidget);
+        expect(find.text('Import PS3 firmware'), findsOneWidget);
+        expect(nativeCalls, isEmpty);
+        await tester.pumpWidget(const SizedBox.shrink());
+      }
+    },
+  );
+
+  testWidgets('a removed firmware brings back the gate on the next opening', (
+    tester,
+  ) async {
+    await tester.runAsync(() => writeVersion('release:04.9100:\n'));
+    expect(await openLibrary(tester), [true]);
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.runAsync(() => versionFile.delete());
+    expect(await openLibrary(tester), [false]);
+    expect(find.text('PS3 firmware required'), findsOneWidget);
+    expect(nativeCalls, isEmpty);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+}

--- a/test/rpcs3_firmware_library_test.dart
+++ b/test/rpcs3_firmware_library_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -91,35 +90,38 @@ void main() {
     VoidCallback? onBack,
   }) async {
     final states = <bool>[];
-    final checked = Completer<void>();
-    final instanceKey = UniqueKey();
-    await tester.runAsync(() async {
-      await tester.pumpWidget(
-        ScreenUtilInit(
-          designSize: const Size(800, 600),
-          builder: (_, _) => MaterialApp(
-            home: Scaffold(
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            ScreenUtil.init(context, designSize: const Size(800, 600));
+            return Scaffold(
               body: Stack(
                 children: [
                   Positioned.fill(
                     child: Rpcs3InternalPlaylistActions(
-                      key: instanceKey,
                       onLibraryChanged: () async {},
-                      onFirmwareChanged: (value) {
-                        states.add(value);
-                        if (!checked.isCompleted) checked.complete();
-                      },
+                      onFirmwareChanged: states.add,
                       onBack: onBack ?? () {},
                     ),
                   ),
                 ],
               ),
-            ),
-          ),
+            );
+          },
         ),
+      ),
+    );
+    // Filesystem callbacks run on the real event loop, while widget callbacks
+    // need the test clock to pump. Waiting on one completer inside runAsync
+    // starves the fake microtask queue and cannot finish the firmware check.
+    for (var frame = 0; states.isEmpty && frame < 200; frame++) {
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 10)),
       );
-      await checked.future.timeout(const Duration(seconds: 5));
-    });
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    expect(states, isNotEmpty, reason: 'The firmware check must finish');
     await tester.pumpAndSettle();
     return states;
   }

--- a/test/rpcs3_internal_integration_test.dart
+++ b/test/rpcs3_internal_integration_test.dart
@@ -5,9 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('RPCS3 internal engine contracts', () {
     test('RPCS3 JIT path is isolated from Dolphin and standalone RPCS3', () {
-      final service = File(
-        'lib/services/rpcs3_internal_service.dart',
-      ).readAsStringSync();
+      final service = File('lib/services/rpcs3_internal_service.dart')
+          .readAsStringSync();
       final hostJit = File(
         'packages/rpcs3_internal_bridge/ios/Classes/Rpcs3JitBridgePlugin.mm',
       ).readAsStringSync();
@@ -26,12 +25,13 @@ void main() {
       expect(helper, isNot(contains('com.xitrix.RPCS3')));
     });
 
-    test('existing process JIT is reused before launching StikJIT again', () {
-      final service = File(
-        'lib/services/rpcs3_internal_service.dart',
-      ).readAsStringSync();
+    test('only legacy JIT may reuse the persistent debugged flag', () {
+      final service = File('lib/services/rpcs3_internal_service.dart')
+          .readAsStringSync();
 
-      final statusIndex = service.indexOf('final current = await _jitStatus();');
+      final statusIndex = service.indexOf(
+        'final current = await _jitStatus();',
+      );
       final debuggedIndex = service.indexOf("current['debugged'] == true");
       final pairingIndex = service.indexOf(
         'PairingFileService.hasStoredPairingFile',
@@ -44,29 +44,43 @@ void main() {
       expect(prepareIndex, greaterThan(pairingIndex));
       expect(service, contains('static Future<void>? _jitPreparation'));
       expect(service, contains("'jitTimeout'"));
-      expect(service, contains('Duration(seconds: 90)'));
+      expect(service, contains("current['requiresCoreHandshake'] != true"));
+      expect(service, contains('Duration(minutes: 11)'));
+      expect(service, isNot(contains('Duration(seconds: 90)')));
     });
 
     test('JIT and arena policy are ready before RPCS3 Core dlopen', () {
-      final service = File(
-        'lib/services/rpcs3_internal_service.dart',
-      ).readAsStringSync();
+      final service = File('lib/services/rpcs3_internal_service.dart')
+          .readAsStringSync();
       final bridge = File(
         'packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm',
       ).readAsStringSync();
 
-      final serviceJit = service.indexOf('await ensureJitReady();');
-      final serviceInitialize = service.indexOf('Rpcs3InternalBridge.initialize');
+      final serviceJit = service.indexOf('await _attachJitForCore();');
+      final serviceInitialize = service.indexOf(
+        'Rpcs3InternalBridge.initialize',
+      );
+      final serviceComplete = service.indexOf(
+        'Rpcs3InternalBridge.completeJit',
+      );
       expect(serviceJit, greaterThanOrEqualTo(0));
       expect(serviceInitialize, greaterThan(serviceJit));
+      expect(serviceComplete, greaterThan(serviceInitialize));
+      expect(
+        service.indexOf('_initialized = true;'),
+        greaterThan(serviceComplete),
+      );
 
       expect(bridge, contains('RPCS3HostIsDebugged'));
       expect(bridge, contains('RPCS3ProbeExecutableMemory'));
+      expect(bridge, contains('RPCS3JitHasActiveCoreHandshake()'));
       expect(bridge, contains('RPCS3_IOS_EXPANDED_JIT_ARENA'));
       final setenvIndex = bridge.indexOf(
         'setenv("RPCS3_IOS_EXPANDED_JIT_ARENA"',
       );
-      final dlopenIndex = bridge.indexOf('dlopen(path.fileSystemRepresentation');
+      final dlopenIndex = bridge.indexOf(
+        'dlopen(path.fileSystemRepresentation',
+      );
       expect(setenvIndex, greaterThanOrEqualTo(0));
       expect(dlopenIndex, greaterThan(setenvIndex));
 
@@ -76,32 +90,64 @@ void main() {
       final initializeStart = bridge.indexOf(
         'if ([call.method isEqualToString:@"initialize"])',
       );
-      final diagnosticsBlock = bridge.substring(diagnosticsStart, initializeStart);
+      final diagnosticsBlock = bridge.substring(
+        diagnosticsStart,
+        initializeStart,
+      );
       expect(diagnosticsBlock, isNot(contains('loadCoreWithExpandedJit')));
     });
 
-    test('manager pre-warms JIT without loading RPCS3 Core', () {
-      final service = File(
-        'lib/services/rpcs3_internal_service.dart',
-      ).readAsStringSync();
-      final manager = File(
-        'lib/screens/rpcs3_manager_screen.dart',
-      ).readAsStringSync();
+    test('manager inspection does not leave a Universal helper waiting', () {
+      final service = File('lib/services/rpcs3_internal_service.dart')
+          .readAsStringSync();
+      final manager = File('lib/screens/rpcs3_manager_screen.dart')
+          .readAsStringSync();
 
-      expect(service, contains('static Future<void> prepareManager() => ensureJitReady();'));
+      final start = service.indexOf('static Future<void> prepareManager()');
+      final end = service.indexOf(
+        'static Future<void> ensureJitReady()',
+        start,
+      );
+      final inspection = service.substring(start, end);
+      expect(inspection, contains('await _jitStatus()'));
+      expect(inspection, isNot(contains('_attachJitForCore')));
+      expect(inspection, isNot(contains('_ensureRuntime')));
       expect(manager, contains('Rpcs3InternalService.prepareManager()'));
       expect(manager, contains('RPCS3 Core'));
       expect(manager, contains('À la demande'));
-      expect(manager, isNot(contains('const Center(child: CircularProgressIndicator())')));
+      expect(
+        manager,
+        isNot(contains('const Center(child: CircularProgressIndicator())')),
+      );
       expect(manager, contains('LinearProgressIndicator'));
       expect(manager, contains('Réessayer'));
     });
 
-    test('firmware picker is shown before RPCS3 runtime initialization', () {
-      final service = File(
-        'lib/services/rpcs3_internal_service.dart',
+    test('Universal attach returns before completion and forces the matching script', () {
+      final host = File(
+        'packages/rpcs3_internal_bridge/ios/Classes/Rpcs3JitBridgePlugin.mm',
       ).readAsStringSync();
-      final methodStart = service.indexOf('static Future<bool> importFirmware()');
+      final helper = File(
+        'packages/rpcs3_jit_helper/ios/Classes/Rpcs3JITRequestHandlerBase.swift',
+      ).readAsStringSync();
+      final prepare = host.substring(
+        host.indexOf('if (![call.method isEqualToString:@"prepareJit"])'),
+      );
+      expect(prepare, contains('waitUntilAttached:kRpcs3AttachTimeout'));
+      expect(prepare, isNot(contains('waitUntilFinished:')));
+      expect(prepare, contains('response[@"requiresCompletion"] = @YES'));
+      expect(host, contains('isEqualToString:@"completeJit"'));
+      expect(host, contains('waitUntilFinished:kRpcs3CompletionTimeout'));
+      expect(helper, contains('forceScript: requiresCoreHandshake'));
+      expect(host, contains('cancelExtensionRequestWithIdentifier:'));
+    });
+
+    test('firmware picker is shown before RPCS3 runtime initialization', () {
+      final service = File('lib/services/rpcs3_internal_service.dart')
+          .readAsStringSync();
+      final methodStart = service.indexOf(
+        'static Future<bool> importFirmware()',
+      );
       final methodEnd = service.indexOf(
         'static Future<Rpcs3ImportResult> importGames()',
         methodStart,
@@ -117,14 +163,15 @@ void main() {
     });
 
     test('RPCS3 signing capabilities match the original iOS runtime needs', () {
-      final config = File(
-        'build-utils/configure_rpcs3_ios_v2.py',
-      ).readAsStringSync();
+      final config = File('build-utils/configure_rpcs3_ios_v2.py')
+          .readAsStringSync();
 
       expect(config, contains("'get-task-allow': True"));
       expect(
         config,
-        contains("'com.apple.developer.kernel.extended-virtual-addressing': True"),
+        contains(
+          "'com.apple.developer.kernel.extended-virtual-addressing': True",
+        ),
       );
       expect(
         config,
@@ -132,7 +179,9 @@ void main() {
       );
       expect(
         config,
-        contains("'com.apple.developer.kernel.increased-debugging-memory-limit': True"),
+        contains(
+          "'com.apple.developer.kernel.increased-debugging-memory-limit': True",
+        ),
       );
     });
 
@@ -140,12 +189,10 @@ void main() {
       final plugin = File(
         'packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm',
       ).readAsStringSync();
-      final launcher = File(
-        'lib/services/rpcs3_launch_service.dart',
-      ).readAsStringSync();
-      final service = File(
-        'lib/services/rpcs3_internal_service.dart',
-      ).readAsStringSync();
+      final launcher = File('lib/services/rpcs3_launch_service.dart')
+          .readAsStringSync();
+      final service = File('lib/services/rpcs3_internal_service.dart')
+          .readAsStringSync();
 
       expect(plugin, contains('rpcs3_ios_boot_game'));
       expect(plugin, contains('self->_api.boot_game'));
@@ -161,10 +208,11 @@ void main() {
     });
 
     test('firmware remains mandatory before direct boot', () {
-      final service = File(
-        'lib/services/rpcs3_internal_service.dart',
-      ).readAsStringSync();
-      final gameplayInit = service.indexOf('await ensureGameplayInitialized();');
+      final service = File('lib/services/rpcs3_internal_service.dart')
+          .readAsStringSync();
+      final gameplayInit = service.indexOf(
+        'await ensureGameplayInitialized();',
+      );
       final firmwareCheck = service.indexOf("'firmwareRequired'");
       final launchCall = service.indexOf('Rpcs3InternalBridge.launchGame');
 
@@ -174,12 +222,10 @@ void main() {
     });
 
     test('PS3 library exposes emulator manager and all import actions', () {
-      final widget = File(
-        'lib/widgets/rpcs3_internal_playlist_actions.dart',
-      ).readAsStringSync();
-      final manager = File(
-        'lib/screens/rpcs3_manager_screen.dart',
-      ).readAsStringSync();
+      final widget = File('lib/widgets/rpcs3_internal_playlist_actions.dart')
+          .readAsStringSync();
+      final manager = File('lib/screens/rpcs3_manager_screen.dart')
+          .readAsStringSync();
 
       expect(widget, contains("value: 'open'"));
       expect(widget, contains('Ouvrir RPCS3'));

--- a/test/rpcs3_jit_handshake_test.py
+++ b/test/rpcs3_jit_handshake_test.py
@@ -1,0 +1,153 @@
+"""Run the production RPCS3 helper socket/condition state machine on macOS.
+
+The host must be released on fresh attach, NOT helper completion: a Universal
+helper cannot complete until the host's Core prepares/seals its executable
+arena. Real ARM64 BRKs/firmware extraction still require a signed iOS device.
+"""
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN = ROOT / 'packages/rpcs3_internal_bridge/ios/Classes/Rpcs3JitBridgePlugin.mm'
+
+
+@unittest.skipUnless(sys.platform == 'darwin', 'Apple Foundation runtime required')
+class Rpcs3JitHandshakeTests(unittest.TestCase):
+    def test_production_session_protocol(self):
+        compiler = shutil.which('clang++')
+        if compiler is None:
+            self.skipTest('Apple clang++ required')
+        source = PLUGIN.read_text()
+        session = source[source.index('@interface RPCS3JitSession : NSObject'):
+                         source.index('static NSString* _Nullable RPCS3FindHelperBundleIdentifier')]
+        harness = r'''
+#import <Foundation/Foundation.h>
+#import <objc/message.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <cassert>
+#include <cstdio>
+static NSTimeInterval const kRpcs3HelperConnectTimeout = 2.0;
+'''
+        harness += session
+        harness += r'''
+static RPCS3JitSession* makeSession(BOOL universal = YES) {
+  NSError* error = nil;
+  RPCS3JitSession* session = [[RPCS3JitSession alloc] initWithError:&error];
+  assert(session && !error);
+  session.requiresCoreHandshake = universal;
+  [session startReader];
+  return session;
+}
+static int connectClient(RPCS3JitSession* session) {
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  assert(fd >= 0);
+  sockaddr_in address = {};
+  address.sin_family = AF_INET;
+  address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  address.sin_port = htons(session.port);
+  assert(connect(fd, reinterpret_cast<sockaddr*>(&address), sizeof(address)) == 0);
+  return fd;
+}
+static void sendEvent(int fd, NSString* token, id event, id pid = nil, id success = nil) {
+  NSMutableDictionary* payload = [@{@"token": token, @"event": event} mutableCopy];
+  if (pid) payload[@"targetPID"] = pid;
+  if (success) payload[@"success"] = success;
+  NSMutableData* bytes = [[NSJSONSerialization dataWithJSONObject:payload options:0 error:nil] mutableCopy];
+  [bytes appendBytes:"\n" length:1];
+  size_t sent = 0;
+  while (sent < bytes.length) {
+    ssize_t n = write(fd, static_cast<const char*>(bytes.bytes) + sent, bytes.length - sent);
+    assert(n > 0);
+    sent += n;
+  }
+}
+static void connected(int fd, RPCS3JitSession* session) {
+  sendEvent(fd, session.token, @"helper_connected");
+  assert([session waitUntilConnected:2]);
+}
+static void universalHandshake() {
+  RPCS3JitSession* session = makeSession();
+  int fd = connectClient(session);
+  connected(fd, session);
+  // Neither a stale token nor another PID may release Core into its BRK.
+  sendEvent(fd, @"stale-token", @"pid_attached", @(getpid()));
+  sendEvent(fd, session.token, @"pid_attached", @(getpid() + 1));
+  sendEvent(fd, session.token, @"pid_attached", @"invalid");
+  assert(![session waitUntilAttached:0.03]);
+  sendEvent(fd, session.token, @"pid_attached", @(getpid()));
+  // This is the regression: host startup must advance while helper waits.
+  assert([session waitUntilAttached:2]);
+  assert(!session.finished);
+  assert(![session waitUntilFinished:0.03]);
+  // Simulate Core preparing and sealing its arena AFTER host was released.
+  sendEvent(fd, session.token, @"complete", nil, @YES);
+  assert([session waitUntilFinished:2] && session.success);
+  close(fd);
+  [session close];
+}
+static void legacyAttachWithoutScript() {
+  RPCS3JitSession* session = makeSession(NO);
+  int fd = connectClient(session);
+  connected(fd, session);
+  // StikJIT's non-TXM attach/detach API never emits attach_response.
+  sendEvent(fd, session.token, @"complete", nil, @YES);
+  assert([session waitUntilAttached:2]);
+  assert(session.finished && session.success && !session.attached);
+  close(fd);
+  [session close];
+}
+static void completionCannotReplaceUniversalAttach() {
+  RPCS3JitSession* session = makeSession();
+  int fd = connectClient(session);
+  connected(fd, session);
+  sendEvent(fd, session.token, @"complete", nil, @YES);
+  assert(![session waitUntilAttached:2]);
+  close(fd);
+  [session close];
+}
+static void failureAndDisconnect() {
+  for (int mode = 0; mode < 3; ++mode) {
+    RPCS3JitSession* session = makeSession();
+    int fd = connectClient(session);
+    connected(fd, session);
+    if (mode == 0) sendEvent(fd, session.token, @"complete", nil, @NO);
+    if (mode == 1) { close(fd); fd = -1; }
+    if (mode == 2) [session close]; // Must unblock fdopen/fgets, not leak it.
+    assert([session waitUntilFinished:2]);
+    assert(!session.success);
+    assert(![session waitUntilAttached:0.03]);
+    if (fd >= 0) close(fd);
+    [session close];
+  }
+}
+int main() {
+  @autoreleasepool {
+    universalHandshake();
+    legacyAttachWithoutScript();
+    completionCannotReplaceUniversalAttach();
+    failureAndDisconnect();
+    puts("RPCS3 production handshake: all scenarios passed");
+  }
+}
+'''
+        with tempfile.TemporaryDirectory(prefix='rpcs3-handshake-') as directory:
+            source_file = Path(directory) / 'harness.mm'
+            executable = Path(directory) / 'harness'
+            source_file.write_text(harness)
+            subprocess.run([compiler, '-std=c++17', '-fobjc-arc', '-fblocks',
+                            '-framework', 'Foundation', str(source_file), '-o',
+                            str(executable)], check=True, timeout=60)
+            subprocess.run([str(executable)], check=True, timeout=30)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/rpcs3_lazy_load_contract_test.dart
+++ b/test/rpcs3_lazy_load_contract_test.dart
@@ -24,6 +24,26 @@ void main() {
       expect(plugin, contains('RTLD_NOW | RTLD_LOCAL'));
     });
 
+    test('embedded RPCS3 relies on NeoStation host process capabilities', () {
+      final plugin = File(
+        'packages/rpcs3_internal_bridge/ios/Classes/Rpcs3InternalBridgePlugin.mm',
+      ).readAsStringSync();
+      expect(plugin, contains('SecTaskCreateFromSelf'));
+      expect(plugin, contains('RPCS3ProbeExecutableMemory'));
+      expect(
+        plugin,
+        isNot(
+          contains(
+            'RPCS3 requires extended-virtual-addressing and increased-memory-limit entitlements in the signed NeoStation IPA.',
+          ),
+        ),
+      );
+      expect(
+        plugin,
+        contains('libRPCS3Core.dylib is loaded into NeoStation itself'),
+      );
+    });
+
     test('opening the PS3 import menu does not initialize RPCS3', () {
       final widget = File(
         'lib/widgets/rpcs3_internal_playlist_actions.dart',
@@ -35,6 +55,29 @@ void main() {
       final opened = widget.substring(start, end);
       expect(opened, isNot(contains('Rpcs3InternalService')));
       expect(opened, isNot(contains('hasFirmware')));
+    });
+
+    test('PS3 library performs firmware-first onboarding', () {
+      final widget = File(
+        'lib/widgets/rpcs3_internal_playlist_actions.dart',
+      ).readAsStringSync();
+      expect(widget, contains('_ensureFirmwareForLibrary'));
+      expect(widget, contains('WidgetsBinding.instance.addPostFrameCallback'));
+      expect(widget, contains('Rpcs3InternalService.firmwareVersion()'));
+      expect(widget, contains('Rpcs3InternalService.importFirmware()'));
+    });
+
+    test('PS3 empty library does not expose recursive ROM scanning', () {
+      final library = File(
+        'lib/screens/game_screen/my_games_list.dart',
+      ).readAsStringSync();
+      expect(
+        library,
+        contains(
+          "Platform.isIOS && widget.system.folderName.toLowerCase() == 'ps3'",
+        ),
+      );
+      expect(library, contains('if (!isRpcs3Library)'));
     });
 
     test('distributed signing sidecar declares RPCS3 runtime entitlements', () {
@@ -49,7 +92,10 @@ void main() {
       ]) {
         expect(configurator, contains("'$key': True"));
       }
-      expect(configurator, contains('payload.update(REQUIRED_RUNTIME_ENTITLEMENTS)'));
+      expect(
+        configurator,
+        contains('payload.update(REQUIRED_RUNTIME_ENTITLEMENTS)'),
+      );
       expect(configurator, isNot(contains('payload.pop(key, None)')));
     });
   });

--- a/test/rpcs3_lazy_load_contract_test.dart
+++ b/test/rpcs3_lazy_load_contract_test.dart
@@ -61,7 +61,8 @@ void main() {
       final widget = File(
         'lib/widgets/rpcs3_internal_playlist_actions.dart',
       ).readAsStringSync();
-      expect(widget, contains('_ensureFirmwareForLibrary'));
+      expect(widget, contains('rpcs3-library-firmware-gate'));
+      expect(widget, isNot(contains('SharedPreferences')));
       expect(widget, contains('WidgetsBinding.instance.addPostFrameCallback'));
       expect(widget, contains('Rpcs3InternalService.firmwareVersion()'));
       expect(widget, contains('Rpcs3InternalService.importFirmware()'));


### PR DESCRIPTION
## PS3 library
- Check installed firmware on disk without starting JIT or Core.
- Missing firmware opens the installation screen immediately; after installation the normal library/import menu opens.
- Keep recursive ROM scanning out of the integrated PS3 library.

## Build 224: firmware import JIT fix
- Return from helper preparation on fresh attachment, not completion. Load/initialize RPCS3 while Universal JIT can service the Core's arena breakpoints; confirm helper completion afterwards.
- Require a fresh attachment on iOS 26, including non-TXM devices (the Core selects its Universal backend by OS version). Preserve legacy attach/detach behavior on older iOS.
- Use the legacy RW-to-RX memory probe only on the legacy backend. Keep the fresh-attachment check before Core dlopen on iOS 26.
- Display DDI/JIT preparation progress and align Flutter deadlines with native preparation; serialize startup and guard incomplete retries.
- Add macOS tests running the production helper socket state machine.

## Validation
Build 224 CI in progress. Real firmware import/JIT execution still needs verification on the user's signed iOS installation. No physical-device success claimed.